### PR TITLE
feat(jobs): safety pack — guards, watchdog probe, final-failure alerts (FP-14)

### DIFF
--- a/docs/fix-plan-checklist.md
+++ b/docs/fix-plan-checklist.md
@@ -68,15 +68,15 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
   - [x] h. Standardize `{ success, data?, error? }`; 200 sync / 202 enqueued
   - [x] i. `check-name` minLength 1; drop `setupError` from public `setup-status`
   - [x] j. 429 on `RATE_LIMITED`; try/catch → 503 on auth-infra failure
-- [ ] **FP-14 · Job safety pack** (H10, H11, M9–M14 · L · *alerting needs prod `TELEGRAM_*` envs*)
-  - [ ] a. `entry-event-results-daily`: `isFPLSeason` + current-event guards
-  - [ ] b. Watchdog checks active job/lock before recovering setups
-  - [ ] c. `errors > 0 → throw` in tournament-event-picks, transfers (pre+post), tournament-info
-  - [ ] d. `alertOnFinalFailure(job)` → Telegram in every worker `failed` handler
-  - [ ] e. `event-lives-db`: window re-check in worker + waiting-room dedup
-  - [ ] f. Deterministic chunk job IDs (`${jobName}-${runId}-chunk-${offset}`)
-  - [ ] g. Cascade fan-outs throw when any enqueue fails (3 call sites)
-  - [ ] h. Per-table scopes (`entry-event-picks|transfers|results:event:N`)
+- [x] **FP-14 · Job safety pack** (H10, H11, M9–M14 · L · *alerting needs prod `TELEGRAM_*` envs*)
+  - [x] a. `entry-event-results-daily`: `isFPLSeason` + current-event guards
+  - [x] b. Watchdog checks active job/lock before recovering setups
+  - [x] c. `errors > 0 → throw` in tournament-event-picks, transfers (pre+post), tournament-info
+  - [x] d. `alertOnFinalFailure(job)` → Telegram in every worker `failed` handler
+  - [x] e. `event-lives-db`: window re-check in worker + waiting-room dedup
+  - [x] f. Deterministic chunk job IDs (`${jobName}-${runId}-chunk-${offset}`)
+  - [x] g. Cascade fan-outs throw when any enqueue fails (3 call sites)
+  - [x] h. Per-table scopes (`entry-event-picks|transfers|results:event:N`)
 - [ ] **FP-15 · Deploy safety pack** (H12, H13, M23, M24 · M · *after FP-01*)
   - [ ] Worker heartbeat file + Docker/compose healthcheck; deploy asserts both services healthy
   - [ ] `cancel-in-progress: false`; `workflow_dispatch` `inputs.sha`; targeted prune (keep last 3)

--- a/docs/fix-plan-checklist.md
+++ b/docs/fix-plan-checklist.md
@@ -128,4 +128,4 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 | FP | Commit SHA | Date | Notes |
 |----|-----------|------|-------|
 | FP-13 | 58bcd28 | 2026-07-17 | PR #15 |
-| FP-14 | f2c7f94 | 2026-07-17 | pending PR |
+| FP-14 | f2c7f94 | 2026-07-17 | PR #16 |

--- a/docs/fix-plan-checklist.md
+++ b/docs/fix-plan-checklist.md
@@ -128,3 +128,4 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 | FP | Commit SHA | Date | Notes |
 |----|-----------|------|-------|
 | FP-13 | 58bcd28 | 2026-07-17 | PR #15 |
+| FP-14 | f2c7f94 | 2026-07-17 | pending PR |

--- a/src/domain/mutation-scope.ts
+++ b/src/domain/mutation-scope.ts
@@ -40,10 +40,15 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
     switch (jobName) {
       case 'entry-info':
         return ['entry-core:all'];
+      // Per-table scopes: jobs writing different entry tables no longer serialize
+      // against each other; jobs writing the SAME table share its scope across the
+      // entry/league/tournament domains below.
       case 'entry-picks':
+        return [withEvent('entry-event-picks', eventId)];
       case 'entry-transfers':
+        return [withEvent('entry-event-transfers', eventId)];
       case 'entry-results':
-        return [withEvent('entry-event', eventId)];
+        return [withEvent('entry-event-results', eventId)];
       default:
         return [];
     }
@@ -75,12 +80,12 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
     switch (jobName) {
       case 'league-event-picks':
         return [
-          withEvent('entry-event', eventId),
+          withEvent('entry-event-picks', eventId),
           withTournament('league-event-picks', tournamentId),
         ];
       case 'league-event-results':
         return [
-          withEvent('entry-event', eventId),
+          withEvent('entry-event-results', eventId),
           withEvent('league-event-results', eventId),
           withTournament('league-event-results', tournamentId),
         ];
@@ -92,13 +97,28 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
   if (queue === 'tournament-sync') {
     switch (jobName) {
       case 'tournament-event-results':
-        return [withEvent('entry-event', eventId), withEvent('tournament-event-results', eventId)];
+        return [
+          withEvent('entry-event-results', eventId),
+          withEvent('tournament-event-results', eventId),
+        ];
       case 'tournament-event-picks':
+        return [
+          withEvent('entry-event-picks', eventId),
+          withEvent('tournament-event-mutations', eventId),
+        ];
       case 'tournament-transfers-pre':
       case 'tournament-transfers-post':
-      case 'tournament-selection-stats':
         return [
-          withEvent('entry-event', eventId),
+          withEvent('entry-event-transfers', eventId),
+          withEvent('tournament-event-mutations', eventId),
+        ];
+      case 'tournament-selection-stats':
+        // Reads all three entry tables to build the stats snapshot — serialize
+        // with writers of each so the snapshot is not taken mid-write.
+        return [
+          withEvent('entry-event-picks', eventId),
+          withEvent('entry-event-transfers', eventId),
+          withEvent('entry-event-results', eventId),
           withEvent('tournament-event-mutations', eventId),
         ];
       case 'tournament-points-race':

--- a/src/jobs/entry-results.jobs.ts
+++ b/src/jobs/entry-results.jobs.ts
@@ -2,8 +2,10 @@ import { cron } from '@elysiajs/cron';
 import type { Elysia } from 'elysia';
 
 import { enqueueEntryResultsSyncJob } from './entry-sync-enqueue';
+import { getCurrentEvent } from '../services/events.service';
+import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
-import { logInfo } from '../utils/logger';
+import { logDebug, logInfo } from '../utils/logger';
 
 /**
  * Entry Event Results Cron Jobs
@@ -18,8 +20,27 @@ export function registerEntryResultsJobs(app: Elysia) {
       async run() {
         try {
           await executeTrackedCron('entry-event-results-daily', async () => {
-            const job = await enqueueEntryResultsSyncJob('cron');
-            logInfo('Entry results sync job enqueued via cron', { jobId: job.id });
+            const now = new Date();
+            if (!(await isFPLSeason(now))) {
+              logDebug('Skipping entry results sync - not FPL season', {
+                month: now.getMonth() + 1,
+              });
+              return;
+            }
+
+            const currentEvent = await getCurrentEvent();
+            if (!currentEvent) {
+              logInfo('Skipping entry results sync - no current event');
+              return;
+            }
+
+            const job = await enqueueEntryResultsSyncJob('cron', {
+              eventId: currentEvent.id,
+            });
+            logInfo('Entry results sync job enqueued via cron', {
+              jobId: job.id,
+              eventId: currentEvent.id,
+            });
           });
         } catch {
           // Failure details are already emitted by runTrackedJob.

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -20,6 +20,7 @@ export interface EntrySyncJobOptions {
   jobId?: string;
   delayMs?: number;
   eventId?: number;
+  runId?: string;
 }
 
 function hashEntryListKey(entryIds: readonly number[], eventId?: number): string {
@@ -56,6 +57,7 @@ async function enqueueEntrySyncJob(
       concurrency,
       throttleMs,
       eventId: options.eventId,
+      runId: options.runId,
     };
 
     const chunkKey =

--- a/src/jobs/live-data.jobs.ts
+++ b/src/jobs/live-data.jobs.ts
@@ -9,19 +9,57 @@ import { logError, logInfo } from '../utils/logger';
 
 export type LiveDataJobSource = 'cron' | 'manual' | 'cascade';
 
+interface LiveDataEnqueueOptions {
+  delay?: number;
+  jobId?: string;
+  /** Post-match consolidation runs outside the live window; skips the worker re-check */
+  skipWindowCheck?: boolean;
+}
+
+/**
+ * A backed-up queue must not pile up duplicate cron ticks for the same
+ * (job, event): when an earlier tick is still waiting or delayed, reuse it.
+ * Manual jobs self-dedupe via deterministic IDs; cascade jobs are one-shot
+ * per parent completion and stay untouched.
+ */
+async function findWaitingJob(
+  queue: ReturnType<typeof getLiveDataQueue>,
+  jobName: LiveDataJobName,
+  eventId: number,
+) {
+  const pending = await queue.getJobs(['waiting', 'delayed']);
+  return pending.find((job) => job.name === jobName && job.data.eventId === eventId);
+}
+
 async function enqueueLiveDataJob(
   jobName: LiveDataJobName,
   eventId: number,
   source: LiveDataJobSource = 'cron',
-  options: { delay?: number; jobId?: string } = {},
+  options: LiveDataEnqueueOptions = {},
 ) {
   try {
     const tier = getLiveDataJobPriority(jobName as LiveDataPriorityJobName);
     const queue = getLiveDataQueue(tier);
+
+    if (source === 'cron') {
+      const waiting = await findWaitingJob(queue, jobName, eventId);
+      if (waiting) {
+        logInfo('Skipping enqueue - waiting job already queued for event', {
+          jobName,
+          eventId,
+          existingJobId: waiting.id,
+          tier,
+          queue: queue.name,
+        });
+        return waiting;
+      }
+    }
+
     const jobData: LiveDataJobData = {
       eventId,
       source,
       triggeredAt: new Date().toISOString(),
+      ...(options.skipWindowCheck ? { skipWindowCheck: true } : {}),
     };
 
     // Manual triggers share a deterministic ID per (job, event) so repeat triggers
@@ -62,8 +100,11 @@ async function enqueueLiveDataJob(
 export const enqueueEventLivesCacheUpdate = (eventId: number, source?: LiveDataJobSource) =>
   enqueueLiveDataJob(LIVE_JOBS.EVENT_LIVES_CACHE, eventId, source);
 
-export const enqueueEventLivesDbSync = (eventId: number, source?: LiveDataJobSource) =>
-  enqueueLiveDataJob(LIVE_JOBS.EVENT_LIVES_DB, eventId, source);
+export const enqueueEventLivesDbSync = (
+  eventId: number,
+  source?: LiveDataJobSource,
+  options?: LiveDataEnqueueOptions,
+) => enqueueLiveDataJob(LIVE_JOBS.EVENT_LIVES_DB, eventId, source, options);
 
 export const enqueueEventLiveSummary = (eventId: number, source?: LiveDataJobSource) =>
   enqueueLiveDataJob(LIVE_JOBS.EVENT_LIVE_SUMMARY, eventId, source);

--- a/src/jobs/live.jobs.ts
+++ b/src/jobs/live.jobs.ts
@@ -129,7 +129,9 @@ export async function runPostMatchConsolidation() {
     return;
   }
 
-  const job = await enqueueEventLivesDbSync(currentEvent.id, 'cron');
+  // Consolidation runs after the live window ends, so the worker-side window
+  // re-check must not skip it.
+  const job = await enqueueEventLivesDbSync(currentEvent.id, 'cron', { skipWindowCheck: true });
   logInfo('Post-match consolidation job enqueued', { jobId: job.id, eventId: currentEvent.id });
 }
 

--- a/src/jobs/tournament-setup.jobs.ts
+++ b/src/jobs/tournament-setup.jobs.ts
@@ -10,6 +10,23 @@ export interface EnqueueTournamentSetupOptions {
   forceNew?: boolean;
 }
 
+/**
+ * State of the canonical setup job (`tournament-setup-${tournamentId}`), or null when
+ * no such job exists in any state. Used by the watchdog to tell a genuinely stuck
+ * setup (DB says "processing", no live job) apart from a merely slow one.
+ */
+export async function getTournamentSetupJobState(
+  tournamentId: number,
+): Promise<{ jobId: string; state: string } | null> {
+  const tier = getTournamentSetupJobPriority('tournament-setup');
+  const queue = getTournamentSetupQueue(tier);
+  const existing = await queue.getJob(`tournament-setup-${tournamentId}`);
+  if (!existing) {
+    return null;
+  }
+  return { jobId: String(existing.id), state: await existing.getState() };
+}
+
 export async function enqueueTournamentSetup(
   tournamentId: number,
   source: TournamentSetupJobSource = 'create',

--- a/src/queues/entry-sync.queue.ts
+++ b/src/queues/entry-sync.queue.ts
@@ -40,6 +40,8 @@ export interface EntrySyncJobData {
   concurrency?: number;
   throttleMs?: number;
   eventId?: number;
+  /** Chain identifier shared by all chunks of one run (first job's BullMQ id) */
+  runId?: string;
 }
 
 const tieredQueueSet = createTieredQueueSet<EntrySyncJobData>(entrySyncQueueName, {

--- a/src/queues/live-data.queue.ts
+++ b/src/queues/live-data.queue.ts
@@ -20,6 +20,8 @@ export interface LiveDataJobData {
   eventId: number;
   source: 'cron' | 'manual' | 'cascade';
   triggeredAt: string;
+  /** Post-match consolidation runs outside the live window; skips the worker re-check */
+  skipWindowCheck?: boolean;
 }
 
 const tieredQueueSet = createTieredQueueSet<LiveDataJobData>(liveDataQueueName, {

--- a/src/services/league-sync.service.ts
+++ b/src/services/league-sync.service.ts
@@ -41,6 +41,14 @@ export async function enqueuePicksPerTournament(eventId: number) {
     }
   });
 
+  // A partially-enqueued fan-out leaves some tournaments silently stale —
+  // fail the coordinator job so BullMQ retries the whole fan-out.
+  if (failed > 0) {
+    throw new Error(
+      `League picks cascade enqueue failed for ${failed} of ${tournaments.length} tournaments`,
+    );
+  }
+
   return { enqueued: successful };
 }
 
@@ -80,6 +88,14 @@ export async function enqueueResultsPerTournament(eventId: number) {
       });
     }
   });
+
+  // A partially-enqueued fan-out leaves some tournaments silently stale —
+  // fail the coordinator job so BullMQ retries the whole fan-out.
+  if (failed > 0) {
+    throw new Error(
+      `League results cascade enqueue failed for ${failed} of ${tournaments.length} tournaments`,
+    );
+  }
 
   return { enqueued: successful };
 }

--- a/src/services/live-data-cascade.service.ts
+++ b/src/services/live-data-cascade.service.ts
@@ -46,6 +46,9 @@ export async function enqueueCascadeJobs(
 
   try {
     const matchWindowOpen = await resolved.isLiveMatchWindowForEvent(eventId);
+    const taskNames = matchWindowOpen
+      ? (['summary', 'explain', 'live-fixture', 'live-bonus', 'overall'] as const)
+      : (['summary', 'explain', 'overall'] as const);
     const enqueueTasks = [
       resolved.enqueueEventLiveSummary(eventId, 'cascade'),
       resolved.enqueueEventLiveExplain(eventId, 'cascade'),
@@ -76,13 +79,21 @@ export async function enqueueCascadeJobs(
 
     results.forEach((result, index) => {
       if (result.status === 'rejected') {
-        const jobNames = ['summary', 'explain', 'live-fixture', 'live-bonus', 'overall'];
         logError('Failed to enqueue cascade job', result.reason, {
           eventId,
-          jobName: jobNames[index],
+          jobName: taskNames[index],
         });
       }
     });
+
+    // A partially-enqueued cascade leaves downstream data silently stale —
+    // fail the parent job so BullMQ retries the whole fan-out.
+    if (failed > 0) {
+      const failedNames = taskNames.filter((_, index) => results[index].status === 'rejected');
+      throw new Error(
+        `Cascade enqueue failed for ${failed} of ${results.length} jobs: ${failedNames.join(', ')}`,
+      );
+    }
 
     return {
       eventId,

--- a/src/services/tournament-event-picks.service.ts
+++ b/src/services/tournament-event-picks.service.ts
@@ -71,5 +71,10 @@ export async function syncTournamentEventPicks(
     errors,
   });
 
+  // Fail the job on partial failure so BullMQ retries instead of leaving silent gaps
+  if (errors > 0) {
+    throw new Error(`Tournament event picks sync failed for ${errors} of ${toSync.length} entries`);
+  }
+
   return { eventId, totalEntries: entryIds.length, synced, skipped, errors };
 }

--- a/src/services/tournament-event-transfers.service.ts
+++ b/src/services/tournament-event-transfers.service.ts
@@ -120,34 +120,35 @@ export async function syncTournamentEventTransfersPost(eventId: number): Promise
     elementInPlayed: boolean | null;
   }> = [];
   let skipped = 0;
+  let errors = 0;
 
   for (const entryId of entryIds) {
+    // Post sync runs as a cascade after event-results succeeded, so a missing
+    // result or empty picks here is an anomaly worth failing (and retrying) the
+    // job for — not a data gap to silently skip.
     const entryResult = entryResultMap.get(entryId);
     if (!entryResult) {
+      errors += 1;
       logError('Entry event result missing for transfer update', new Error('No result'), {
         eventId,
         entryId,
       });
-      skipped += 1;
       continue;
     }
 
     const picks = normalizePicks(entryResult.eventPicks);
     if (picks.length === 0) {
+      errors += 1;
       logError('Entry picks missing for transfer update', new Error('No picks'), {
         eventId,
         entryId,
       });
-      skipped += 1;
       continue;
     }
 
+    // Zero transfer rows is legitimate — the entry made no transfers this event.
     const entryTransfers = transferMap.get(entryId);
     if (!entryTransfers || entryTransfers.length === 0) {
-      logError('Entry event transfers missing for update', new Error('No transfers'), {
-        eventId,
-        entryId,
-      });
       skipped += 1;
       continue;
     }
@@ -180,9 +181,16 @@ export async function syncTournamentEventTransfersPost(eventId: number): Promise
     totalEntries: entryIds.length,
     updated,
     skipped,
+    errors,
   });
 
-  return { eventId, totalEntries: entryIds.length, updated, skipped, errors: 0 };
+  if (errors > 0) {
+    throw new Error(
+      `Tournament event transfers post sync failed for ${errors} of ${entryIds.length} entries`,
+    );
+  }
+
+  return { eventId, totalEntries: entryIds.length, updated, skipped, errors };
 }
 
 export async function syncTournamentEventTransfersPre(
@@ -278,6 +286,13 @@ export async function syncTournamentEventTransfersPre(
     skipped,
     errors,
   });
+
+  // Fail the job on partial failure so BullMQ retries instead of leaving silent gaps
+  if (errors > 0) {
+    throw new Error(
+      `Tournament event transfers pre sync failed for ${errors} of ${entryIds.length} entries`,
+    );
+  }
 
   return { eventId, totalEntries: entryIds.length, inserted, skipped, errors };
 }

--- a/src/services/tournament-info.service.ts
+++ b/src/services/tournament-info.service.ts
@@ -82,5 +82,10 @@ export async function syncTournamentInfo(options?: {
     errors,
   });
 
+  // Fail the job on partial failure so BullMQ retries instead of leaving stale names
+  if (errors > 0) {
+    throw new Error(`Tournament info sync failed for ${errors} of ${tournaments.length} leagues`);
+  }
+
   return { total: tournaments.length, updated, skipped, errors };
 }

--- a/src/services/tournament-setup.service.ts
+++ b/src/services/tournament-setup.service.ts
@@ -1,4 +1,4 @@
-import { enqueueTournamentSetup } from '../jobs/tournament-setup.jobs';
+import { enqueueTournamentSetup, getTournamentSetupJobState } from '../jobs/tournament-setup.jobs';
 import { tournamentEntryRepository } from '../repositories/tournament-entries';
 import { tournamentInfoRepository } from '../repositories/tournament-infos';
 import { NotFoundError } from '../utils/errors';
@@ -94,6 +94,20 @@ export async function recoverStuckTournamentSetups(
   const recovered: number[] = [];
   for (const row of stuck) {
     try {
+      // A live BullMQ job means the setup is slow, not stuck — marking it failed
+      // mid-run would flip-flop the status and forceNew would race a duplicate
+      // setup against the active one. Only recover when no live job exists.
+      const liveJob = await getTournamentSetupJobState(row.id);
+      if (liveJob && ['waiting', 'delayed', 'active', 'prioritized'].includes(liveJob.state)) {
+        logInfo('Watchdog skipping setup with live job', {
+          tournamentId: row.id,
+          jobId: liveJob.jobId,
+          jobState: liveJob.state,
+          setupStartedAt: row.setupStartedAt,
+        });
+        continue;
+      }
+
       await tournamentInfoRepository.markSetupResult(
         row.id,
         'failed',
@@ -104,6 +118,7 @@ export async function recoverStuckTournamentSetups(
       logInfo('Watchdog recovered stuck tournament setup', {
         tournamentId: row.id,
         setupStartedAt: row.setupStartedAt,
+        previousJobState: liveJob?.state ?? 'missing',
       });
     } catch (error) {
       logError('Watchdog failed to recover stuck tournament setup', error, {

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -96,3 +96,47 @@ export async function notifyTwoBots(text: string): Promise<void> {
   await sendTelegramBotNotification(text).catch(() => {});
   await sendWeChatBotNotification(text).catch(() => {});
 }
+
+export type FinalFailureAlert = {
+  queueName: string;
+  jobName?: string;
+  jobId?: string;
+  attemptsMade?: number;
+  attempts?: number;
+  tier?: string;
+  error: unknown;
+};
+
+/**
+ * Telegram alert for jobs that exhausted all BullMQ attempts. Never throws and
+ * never alerts for intermediate (retryable) failures — alerting must not turn a
+ * worker 'failed' event into another failure, and noisy per-attempt pings would
+ * bury the signal. No-op with a warn when TELEGRAM_* envs are unset.
+ */
+export async function alertOnFinalFailure(
+  alert: FinalFailureAlert,
+  send: (message: string) => Promise<void> = sendTelegramMessage,
+): Promise<void> {
+  const attemptsMade = alert.attemptsMade ?? 0;
+  const attempts = Math.max(alert.attempts ?? 1, 1);
+  if (attemptsMade < attempts) {
+    return;
+  }
+
+  const errorMessage = alert.error instanceof Error ? alert.error.message : String(alert.error);
+  const message = (
+    `[letletme_data] Job permanently failed: ${alert.queueName}/${alert.jobName ?? 'unknown'} ` +
+    `(id ${alert.jobId ?? 'unknown'}) after ${attemptsMade}/${attempts} attempts` +
+    `${alert.tier ? ` [${alert.tier}]` : ''}: ${errorMessage}`
+  ).slice(0, 900);
+
+  try {
+    await send(message);
+  } catch (error) {
+    logError('Failed to send final-failure alert', error, {
+      queueName: alert.queueName,
+      jobName: alert.jobName,
+      jobId: alert.jobId,
+    });
+  }
+}

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -18,6 +18,7 @@ import { syncTeams } from '../services/teams.service';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
+import { alertOnFinalFailure } from '../utils/notify';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
 
@@ -93,6 +94,17 @@ export function createDataSyncWorker(): WorkerRuntime {
         attemptsMade: job?.attemptsMade,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure({
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId: String(job.id),
+          attemptsMade: job.attemptsMade,
+          attempts: job.opts.attempts ?? 1,
+          tier,
+          error,
+        });
+      }
     });
 
     workers.push(worker);

--- a/src/workers/entry-sync.worker.ts
+++ b/src/workers/entry-sync.worker.ts
@@ -35,6 +35,7 @@ import {
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
+import { alertOnFinalFailure } from '../utils/notify';
 import { getQueueConnection } from '../utils/queue';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
@@ -183,6 +184,7 @@ async function handleEntryJob(
   label: string,
   handler: (entryId: number) => Promise<unknown>,
   jobData?: EntrySyncJobData,
+  runId?: string,
 ) {
   const loaded = await loadEntryIds(jobData);
   if (loaded.entryIds.length === 0) {
@@ -203,12 +205,19 @@ async function handleEntryJob(
 
   if (!jobData?.entryIds && loaded.fetchedFromDb && loaded.hasMore) {
     const nextOffset = loaded.nextOffset;
+    // Deterministic per-run chain IDs: a BullMQ retry of this chunk re-enqueues the
+    // next chunk with the SAME id, so BullMQ dedupes instead of forking a second
+    // chain (unique Date.now() ids let every retry fork one). runId ties the whole
+    // chain to the first job of the run, so separate cycles never collide.
+    const chainRunId = runId ?? `fallback-${Date.now()}`;
     const nextJob = await enqueueEntryJob(jobName, jobData?.source, {
       chunkOffset: nextOffset,
       chunkSize: loaded.chunkSize,
       concurrency,
       throttleMs,
       eventId: jobData?.eventId,
+      runId: chainRunId,
+      jobId: `${jobName}-${chainRunId}-chunk-${nextOffset}`,
     });
     logInfo('Entry sync next chunk enqueued', {
       jobName,
@@ -260,6 +269,10 @@ export function createEntrySyncWorker(): WorkerRuntime {
 
     logJobTriggered(context);
 
+    // All chunks of one run share the first job's id as their runId (propagated via
+    // job data), so a retried chunk re-enqueues the same deterministic next-chunk id.
+    const runId = job.data?.runId ?? jobId;
+
     return withMutationConflictGuard(
       {
         queueName: job.queueName,
@@ -276,6 +289,7 @@ export function createEntrySyncWorker(): WorkerRuntime {
                 'entry info sync',
                 syncEntryInfo,
                 job.data,
+                runId,
               );
               // Mark only after the final chunk succeeds with zero failures so
               // mid-chunk crashes and pending retries can still re-run same day.
@@ -290,6 +304,7 @@ export function createEntrySyncWorker(): WorkerRuntime {
                 'entry picks sync',
                 (entryId) => syncEntryEventPicks(entryId, job.data?.eventId),
                 job.data,
+                runId,
               );
             case 'entry-transfers':
               return handleEntryJob(
@@ -297,13 +312,15 @@ export function createEntrySyncWorker(): WorkerRuntime {
                 'entry transfers sync',
                 (entryId) => syncEntryEventTransfers(entryId, job.data?.eventId),
                 job.data,
+                runId,
               );
             case 'entry-results':
               return handleEntryJob(
                 'entry-results',
                 'entry results sync',
-                syncEntryEventResults,
+                (entryId) => syncEntryEventResults(entryId, job.data?.eventId),
                 job.data,
+                runId,
               );
             default:
               throw new Error(`Unknown entry-sync job: ${job.name}`);
@@ -333,6 +350,17 @@ export function createEntrySyncWorker(): WorkerRuntime {
         attemptsMade: job?.attemptsMade,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure({
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId: String(job.id),
+          attemptsMade: job.attemptsMade,
+          attempts: job.opts.attempts ?? 1,
+          tier,
+          error,
+        });
+      }
     });
 
     workers.push(worker);

--- a/src/workers/league-sync.worker.ts
+++ b/src/workers/league-sync.worker.ts
@@ -16,6 +16,7 @@ import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
+import { alertOnFinalFailure } from '../utils/notify';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
 
@@ -103,6 +104,17 @@ export function createLeagueSyncWorker(): WorkerRuntime {
         tournamentId: job?.data.tournamentId,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure({
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId: String(job.id),
+          attemptsMade: job.attemptsMade,
+          attempts: job.opts.attempts ?? 1,
+          tier,
+          error: err,
+        });
+      }
     });
 
     worker.on('error', (err) => {

--- a/src/workers/live-data.worker.ts
+++ b/src/workers/live-data.worker.ts
@@ -23,6 +23,7 @@ import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
+import { alertOnFinalFailure } from '../utils/notify';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
 
@@ -69,6 +70,17 @@ async function processLiveDataJob(job: Job<LiveDataJobData>) {
             break;
 
           case LIVE_JOBS.EVENT_LIVES_DB:
+            // Re-check the window at execution time: a cron tick enqueued during
+            // match hours may only run after the window closed (backed-up queue,
+            // retry). Consolidation (skipWindowCheck) and manual triggers always run.
+            if (
+              job.data.source === 'cron' &&
+              !job.data.skipWindowCheck &&
+              !(await isLiveMatchWindowForEvent(eventId))
+            ) {
+              logInfo('Skipping event lives DB job - live window closed', { eventId });
+              break;
+            }
             await syncEventLives(eventId);
             // After DB sync completes, trigger dependent jobs
             await enqueueCascadeJobs(eventId);
@@ -149,6 +161,17 @@ export function createLiveDataWorker(): WorkerRuntime {
         eventId: job?.data.eventId,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure({
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId: String(job.id),
+          attemptsMade: job.attemptsMade,
+          attempts: job.opts.attempts ?? 1,
+          tier,
+          error: err,
+        });
+      }
     });
 
     worker.on('error', (err) => {

--- a/src/workers/tournament-setup.worker.ts
+++ b/src/workers/tournament-setup.worker.ts
@@ -11,6 +11,7 @@ import {
 } from '../services/tournament-setup.service';
 import { logError, logInfo } from '../utils/logger';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
+import { alertOnFinalFailure } from '../utils/notify';
 import { getQueueConnection } from '../utils/queue';
 import type { WorkerRuntime } from './worker-runtime';
 
@@ -61,6 +62,16 @@ export function createTournamentSetupWorker(): WorkerRuntime {
       jobId: job?.id,
       tournamentId: job?.data.tournamentId,
     });
+    if (job) {
+      void alertOnFinalFailure({
+        queueName: job.queueName,
+        jobName: job.name,
+        jobId: String(job.id),
+        attemptsMade: job.attemptsMade,
+        attempts: job.opts.attempts ?? 1,
+        error: err,
+      });
+    }
   });
 
   worker.on('error', (err) => {

--- a/src/workers/tournament-sync.worker.ts
+++ b/src/workers/tournament-sync.worker.ts
@@ -25,6 +25,7 @@ import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
+import { alertOnFinalFailure } from '../utils/notify';
 import {
   enqueueTournamentPointsRace,
   enqueueTournamentBattleRace,
@@ -65,29 +66,36 @@ async function enqueueTournamentCascade(eventId: number) {
     });
 
     // Log any failures
+    const cascadeJobNames = [
+      'points-race',
+      'battle-race',
+      'knockout',
+      'transfers-post',
+      'cup-results',
+    ];
     results.forEach((result, index) => {
       if (result.status === 'rejected') {
-        const jobNames = [
-          'points-race',
-          'battle-race',
-          'knockout',
-          'transfers-post',
-          'cup-results',
-        ];
         logError('Failed to enqueue cascade job', result.reason, {
           eventId,
-          jobName: jobNames[index],
+          jobName: cascadeJobNames[index],
         });
       }
     });
 
-    // Enqueue materialized view refresh with a 30s delay so parallel writes finish first
-    try {
-      await enqueueTournamentMaterializedViewsRefresh(eventId, 'cascade', { delay: 30_000 });
-      logInfo('Enqueued tournament materialized views refresh', { eventId, delayMs: 30_000 });
-    } catch (error) {
-      logError('Failed to enqueue materialized views refresh', error, { eventId });
+    // A partially-enqueued cascade leaves downstream results silently stale —
+    // fail the parent job so BullMQ retries the whole fan-out.
+    if (failed > 0) {
+      const failedNames = cascadeJobNames.filter(
+        (_, index) => results[index].status === 'rejected',
+      );
+      throw new Error(
+        `Tournament cascade enqueue failed for ${failed} of ${results.length} jobs: ${failedNames.join(', ')}`,
+      );
     }
+
+    // Enqueue materialized view refresh with a 30s delay so parallel writes finish first
+    await enqueueTournamentMaterializedViewsRefresh(eventId, 'cascade', { delay: 30_000 });
+    logInfo('Enqueued tournament materialized views refresh', { eventId, delayMs: 30_000 });
   } catch (error) {
     logError('Failed to enqueue tournament cascade jobs', error, { eventId });
     throw error;
@@ -221,6 +229,17 @@ export function createTournamentSyncWorker(): WorkerRuntime {
         eventId: job?.data.eventId,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure({
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId: String(job.id),
+          attemptsMade: job.attemptsMade,
+          attempts: job.opts.attempts ?? 1,
+          tier,
+          error: err,
+        });
+      }
     });
 
     worker.on('error', (err) => {

--- a/tests/unit/league-sync-fanout.test.ts
+++ b/tests/unit/league-sync-fanout.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const findActive = mock(async (): Promise<Array<{ id: number }>> => []);
+mock.module('../../src/repositories/tournament-infos', () => ({
+  tournamentInfoRepository: { findActive },
+}));
+
+const enqueueLeagueEventPicks = mock(
+  async (_eventId: number, _source?: string, _options?: { tournamentId?: number }) => ({
+    id: 'picks-job',
+  }),
+);
+const enqueueLeagueEventResults = mock(
+  async (_eventId: number, _source?: string, _options?: { tournamentId?: number }) => ({
+    id: 'results-job',
+  }),
+);
+mock.module('../../src/jobs/league-sync.jobs', () => ({
+  enqueueLeagueEventPicks,
+  enqueueLeagueEventResults,
+}));
+
+const { enqueuePicksPerTournament, enqueueResultsPerTournament } = await import(
+  '../../src/services/league-sync.service'
+);
+
+describe('league-sync fan-out', () => {
+  beforeEach(() => {
+    findActive.mockClear();
+    enqueueLeagueEventPicks.mockClear();
+    enqueueLeagueEventResults.mockClear();
+  });
+
+  test('returns the enqueued count when every tournament enqueue succeeds', async () => {
+    findActive.mockImplementation(async () => [{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+    const result = await enqueuePicksPerTournament(20);
+
+    expect(result).toEqual({ enqueued: 3 });
+    expect(enqueueLeagueEventPicks).toHaveBeenCalledTimes(3);
+    expect(enqueueLeagueEventPicks).toHaveBeenCalledWith(20, 'cascade', { tournamentId: 2 });
+  });
+
+  test('throws when any picks enqueue fails so the coordinator retries', async () => {
+    findActive.mockImplementation(async () => [{ id: 1 }, { id: 2 }, { id: 3 }]);
+    enqueueLeagueEventPicks.mockImplementation(async (_eventId, _source, options) => {
+      if (options?.tournamentId === 2) {
+        throw new Error('redis down');
+      }
+      return { id: 'picks-job' };
+    });
+
+    await expect(enqueuePicksPerTournament(20)).rejects.toThrow(
+      'League picks cascade enqueue failed for 1 of 3 tournaments',
+    );
+  });
+
+  test('throws when any results enqueue fails so the coordinator retries', async () => {
+    findActive.mockImplementation(async () => [{ id: 7 }]);
+    enqueueLeagueEventResults.mockImplementation(async () => {
+      throw new Error('redis down');
+    });
+
+    await expect(enqueueResultsPerTournament(20)).rejects.toThrow(
+      'League results cascade enqueue failed for 1 of 1 tournaments',
+    );
+  });
+
+  test('returns zero when no tournaments are active', async () => {
+    findActive.mockImplementation(async () => []);
+
+    expect(await enqueuePicksPerTournament(20)).toEqual({ enqueued: 0 });
+    expect(await enqueueResultsPerTournament(20)).toEqual({ enqueued: 0 });
+  });
+});

--- a/tests/unit/live-data-cascade.test.ts
+++ b/tests/unit/live-data-cascade.test.ts
@@ -66,4 +66,46 @@ describe('event-lives-db cascade enqueue', () => {
     expect(enqueueLiveFixtureCache).toHaveBeenCalledWith(12, 'cascade');
     expect(enqueueLiveBonusCache).toHaveBeenCalledWith(12, 'cascade');
   });
+
+  test('throws when any cascade enqueue fails so the parent job retries', async () => {
+    const enqueueEventLiveSummary = createEnqueueMock();
+    const enqueueEventLiveExplain = mock(async () => {
+      throw new Error('redis down');
+    }) as unknown as CascadeEnqueueDeps['enqueueEventLiveExplain'];
+    const enqueueLiveFixtureCache = createEnqueueMock();
+    const enqueueLiveBonusCache = createEnqueueMock();
+    const enqueueEventOverallResult = createEnqueueMock();
+
+    await expect(
+      enqueueCascadeJobs(12, {
+        isLiveMatchWindowForEvent: async () => false,
+        enqueueEventLiveSummary,
+        enqueueEventLiveExplain,
+        enqueueLiveFixtureCache,
+        enqueueLiveBonusCache,
+        enqueueEventOverallResult,
+      }),
+    ).rejects.toThrow('Cascade enqueue failed for 1 of 3 jobs: explain');
+  });
+
+  test('names failed jobs correctly when the match window is open', async () => {
+    const enqueueEventLiveSummary = createEnqueueMock();
+    const enqueueEventLiveExplain = createEnqueueMock();
+    const enqueueLiveFixtureCache = createEnqueueMock();
+    const enqueueLiveBonusCache = mock(async () => {
+      throw new Error('redis down');
+    }) as unknown as CascadeEnqueueDeps['enqueueLiveBonusCache'];
+    const enqueueEventOverallResult = createEnqueueMock();
+
+    await expect(
+      enqueueCascadeJobs(12, {
+        isLiveMatchWindowForEvent: async () => true,
+        enqueueEventLiveSummary,
+        enqueueEventLiveExplain,
+        enqueueLiveFixtureCache,
+        enqueueLiveBonusCache,
+        enqueueEventOverallResult,
+      }),
+    ).rejects.toThrow('live-bonus');
+  });
 });

--- a/tests/unit/manual-job-ids.test.ts
+++ b/tests/unit/manual-job-ids.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 type AddCall = { name: string; data: Record<string, unknown>; opts: Record<string, unknown> };
+type PendingJob = { id: string; name: string; data: { eventId: number } };
 
 const liveDataAddCalls: AddCall[] = [];
 const entrySyncAddCalls: AddCall[] = [];
+const liveDataPendingJobs: PendingJob[] = [];
 
 mock.module('../../src/queues/live-data.queue', () => ({
   LIVE_JOBS: {
@@ -22,6 +24,7 @@ mock.module('../../src/queues/live-data.queue', () => ({
       liveDataAddCalls.push({ name, data, opts });
       return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
     },
+    getJobs: async () => liveDataPendingJobs,
   }),
 }));
 
@@ -87,6 +90,56 @@ describe('live-data manual job IDs', () => {
     expect(job.id).not.toBe('event-lives-db-e10-manual');
     // Cron jobs keep queue-level retention (no per-job cleanup override)
     expect(liveDataAddCalls[0].opts.removeOnComplete).toBeUndefined();
+  });
+});
+
+describe('live-data cron waiting-room dedup', () => {
+  beforeEach(() => {
+    liveDataAddCalls.length = 0;
+    liveDataPendingJobs.length = 0;
+  });
+
+  test('cron enqueue reuses a waiting job for the same (job, event)', async () => {
+    liveDataPendingJobs.push({ id: 'existing-1', name: 'event-lives-db', data: { eventId: 10 } });
+
+    const job = await enqueueEventLivesDbSync(10, 'cron');
+
+    expect(job.id).toBe('existing-1');
+    expect(liveDataAddCalls).toHaveLength(0);
+  });
+
+  test('cron enqueue proceeds for a different event or job name', async () => {
+    liveDataPendingJobs.push({ id: 'existing-1', name: 'event-lives-db', data: { eventId: 11 } });
+    liveDataPendingJobs.push({
+      id: 'existing-2',
+      name: 'event-lives-cache',
+      data: { eventId: 10 },
+    });
+
+    await enqueueEventLivesDbSync(10, 'cron');
+
+    expect(liveDataAddCalls).toHaveLength(1);
+  });
+
+  test('cascade and manual enqueues skip the waiting-room check', async () => {
+    liveDataPendingJobs.push({ id: 'existing-1', name: 'event-lives-db', data: { eventId: 10 } });
+
+    await enqueueEventLivesDbSync(10, 'cascade');
+    await enqueueEventLivesDbSync(10, 'manual');
+
+    expect(liveDataAddCalls).toHaveLength(2);
+  });
+
+  test('skipWindowCheck rides into the job data for post-match consolidation', async () => {
+    await enqueueEventLivesDbSync(10, 'cron', { skipWindowCheck: true });
+
+    expect(liveDataAddCalls[0].data.skipWindowCheck).toBe(true);
+  });
+
+  test('regular cron jobs carry no skipWindowCheck flag', async () => {
+    await enqueueEventLivesDbSync(10, 'cron');
+
+    expect(liveDataAddCalls[0].data.skipWindowCheck).toBeUndefined();
   });
 });
 

--- a/tests/unit/mutation-scope.test.ts
+++ b/tests/unit/mutation-scope.test.ts
@@ -19,7 +19,7 @@ describe('resolveMutationScopes', () => {
       eventId: 33,
       tournamentId: 1001,
     });
-    expect(scopes).toContain('entry-event:event:33');
+    expect(scopes).toContain('entry-event-results:event:33');
     expect(scopes).toContain('league-event-results:event:33');
     expect(scopes).toContain('league-event-results:tournament:1001');
   });
@@ -40,7 +40,72 @@ describe('resolveMutationScopes', () => {
       jobName: 'tournament-selection-stats',
       eventId: 35,
     });
-    expect(scopes).toContain('entry-event:event:35');
+    expect(scopes).toContain('entry-event-picks:event:35');
+    expect(scopes).toContain('entry-event-transfers:event:35');
+    expect(scopes).toContain('entry-event-results:event:35');
     expect(scopes).toContain('tournament-event-mutations:event:35');
+  });
+
+  it('scopes entry-sync jobs per table so different tables do not serialize', () => {
+    const picks = resolveMutationScopes({
+      queueName: 'entry-sync-p2',
+      jobName: 'entry-picks',
+      eventId: 33,
+    });
+    const transfers = resolveMutationScopes({
+      queueName: 'entry-sync-p2',
+      jobName: 'entry-transfers',
+      eventId: 33,
+    });
+    const results = resolveMutationScopes({
+      queueName: 'entry-sync-p2',
+      jobName: 'entry-results',
+      eventId: 33,
+    });
+
+    expect(picks).toEqual(['entry-event-picks:event:33']);
+    expect(transfers).toEqual(['entry-event-transfers:event:33']);
+    expect(results).toEqual(['entry-event-results:event:33']);
+
+    // No shared scope between different tables — a slow picks run must not block results
+    expect(picks.filter((s) => transfers.includes(s) || results.includes(s))).toEqual([]);
+  });
+
+  it('shares the per-table scope across entry, league, and tournament writers', () => {
+    const entryPicks = resolveMutationScopes({
+      queueName: 'entry-sync-p2',
+      jobName: 'entry-picks',
+      eventId: 33,
+    });
+    const leaguePicks = resolveMutationScopes({
+      queueName: 'league-sync-p3',
+      jobName: 'league-event-picks',
+      eventId: 33,
+      tournamentId: 1001,
+    });
+    const tournamentPicks = resolveMutationScopes({
+      queueName: 'tournament-sync-p2',
+      jobName: 'tournament-event-picks',
+      eventId: 33,
+    });
+    const tournamentTransfersPost = resolveMutationScopes({
+      queueName: 'tournament-sync-p2',
+      jobName: 'tournament-transfers-post',
+      eventId: 33,
+    });
+    const tournamentResults = resolveMutationScopes({
+      queueName: 'tournament-sync-p2',
+      jobName: 'tournament-event-results',
+      eventId: 33,
+    });
+
+    // Same-table writers across domains share exactly one table scope
+    expect(leaguePicks).toContain('entry-event-picks:event:33');
+    expect(tournamentPicks).toContain('entry-event-picks:event:33');
+    expect(entryPicks).toEqual(['entry-event-picks:event:33']);
+    expect(tournamentTransfersPost).toContain('entry-event-transfers:event:33');
+    expect(tournamentTransfersPost).not.toContain('entry-event-picks:event:33');
+    expect(tournamentResults).toContain('entry-event-results:event:33');
+    expect(tournamentResults).not.toContain('entry-event-picks:event:33');
   });
 });

--- a/tests/unit/notify.test.ts
+++ b/tests/unit/notify.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { alertOnFinalFailure } from '../../src/utils/notify';
+
+describe('alertOnFinalFailure', () => {
+  test('does not alert for intermediate (retryable) failures', async () => {
+    const send = mock(async (_message: string) => {});
+
+    await alertOnFinalFailure(
+      {
+        queueName: 'data-sync-p1',
+        jobName: 'fixtures',
+        jobId: 'j1',
+        attemptsMade: 1,
+        attempts: 3,
+        error: new Error('boom'),
+      },
+      send,
+    );
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test('alerts when attempts are exhausted, with job context in the message', async () => {
+    const send = mock(async (_message: string) => {});
+
+    await alertOnFinalFailure(
+      {
+        queueName: 'live-data-p0',
+        jobName: 'event-lives-db',
+        jobId: 'job-42',
+        attemptsMade: 3,
+        attempts: 3,
+        tier: 'p0',
+        error: new Error('FPL API timeout'),
+      },
+      send,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const message = send.mock.calls[0][0];
+    expect(message).toContain('live-data-p0/event-lives-db');
+    expect(message).toContain('job-42');
+    expect(message).toContain('3/3 attempts');
+    expect(message).toContain('FPL API timeout');
+    expect(message).toContain('[p0]');
+  });
+
+  test('treats jobs without configured attempts as final on first failure', async () => {
+    const send = mock(async (_message: string) => {});
+
+    await alertOnFinalFailure(
+      {
+        queueName: 'tournament-setup-p0',
+        jobName: 'tournament-setup',
+        jobId: 'j9',
+        attemptsMade: 1,
+        attempts: undefined,
+        error: 'db gone',
+      },
+      send,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toContain('1/1 attempts');
+    expect(send.mock.calls[0]?.[0]).toContain('db gone');
+  });
+
+  test('never throws when the sender fails', async () => {
+    const send = mock(async () => {
+      throw new Error('telegram down');
+    });
+
+    await expect(
+      alertOnFinalFailure(
+        {
+          queueName: 'entry-sync-p2',
+          jobName: 'entry-picks',
+          jobId: 'j3',
+          attemptsMade: 3,
+          attempts: 3,
+          error: new Error('x'),
+        },
+        send,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  test('truncates very long error messages', async () => {
+    const send = mock(async (_message: string) => {});
+
+    await alertOnFinalFailure(
+      {
+        queueName: 'q',
+        jobName: 'j',
+        jobId: 'i',
+        attemptsMade: 2,
+        attempts: 2,
+        error: new Error('y'.repeat(5000)),
+      },
+      send,
+    );
+
+    expect(send.mock.calls[0]?.[0].length).toBeLessThanOrEqual(900);
+  });
+});

--- a/tests/unit/tournament-setup-watchdog.test.ts
+++ b/tests/unit/tournament-setup-watchdog.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const findStuckProcessing = mock(async (): Promise<Array<Record<string, unknown>>> => []);
+const markSetupResult = mock(async () => {});
+mock.module('../../src/repositories/tournament-infos', () => ({
+  tournamentInfoRepository: { findStuckProcessing, markSetupResult },
+}));
+
+const enqueueTournamentSetup = mock(async () => ({ id: 'setup-job-1' }));
+const getTournamentSetupJobState = mock(
+  async (): Promise<{ jobId: string; state: string } | null> => null,
+);
+mock.module('../../src/jobs/tournament-setup.jobs', () => ({
+  enqueueTournamentSetup,
+  getTournamentSetupJobState,
+}));
+
+const { recoverStuckTournamentSetups } = await import(
+  '../../src/services/tournament-setup.service'
+);
+
+const stuckRow = {
+  id: 777,
+  setupStartedAt: new Date('2026-07-17T00:00:00Z'),
+};
+
+describe('recoverStuckTournamentSetups', () => {
+  beforeEach(() => {
+    findStuckProcessing.mockClear();
+    markSetupResult.mockClear();
+    enqueueTournamentSetup.mockClear();
+    getTournamentSetupJobState.mockClear();
+    findStuckProcessing.mockImplementation(async () => [stuckRow]);
+  });
+
+  test('recovers a stuck setup when no BullMQ job exists', async () => {
+    getTournamentSetupJobState.mockImplementation(async () => null);
+
+    const result = await recoverStuckTournamentSetups(60);
+
+    expect(result.recovered).toEqual([777]);
+    expect(markSetupResult).toHaveBeenCalledWith(777, 'failed', expect.stringContaining('stuck'));
+    expect(enqueueTournamentSetup).toHaveBeenCalledWith(777, 'watchdog', { forceNew: true });
+  });
+
+  test('recovers when the canonical job already settled', async () => {
+    getTournamentSetupJobState.mockImplementation(async () => ({
+      jobId: 'tournament-setup-777',
+      state: 'failed',
+    }));
+
+    const result = await recoverStuckTournamentSetups(60);
+
+    expect(result.recovered).toEqual([777]);
+    expect(enqueueTournamentSetup).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips recovery while a job is active — slow is not stuck', async () => {
+    getTournamentSetupJobState.mockImplementation(async () => ({
+      jobId: 'tournament-setup-777',
+      state: 'active',
+    }));
+
+    const result = await recoverStuckTournamentSetups(60);
+
+    expect(result.recovered).toEqual([]);
+    expect(markSetupResult).not.toHaveBeenCalled();
+    expect(enqueueTournamentSetup).not.toHaveBeenCalled();
+  });
+
+  test('skips recovery while a job is still waiting or delayed', async () => {
+    for (const state of ['waiting', 'delayed', 'prioritized']) {
+      getTournamentSetupJobState.mockImplementation(async () => ({
+        jobId: 'tournament-setup-777',
+        state,
+      }));
+
+      const result = await recoverStuckTournamentSetups(60);
+
+      expect(result.recovered).toEqual([]);
+    }
+    expect(enqueueTournamentSetup).not.toHaveBeenCalled();
+  });
+
+  test('returns empty when nothing is stuck', async () => {
+    findStuckProcessing.mockImplementation(async () => []);
+
+    const result = await recoverStuckTournamentSetups(60);
+
+    expect(result.recovered).toEqual([]);
+    expect(getTournamentSetupJobState).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## FP-14 · Job safety pack

Implements all eight sub-items (a–h) from `docs/fix-plan-2026-07-17.md` (findings H10, H11, M9–M14).

**Stacked on #15** (`fix/fp-13-api-hardening`) — touches the same enqueue modules; GitHub will auto-retarget to `main` when #15 merges.

> **Ops note**: final-failure alerting (d) is a no-op until `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` are set in prod.

| # | Change | Where |
|---|--------|-------|
| a | `entry-event-results-daily` gains `isFPLSeason` + current-event guards (matching sibling crons) and enqueues with the current `eventId`; worker passes it through | `src/jobs/entry-results.jobs.ts`, `src/workers/entry-sync.worker.ts` |
| b | Setup watchdog probes the canonical BullMQ job state first: waiting/delayed/active/prioritized → skip (slow ≠ stuck). The old flow marked live setups failed mid-run and `forceNew` raced a duplicate setup | `src/jobs/tournament-setup.jobs.ts` (`getTournamentSetupJobState`), `src/services/tournament-setup.service.ts` |
| c | `errors > 0 → throw` in tournament-event-picks, transfers pre+post, tournament-info — BullMQ retries instead of silent gaps. Transfers-post: missing result/picks = error (cascade only runs after results succeeded); zero transfer rows stay a legitimate skip | 3 tournament services |
| d | `alertOnFinalFailure()` (Telegram, dep-injectable sender, 900-char cap, never throws) wired into all six workers' `failed` handlers; fires only when `attemptsMade >= attempts` | `src/utils/notify.ts`, `src/workers/*.ts` |
| e | `event-lives-db` re-checks the live window inside the worker for cron jobs (backed-up tick no longer runs after the window closes); post-match consolidation carries `skipWindowCheck`. Cron enqueues dedupe against the waiting room: an earlier waiting/delayed job for the same (job, event) is reused | `src/jobs/live-data.jobs.ts`, `src/jobs/live.jobs.ts`, `src/workers/live-data.worker.ts`, `src/queues/live-data.queue.ts` |
| f | Entry-sync chunk chains use deterministic IDs `${jobName}-${runId}-chunk-${offset}` (runId = first job's id, propagated via job data) — a retried chunk re-enqueues the same id and BullMQ dedupes instead of forking a duplicate chain | `src/workers/entry-sync.worker.ts`, `src/jobs/entry-sync-enqueue.ts`, `src/queues/entry-sync.queue.ts` |
| g | Cascade fan-outs throw when any enqueue failed (tournament-sync cascade incl. MV refresh, live-data cascade, both league fan-outs) so parents retry instead of leaving downstream data silently stale. Also fixes misaligned failed-job names in the live-data cascade when the match window is closed | `tournament-sync.worker.ts`, `live-data-cascade.service.ts`, `league-sync.service.ts` |
| h | Mutation scopes narrowed per table: `entry-event-picks\|transfers\|results:event:N`, shared across entry/league/tournament writers of the same table; selection-stats takes all three (reads all three). Lock keys are ephemeral TTL'd coordination keys — no frozen-shape impact | `src/domain/mutation-scope.ts` |

### Verification
- **Unit**: 341 tests pass (new: watchdog probe states, `alertOnFinalFailure`, cron waiting-room dedup + `skipWindowCheck` job data, cascade throws with correct failed-job names, league fan-out throws, per-table scope isolation + cross-domain sharing); `tsc --noEmit` clean; eslint clean (13 pre-existing warnings).
- **BullMQ rehearsed against real Redis** (local throwaway DB, flushed after): second cron tick reuses the waiting job; different event still enqueues; `skipWindowCheck` persisted in job data; retried chunk enqueue dedupes via deterministic chain id; `runId` propagates; different runId doesn't collide. **8/8 checks passed.**

### Known trade-offs
- Coordinator/fan-out retries (g) re-enqueue all children; already-enqueued children run duplicate (idempotent) syncs since league/tournament child jobs use per-tick unique IDs. Wasteful, not corrupting; deterministic child IDs would be a follow-up.
- Final-failure alerts (d) fire on first failure for jobs without configured attempts (e.g. tournament-setup) — correct, since those jobs have no retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
