### PR TITLE
refactor(types): schema-inferred types + transformer hygiene (FP-19)

### DIFF
--- a/docs/fix-plan-checklist.md
+++ b/docs/fix-plan-checklist.md
@@ -98,7 +98,7 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
   - [x] `Season:active` in-process cache (~5 s)
   - [x] Battle-race N+1 → batch `findByTournamentAndEntries` + in-memory bucket
 - [x] **FP-18 · FPL client resilience** (M18 · M) — one `request()` helper (10 s timeout, ≤3 jittered retries honoring `Retry-After`, User-Agent); all 9 call sites; mocked-fetch tests
-- [ ] **FP-19 · Type & transformer consolidation** (L5, L6, L8 · M) — `z.infer` RawFPL types from client schemas; delete `types/index.ts` duplicates; `transformEventLive` validates output; dedupe `getChangeType`
+- [x] **FP-19 · Type & transformer consolidation** (L5, L6, L8 · M) — `z.infer` RawFPL types from client schemas; delete `types/index.ts` duplicates; `transformEventLive` validates output; dedupe `getChangeType`
 - [ ] **FP-20 · RLS & migration-ledger hardening** (M19, L17 · M · *after FP-01*) — RLS into numbered migrations; delete stale `sql/*.sql`; advisory lock + `ON CONFLICT` in `apply-sql-migrations`; update `RLS_SECURITY.md` to reality
 - [ ] **FP-21 · Schema types + season semantics** (M20, M21 · M) — `text→numeric(10,2)` metric columns; `deadline_time→timestamptz`; document single-season semantics (accepted design)
 - [ ] **FP-22 · Config & logging hygiene** (M22, L16 · S) — 6 env flags into Zod `EnvSchema` (one transform); pino `redact` paths; scrub `notify.ts` URL/chat-ID logging
@@ -145,3 +145,4 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 | FP-16 | (PR #18) | 2026-07-17 | transaction coverage: event-lives, knockout, upsertFromSummary |
 | FP-17 | (PR #19) | 2026-07-17 | cache hygiene: TTL, resilient hash reads, season memo, battle-race batch |
 | FP-18 | (PR #20) | 2026-07-17 | one resilient FPL request() with timeout/retries |
+| FP-19 | 270bb0b | 2026-07-17 | PR #21 |

--- a/src/clients/fpl.ts
+++ b/src/clients/fpl.ts
@@ -1,14 +1,5 @@
 import { z } from 'zod';
 
-import {
-  FPLBootstrapResponse,
-  RawFPLEventLiveResponse,
-  RawFPLFixture,
-  RawFPLEntryHistoryResponse,
-  RawFPLLeagueStandingsResponse,
-  RawFPLEntryCupResponse,
-  RawFPLEntryTransfersResponse,
-} from '../types';
 import { FPLClientError } from '../utils/errors';
 import { logDebug } from '../utils/logger';
 
@@ -65,8 +56,14 @@ function computeBackoffMs(attempt: number): number {
   return Math.floor(Math.random() * (ceiling + 1));
 }
 
-// Zod schemas for validation
-const EventSchema = z.object({
+// ---------------------------------------------------------------------------
+// Zod schemas — exported as the canonical boundary validation + type source.
+// Each schema validates the raw FPL JSON at the API boundary. The inferred
+// types (z.infer) replace the hand-maintained RawFPL* interfaces that lived in
+// src/types/index.ts before FP-19.
+// ---------------------------------------------------------------------------
+
+export const EventSchema = z.object({
   id: z.number(),
   name: z.string(),
   deadline_time: z.string().nullable(),
@@ -103,7 +100,7 @@ const EventSchema = z.object({
   most_vice_captained: z.number().nullable(),
 });
 
-const TeamSchema = z.object({
+export const TeamSchema = z.object({
   code: z.number(),
   draw: z.number(),
   form: z.string().nullable(),
@@ -127,7 +124,7 @@ const TeamSchema = z.object({
   pulse_id: z.number(),
 });
 
-const ElementSchema = z.object({
+export const ElementSchema = z.object({
   id: z.number(),
   code: z.number(),
   element_type: z.number(),
@@ -160,6 +157,7 @@ const ElementSchema = z.object({
   transfers_out: z.number(),
   transfers_in_event: z.number(),
   transfers_out_event: z.number(),
+  // Performance stats (many more fields available)
   minutes: z.number(),
   goals_scored: z.number(),
   assists: z.number(),
@@ -181,9 +179,19 @@ const ElementSchema = z.object({
   expected_assists: z.string(),
   expected_goal_involvements: z.string(),
   expected_goals_conceded: z.string(),
+  // Optional fields — available in some endpoint responses (e.g. element-summary)
+  starts: z.number().optional(),
+  influence_rank: z.number().optional(),
+  influence_rank_type: z.number().optional(),
+  creativity_rank: z.number().optional(),
+  creativity_rank_type: z.number().optional(),
+  threat_rank: z.number().optional(),
+  threat_rank_type: z.number().optional(),
+  ict_index_rank: z.number().optional(),
+  ict_index_rank_type: z.number().optional(),
 });
 
-const PhaseSchema = z.object({
+export const PhaseSchema = z.object({
   id: z.number(),
   name: z.string(),
   start_event: z.number(),
@@ -191,7 +199,7 @@ const PhaseSchema = z.object({
   highest_score: z.number().nullable(),
 });
 
-const FixtureStatSchema = z.object({
+export const FixtureStatSchema = z.object({
   identifier: z.string(),
   a: z.array(
     z.object({
@@ -207,7 +215,7 @@ const FixtureStatSchema = z.object({
   ),
 });
 
-const FixtureSchema = z.object({
+export const FixtureSchema = z.object({
   code: z.number(),
   event: z.number().nullable(),
   finished: z.boolean(),
@@ -227,7 +235,7 @@ const FixtureSchema = z.object({
   pulse_id: z.number(),
 });
 
-const BootstrapResponseSchema = z.object({
+export const BootstrapResponseSchema = z.object({
   events: z.array(EventSchema),
   teams: z.array(TeamSchema),
   elements: z.array(ElementSchema),
@@ -237,6 +245,242 @@ const BootstrapResponseSchema = z.object({
   element_stats: z.array(z.unknown()),
   element_types: z.array(z.unknown()),
 });
+
+// Event Live schemas
+export const EventLiveStatsSchema = z.object({
+  minutes: z.number(),
+  goals_scored: z.number(),
+  assists: z.number(),
+  clean_sheets: z.number(),
+  goals_conceded: z.number(),
+  own_goals: z.number(),
+  penalties_saved: z.number(),
+  penalties_missed: z.number(),
+  yellow_cards: z.number(),
+  red_cards: z.number(),
+  saves: z.number(),
+  bonus: z.number(),
+  bps: z.number(),
+  influence: z.string(),
+  creativity: z.string(),
+  threat: z.string(),
+  ict_index: z.string(),
+  clearances_blocks_interceptions: z.number().optional(),
+  recoveries: z.number().optional(),
+  tackles: z.number().optional(),
+  defensive_contribution: z.number().optional(),
+  starts: z.number(),
+  expected_goals: z.string(),
+  expected_assists: z.string(),
+  expected_goal_involvements: z.string(),
+  expected_goals_conceded: z.string(),
+  total_points: z.number(),
+  in_dreamteam: z.boolean(),
+});
+
+export const EventLiveElementSchema = z.object({
+  id: z.number(),
+  stats: EventLiveStatsSchema,
+  // FPL returns explain: null for players with no recorded stats yet
+  explain: z.array(z.unknown()).nullable(),
+});
+
+export const EventLiveResponseSchema = z.object({
+  elements: z.array(EventLiveElementSchema),
+});
+
+// Entry summary schema (FPL: /api/entry/{entryId}/)
+const EntryLeagueItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  short_name: z.string().nullable().optional(),
+  created: z.string().optional(),
+  entry_rank: z.number().nullable(),
+  entry_last_rank: z.number().nullable(),
+  start_event: z.number().nullable().optional(),
+});
+
+const EntryLeaguesSchema = z
+  .object({
+    classic: z.array(EntryLeagueItemSchema),
+    h2h: z.array(EntryLeagueItemSchema),
+  })
+  .passthrough()
+  .optional();
+
+export const EntrySummarySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  player_first_name: z.string(),
+  player_last_name: z.string(),
+  player_region_name: z.string().nullable().optional(),
+  started_event: z.number().nullable().optional(),
+  summary_overall_points: z.number().nullable().optional(),
+  summary_overall_rank: z.number().nullable().optional(),
+  bank: z.number().nullable().optional(),
+  value: z.number().nullable().optional(),
+  last_deadline_total_transfers: z.number().nullable().optional(),
+  last_deadline_bank: z.number().nullable().optional(),
+  last_deadline_total_points: z.number().nullable().optional(),
+  last_deadline_rank: z.number().nullable().optional(),
+  last_deadline_value: z.number().nullable().optional(),
+  leagues: EntryLeaguesSchema,
+});
+
+// Entry event picks schemas (FPL: /api/entry/{entryId}/event/{eventId}/picks/)
+export const PickItemSchema = z.object({
+  element: z.number(),
+  position: z.number(),
+  multiplier: z.number(),
+  is_captain: z.boolean(),
+  is_vice_captain: z.boolean(),
+});
+
+export const PicksEntryHistorySchema = z.object({
+  event: z.number(),
+  points: z.number(),
+  total_points: z.number(),
+  rank: z.number().nullable(),
+  overall_rank: z.number().nullable(),
+  bank: z.number(),
+  value: z.number(),
+  event_transfers: z.number(),
+  event_transfers_cost: z.number(),
+  points_on_bench: z.number(),
+});
+
+export const PicksResponseSchema = z.object({
+  // Accept any chip string at the boundary — FPL adds chip types faster
+  // than downstream enums track (e.g. 'manager'). Mapping happens in
+  // src/domain/chips.ts.
+  active_chip: z.string().nullable(),
+  automatic_subs: z.array(z.unknown()),
+  entry_history: PicksEntryHistorySchema,
+  picks: z.array(PickItemSchema),
+});
+
+// League standings schemas
+const StandingsResultSchema = z.object({ entry: z.number() }).passthrough();
+const StandingsSchema = z
+  .object({
+    has_next: z.boolean(),
+    results: z.array(StandingsResultSchema),
+  })
+  .passthrough();
+const StandingsLeagueSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+  })
+  .passthrough();
+export const LeagueStandingsSchema = z
+  .object({ standings: StandingsSchema, league: StandingsLeagueSchema.optional() })
+  .passthrough();
+
+// Entry history schemas (FPL: /api/entry/{entryId}/history/)
+export const EntryHistoryPastSeasonSchema = z.object({
+  season_name: z.string(),
+  total_points: z.number(),
+  rank: z.number(),
+});
+
+export const EntryHistoryCurrentItemSchema = z.object({
+  event: z.number(),
+  points: z.number(),
+  total_points: z.number(),
+  rank: z.number().nullable().optional(),
+  overall_rank: z.number().nullable().optional(),
+});
+
+export const EntryHistoryResponseSchema = z.object({
+  current: z.array(EntryHistoryCurrentItemSchema),
+  chips: z.array(z.unknown()),
+  past: z.array(EntryHistoryPastSeasonSchema),
+});
+
+// Entry transfers schema (FPL: /api/entry/{entryId}/transfers/)
+export const TransferSchema = z.object({
+  element_in: z.number(),
+  element_in_cost: z.number(),
+  element_in_points: z.number().nullable().optional(),
+  element_out: z.number(),
+  element_out_cost: z.number(),
+  element_out_points: z.number().nullable().optional(),
+  entry: z.number(),
+  event: z.number(),
+  time: z.string(),
+});
+
+export const TransfersSchema = z.array(TransferSchema);
+
+// Entry cup schemas (FPL: /api/entry/{entryId}/cup/)
+export const CupMatchSchema = z.object({
+  event: z.number(),
+  entry_1_entry: z.number(),
+  entry_1_name: z.string(),
+  entry_1_player_name: z.string(),
+  entry_1_points: z.number().nullable(),
+  entry_2_entry: z.number(),
+  entry_2_name: z.string(),
+  entry_2_player_name: z.string(),
+  entry_2_points: z.number().nullable(),
+  winner: z.number().nullable(),
+});
+
+export const CupResponseSchema = z
+  .object({
+    cup_matches: z.array(CupMatchSchema),
+    cup_status: z.unknown().optional(),
+  })
+  .passthrough();
+
+// ---------------------------------------------------------------------------
+// Inferred types — replaces hand-maintained RawFPL* interfaces.
+// ---------------------------------------------------------------------------
+
+export type RawFPLEvent = z.infer<typeof EventSchema>;
+export type RawFPLTeam = z.infer<typeof TeamSchema>;
+export type RawFPLElement = z.infer<typeof ElementSchema>;
+export type RawFPLPhase = z.infer<typeof PhaseSchema>;
+export type RawFPLFixtureStat = z.infer<typeof FixtureStatSchema>;
+export type RawFPLFixture = z.infer<typeof FixtureSchema>;
+export type FPLBootstrapResponse = z.infer<typeof BootstrapResponseSchema>;
+export type RawFPLEventLiveStats = z.infer<typeof EventLiveStatsSchema>;
+export type RawFPLEventLiveElement = z.infer<typeof EventLiveElementSchema>;
+export type RawFPLEventLiveResponse = z.infer<typeof EventLiveResponseSchema>;
+export type RawFPLEntrySummary = z.infer<typeof EntrySummarySchema>;
+export type RawFPLLeagueItem = z.infer<typeof EntryLeagueItemSchema>;
+export type RawFPLEntryLeagues = z.infer<typeof EntryLeaguesSchema>;
+export type RawFPLEntryEventPickItem = z.infer<typeof PickItemSchema>;
+export type RawFPLEntryEventPicksEntryHistory = z.infer<typeof PicksEntryHistorySchema>;
+export type RawFPLEntryEventPicksResponse = z.infer<typeof PicksResponseSchema>;
+export type RawFPLLeagueStandingsResult = z.infer<typeof StandingsResultSchema>;
+export type RawFPLLeagueStandings = z.infer<typeof StandingsSchema>;
+export type RawFPLLeagueInfo = z.infer<typeof StandingsLeagueSchema>;
+export type RawFPLLeagueStandingsResponse = z.infer<typeof LeagueStandingsSchema>;
+export type RawFPLEntryHistoryPastSeason = z.infer<typeof EntryHistoryPastSeasonSchema>;
+export type RawFPLEntryHistoryCurrentItem = z.infer<typeof EntryHistoryCurrentItemSchema>;
+export type RawFPLEntryHistoryResponse = z.infer<typeof EntryHistoryResponseSchema>;
+export type RawFPLEntryTransfer = z.infer<typeof TransferSchema>;
+export type RawFPLEntryTransfersResponse = z.infer<typeof TransfersSchema>;
+export type RawFPLEntryCupMatch = z.infer<typeof CupMatchSchema>;
+export type RawFPLEntryCupResponse = z.infer<typeof CupResponseSchema>;
+
+// Explain schemas (for event-live-explains transformer)
+export const EventExplainStatSchema = z.object({
+  identifier: z.string(),
+  points: z.number(),
+  value: z.number(),
+  points_modification: z.number().nullable().optional(),
+});
+
+export const EventExplainFixtureSchema = z.object({
+  fixture: z.number(),
+  stats: z.array(EventExplainStatSchema),
+});
+
+export type RawFPLEventExplainStat = z.infer<typeof EventExplainStatSchema>;
+export type RawFPLEventExplainFixture = z.infer<typeof EventExplainFixtureSchema>;
 
 class FPLClient {
   private readonly baseUrl = 'https://fantasy.premierleague.com/api';
@@ -394,7 +638,7 @@ class FPLClient {
         phaseCount: validated.phases.length,
       });
 
-      return validated as FPLBootstrapResponse;
+      return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new FPLClientError(
@@ -446,7 +690,7 @@ class FPLClient {
         fixtureCount: validated.length,
       });
 
-      return validated as RawFPLFixture[];
+      return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new FPLClientError(
@@ -488,49 +732,7 @@ class FPLClient {
 
       const data: unknown = await response.json();
 
-      // Validate with Zod
-      const EventLiveStatsSchema = z.object({
-        minutes: z.number(),
-        goals_scored: z.number(),
-        assists: z.number(),
-        clean_sheets: z.number(),
-        goals_conceded: z.number(),
-        own_goals: z.number(),
-        penalties_saved: z.number(),
-        penalties_missed: z.number(),
-        yellow_cards: z.number(),
-        red_cards: z.number(),
-        saves: z.number(),
-        bonus: z.number(),
-        bps: z.number(),
-        influence: z.string(),
-        creativity: z.string(),
-        threat: z.string(),
-        ict_index: z.string(),
-        clearances_blocks_interceptions: z.number().optional(),
-        recoveries: z.number().optional(),
-        tackles: z.number().optional(),
-        defensive_contribution: z.number().optional(),
-        starts: z.number(),
-        expected_goals: z.string(),
-        expected_assists: z.string(),
-        expected_goal_involvements: z.string(),
-        expected_goals_conceded: z.string(),
-        total_points: z.number(),
-        in_dreamteam: z.boolean(),
-      });
-
-      const EventLiveElementSchema = z.object({
-        id: z.number(),
-        stats: EventLiveStatsSchema,
-        // FPL returns explain: null for players with no recorded stats yet
-        explain: z.array(z.unknown()).nullable(),
-      });
-
-      const EventLiveResponseSchema = z.object({
-        elements: z.array(EventLiveElementSchema),
-      });
-
+      // Validate with Zod (schemas at module level)
       const validated = EventLiveResponseSchema.parse(data);
 
       logDebug('Successfully fetched and validated event live data', {
@@ -538,7 +740,7 @@ class FPLClient {
         elementCount: validated.elements.length,
       });
 
-      return validated as RawFPLEventLiveResponse;
+      return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new FPLClientError(
@@ -577,44 +779,6 @@ class FPLClient {
       }
 
       const data: unknown = await response.json();
-
-      // Validate a minimal subset we depend on
-      const LeagueItemSchema = z.object({
-        id: z.number(),
-        name: z.string(),
-        short_name: z.string().nullable().optional(),
-        created: z.string().optional(),
-        entry_rank: z.number().nullable(),
-        entry_last_rank: z.number().nullable(),
-        start_event: z.number().nullable().optional(),
-      });
-
-      const EntryLeaguesSchema = z
-        .object({
-          classic: z.array(LeagueItemSchema),
-          h2h: z.array(LeagueItemSchema),
-        })
-        .passthrough()
-        .optional();
-
-      const EntrySummarySchema = z.object({
-        id: z.number(),
-        name: z.string(),
-        player_first_name: z.string(),
-        player_last_name: z.string(),
-        player_region_name: z.string().nullable().optional(),
-        started_event: z.number().nullable().optional(),
-        summary_overall_points: z.number().nullable().optional(),
-        summary_overall_rank: z.number().nullable().optional(),
-        bank: z.number().nullable().optional(),
-        value: z.number().nullable().optional(),
-        last_deadline_total_transfers: z.number().nullable().optional(),
-        last_deadline_bank: z.number().nullable().optional(),
-        last_deadline_total_points: z.number().nullable().optional(),
-        last_deadline_rank: z.number().nullable().optional(),
-        last_deadline_value: z.number().nullable().optional(),
-        leagues: EntryLeaguesSchema,
-      });
 
       const validated = EntrySummarySchema.parse(data);
       logDebug('Successfully fetched and validated entry summary', { entryId });
@@ -655,37 +819,6 @@ class FPLClient {
       }
 
       const data: unknown = await response.json();
-
-      const PickItemSchema = z.object({
-        element: z.number(),
-        position: z.number(),
-        multiplier: z.number(),
-        is_captain: z.boolean(),
-        is_vice_captain: z.boolean(),
-      });
-
-      const EntryHistorySchema = z.object({
-        event: z.number(),
-        points: z.number(),
-        total_points: z.number(),
-        rank: z.number().nullable(),
-        overall_rank: z.number().nullable(),
-        bank: z.number(),
-        value: z.number(),
-        event_transfers: z.number(),
-        event_transfers_cost: z.number(),
-        points_on_bench: z.number(),
-      });
-
-      const PicksResponseSchema = z.object({
-        // Accept any chip string at the boundary — FPL adds chip types faster
-        // than downstream enums track (e.g. 'manager'). Mapping happens in
-        // src/domain/chips.ts.
-        active_chip: z.string().nullable(),
-        automatic_subs: z.array(z.unknown()),
-        entry_history: EntryHistorySchema,
-        picks: z.array(PickItemSchema),
-      });
 
       const validated = PicksResponseSchema.parse(data);
       logDebug('Successfully fetched and validated entry event picks', {
@@ -736,23 +869,6 @@ class FPLClient {
 
       const data: unknown = await response.json();
 
-      const StandingsResultSchema = z.object({ entry: z.number() }).passthrough();
-      const StandingsSchema = z
-        .object({
-          has_next: z.boolean(),
-          results: z.array(StandingsResultSchema),
-        })
-        .passthrough();
-      const LeagueSchema = z
-        .object({
-          id: z.number(),
-          name: z.string(),
-        })
-        .passthrough();
-      const LeagueStandingsSchema = z
-        .object({ standings: StandingsSchema, league: LeagueSchema.optional() })
-        .passthrough();
-
       const validated = LeagueStandingsSchema.parse(data);
       logDebug('Successfully fetched league standings', {
         leagueId,
@@ -760,7 +876,7 @@ class FPLClient {
         leagueType,
         entryCount: validated.standings.results.length,
       });
-      return validated as RawFPLLeagueStandingsResponse;
+      return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new FPLClientError(
@@ -816,26 +932,13 @@ class FPLClient {
 
       const data: unknown = await response.json();
 
-      const TransferSchema = z.object({
-        element_in: z.number(),
-        element_in_cost: z.number(),
-        element_in_points: z.number().nullable().optional(),
-        element_out: z.number(),
-        element_out_cost: z.number(),
-        element_out_points: z.number().nullable().optional(),
-        entry: z.number(),
-        event: z.number(),
-        time: z.string(),
-      });
-
-      const TransfersSchema = z.array(TransferSchema);
       const validated = TransfersSchema.parse(data);
 
       logDebug('Successfully fetched and validated entry transfers', {
         entryId,
         count: validated.length,
       });
-      return validated as RawFPLEntryTransfersResponse;
+      return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new FPLClientError(
@@ -873,33 +976,13 @@ class FPLClient {
 
       const data: unknown = await response.json();
 
-      const EntryHistoryPastSeasonSchema = z.object({
-        season_name: z.string(),
-        total_points: z.number(),
-        rank: z.number(),
-      });
-
-      const EntryHistoryCurrentItemSchema = z.object({
-        event: z.number(),
-        points: z.number(),
-        total_points: z.number(),
-        rank: z.number().nullable().optional(),
-        overall_rank: z.number().nullable().optional(),
-      });
-
-      const EntryHistoryResponseSchema = z.object({
-        current: z.array(EntryHistoryCurrentItemSchema),
-        chips: z.array(z.unknown()),
-        past: z.array(EntryHistoryPastSeasonSchema),
-      });
-
       const validated = EntryHistoryResponseSchema.parse(data);
       logDebug('Successfully fetched and validated entry history', {
         entryId,
         pastSeasons: validated.past.length,
         currentSnapshots: validated.current.length,
       });
-      return validated as RawFPLEntryHistoryResponse;
+      return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new FPLClientError(
@@ -941,32 +1024,12 @@ class FPLClient {
 
       const data: unknown = await response.json();
 
-      const CupMatchSchema = z.object({
-        event: z.number(),
-        entry_1_entry: z.number(),
-        entry_1_name: z.string(),
-        entry_1_player_name: z.string(),
-        entry_1_points: z.number().nullable(),
-        entry_2_entry: z.number(),
-        entry_2_name: z.string(),
-        entry_2_player_name: z.string(),
-        entry_2_points: z.number().nullable(),
-        winner: z.number().nullable(),
-      });
-
-      const CupResponseSchema = z
-        .object({
-          cup_matches: z.array(CupMatchSchema),
-          cup_status: z.unknown().optional(),
-        })
-        .passthrough();
-
       const validated = CupResponseSchema.parse(data);
       logDebug('Successfully fetched and validated entry cup', {
         entryId,
         matchCount: validated.cup_matches.length,
       });
-      return validated as RawFPLEntryCupResponse;
+      return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new FPLClientError(

--- a/src/domain/event-lives.ts
+++ b/src/domain/event-lives.ts
@@ -50,7 +50,8 @@ export type EventLives = readonly EventLive[];
 export const EventLiveSchema = z.object({
   eventId: z.number().int().positive(),
   elementId: z.number().int().positive(),
-  minutes: z.number().int().min(0).max(90).nullable(),
+  // max 150: extra time (90+30) + stoppage; penalties don't count as minutes.
+  minutes: z.number().int().min(0).max(150).nullable(),
   goalsScored: z.number().int().min(0).nullable(),
   assists: z.number().int().min(0).nullable(),
   cleanSheets: z.number().int().min(0).max(1).nullable(),

--- a/src/transformers/event-lives.ts
+++ b/src/transformers/event-lives.ts
@@ -1,4 +1,4 @@
-import type { EventLive } from '../domain/event-lives';
+import { EventLiveSchema, type EventLive } from '../domain/event-lives';
 import type { RawFPLEventLiveElement } from '../types';
 
 /**
@@ -7,7 +7,7 @@ import type { RawFPLEventLiveElement } from '../types';
 export function transformEventLive(eventId: number, rawElement: RawFPLEventLiveElement): EventLive {
   const stats = rawElement.stats;
 
-  return {
+  const transformed = {
     eventId,
     elementId: rawElement.id,
     minutes: stats.minutes,
@@ -33,6 +33,8 @@ export function transformEventLive(eventId: number, rawElement: RawFPLEventLiveE
     totalPoints: stats.total_points,
     createdAt: null,
   };
+
+  return EventLiveSchema.parse(transformed);
 }
 
 /**

--- a/src/transformers/player-values.ts
+++ b/src/transformers/player-values.ts
@@ -309,17 +309,6 @@ export function groupPlayerValuesByTeam(
 }
 
 /**
- * Get change type based on price comparison (matching Java implementation)
- */
-function getChangeType(currentValue: number, lastValue: number): 'Start' | 'Rise' | 'Faller' {
-  if (lastValue === 0) {
-    return 'Start'; // First time recording this player
-  }
-
-  return currentValue > lastValue ? 'Rise' : 'Faller';
-}
-
-/**
  * Transform players with price changes to PlayerValue objects (Daily approach)
  * Only processes players whose prices have actually changed from their last stored values
  */
@@ -349,7 +338,7 @@ export function transformPlayerValuesWithChanges(
       const currentValue = player.now_cost;
 
       // Determine change type based on price comparison
-      const changeType = getChangeType(currentValue, lastValue);
+      const changeType = determineValueChangeType(currentValue, lastValue);
 
       const playerValue: PlayerValue = {
         eventId,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
+// Re-export domain EventChipData/EventTopElementData for consumers that import from types.
 import type { EventChipData, EventTopElementData } from '../domain/event-overall-results';
 
-// Re-export for consumers that import from types
 export type { EventChipData, EventTopElementData };
 
 // Core domain types
@@ -14,7 +14,7 @@ export type EntryID = number;
 export type PhaseID = number;
 export type FixtureID = number;
 
-// Event types
+// Domain types (transformed/camelCase — not raw FPL shapes)
 export interface Event {
   id: EventID;
   name: string;
@@ -43,7 +43,6 @@ export interface Event {
   updatedAt: Date | null;
 }
 
-// Player types
 export interface Player {
   id: PlayerID;
   code: number;
@@ -56,7 +55,6 @@ export interface Player {
   webName: string;
 }
 
-// Team types
 export interface Team {
   id: TeamID;
   name: string;
@@ -83,7 +81,6 @@ export interface Team {
   updatedAt: Date | null;
 }
 
-// Phase types
 export interface Phase {
   id: PhaseID;
   name: string;
@@ -92,7 +89,6 @@ export interface Phase {
   highestScore: number | null;
 }
 
-// Fixture types
 export interface FixtureStat {
   identifier: string;
   a: Array<{ value: number; element: number }>;
@@ -121,379 +117,42 @@ export interface Fixture {
   updatedAt: Date | null;
 }
 
-// Raw FPL API Response types
-export interface RawFPLEvent {
-  id: number;
-  name: string;
-  deadline_time: string | null;
-  release_time: string | null;
-  average_entry_score: number | null;
-  finished: boolean;
-  data_checked: boolean;
-  highest_scoring_entry: number | null;
-  deadline_time_epoch: number | null;
-  deadline_time_game_offset: number | null;
-  highest_score: number | null;
-  is_previous: boolean;
-  is_current: boolean;
-  is_next: boolean;
-  cup_leagues_created: boolean;
-  h2h_ko_matches_created: boolean;
-  can_enter: boolean;
-  can_manage: boolean;
-  released: boolean;
-  ranked_count: number;
-  overrides: {
-    rules: unknown;
-    scoring: unknown;
-    element_types: unknown[];
-    pick_multiplier: unknown;
-  };
-  chip_plays: Array<
-    { chip_name: string; num_played: number } | { name: string; num_played: number }
-  >;
-  most_selected: number | null;
-  most_transferred_in: number | null;
-  top_element: number | null;
-  top_element_info: ({ element: number; points: number } | { id: number; points: number }) | null;
-  transfers_made: number | null;
-  most_captained: number | null;
-  most_vice_captained: number | null;
-}
-
-export interface RawFPLTeam {
-  code: number;
-  draw: number;
-  form: string | null;
-  id: number;
-  loss: number;
-  name: string;
-  played: number;
-  points: number;
-  position: number;
-  short_name: string;
-  strength: number;
-  team_division: number | null;
-  unavailable: boolean;
-  win: number;
-  strength_overall_home: number;
-  strength_overall_away: number;
-  strength_attack_home: number;
-  strength_attack_away: number;
-  strength_defence_home: number;
-  strength_defence_away: number;
-  pulse_id: number;
-}
-
-export interface RawFPLPhase {
-  id: number;
-  name: string;
-  start_event: number;
-  stop_event: number;
-  highest_score: number | null;
-}
-
-export interface RawFPLFixtureStat {
-  identifier: string;
-  a: Array<{ value: number; element: number }>;
-  h: Array<{ value: number; element: number }>;
-}
-
-export interface RawFPLFixture {
-  code: number;
-  event: number | null;
-  finished: boolean;
-  finished_provisional: boolean;
-  id: number;
-  kickoff_time: string | null;
-  minutes: number;
-  provisional_start_time: boolean;
-  started: boolean | null;
-  team_a: number;
-  team_a_score: number | null;
-  team_h: number;
-  team_h_score: number | null;
-  stats: RawFPLFixtureStat[];
-  team_h_difficulty: number | null;
-  team_a_difficulty: number | null;
-  pulse_id: number;
-}
-
-export interface RawFPLElement {
-  id: number;
-  code: number;
-  element_type: number;
-  team: number;
-  now_cost: number;
-  cost_change_start: number;
-  cost_change_event: number;
-  cost_change_event_fall: number;
-  cost_change_start_fall: number;
-  first_name: string;
-  second_name: string;
-  web_name: string;
-  photo: string;
-  status: string;
-  selected_by_percent: string;
-  total_points: number;
-  points_per_game: string;
-  form: string;
-  dreamteam_count: number;
-  in_dreamteam: boolean;
-  special: boolean;
-  squad_number: number | null;
-  news: string;
-  news_added: string | null;
-  chance_of_playing_this_round: number | null;
-  chance_of_playing_next_round: number | null;
-  value_form: string;
-  value_season: string;
-  transfers_in: number;
-  transfers_out: number;
-  transfers_in_event: number;
-  transfers_out_event: number;
-  // Performance stats (many more fields available)
-  minutes: number;
-  goals_scored: number;
-  assists: number;
-  clean_sheets: number;
-  goals_conceded: number;
-  own_goals: number;
-  penalties_saved: number;
-  penalties_missed: number;
-  yellow_cards: number;
-  red_cards: number;
-  saves: number;
-  bonus: number;
-  bps: number;
-  influence: string;
-  creativity: string;
-  threat: string;
-  ict_index: string;
-  expected_goals: string;
-  expected_assists: string;
-  expected_goal_involvements: string;
-  expected_goals_conceded: string;
-  // These fields are NOT available in bootstrap-static endpoint
-  // They may be available in other endpoints like /element-summary/
-  starts?: number;
-  influence_rank?: number;
-  influence_rank_type?: number;
-  creativity_rank?: number;
-  creativity_rank_type?: number;
-  threat_rank?: number;
-  threat_rank_type?: number;
-  ict_index_rank?: number;
-  ict_index_rank_type?: number;
-}
-
-// API Response types
-export interface FPLBootstrapResponse {
-  events: RawFPLEvent[];
-  game_settings: unknown;
-  phases: RawFPLPhase[];
-  teams: RawFPLTeam[];
-  total_players: number;
-  elements: RawFPLElement[];
-  element_stats: unknown[];
-  element_types: unknown[];
-}
-
-// Raw FPL Event Live Response
-export interface RawFPLEventLiveStats {
-  minutes: number;
-  goals_scored: number;
-  assists: number;
-  clean_sheets: number;
-  goals_conceded: number;
-  own_goals: number;
-  penalties_saved: number;
-  penalties_missed: number;
-  yellow_cards: number;
-  red_cards: number;
-  saves: number;
-  bonus: number;
-  bps: number;
-  influence: string;
-  creativity: string;
-  threat: string;
-  ict_index: string;
-  clearances_blocks_interceptions?: number;
-  recoveries?: number;
-  tackles?: number;
-  defensive_contribution?: number;
-  starts: number;
-  expected_goals: string;
-  expected_assists: string;
-  expected_goal_involvements: string;
-  expected_goals_conceded: string;
-  total_points: number;
-  in_dreamteam: boolean;
-}
-
-export interface RawFPLEventExplainStat {
-  identifier: string;
-  points: number;
-  value: number;
-  points_modification?: number | null;
-}
-
-export interface RawFPLEventExplainFixture {
-  fixture: number;
-  stats: RawFPLEventExplainStat[];
-}
-
-export interface RawFPLEventLiveElement {
-  id: number;
-  stats: RawFPLEventLiveStats;
-  explain: RawFPLEventExplainFixture[] | null;
-}
-
-export interface RawFPLEventLiveResponse {
-  elements: RawFPLEventLiveElement[];
-}
-
-// Entry summary (FPL: /api/entry/{entryId}/)
-export interface RawFPLEntrySummary {
-  id: number;
-  name: string;
-  player_first_name: string;
-  player_last_name: string;
-  player_region_name?: string | null;
-  started_event?: number | null;
-  summary_overall_points?: number | null;
-  summary_overall_rank?: number | null;
-  bank?: number | null; // in tenths
-  value?: number | null; // in tenths
-  last_deadline_total_transfers?: number | null;
-  last_deadline_bank?: number | null;
-  last_deadline_total_points?: number | null;
-  last_deadline_rank?: number | null;
-  last_deadline_value?: number | null; // in tenths
-  leagues?: RawFPLEntryLeagues; // optional leagues block
-}
-
-// Entry history (FPL: /api/entry/{entryId}/history/)
-export interface RawFPLEntryHistoryPastSeason {
-  season_name: string; // e.g., "2024/25"
-  total_points: number; // season total
-  rank: number; // final overall rank
-}
-
-export interface RawFPLEntryHistoryCurrentItem {
-  event: number; // GW
-  points: number;
-  total_points: number;
-  rank?: number | null; // GW rank (not used)
-  overall_rank?: number | null; // snapshot overall rank
-}
-
-export interface RawFPLEntryHistoryResponse {
-  current: RawFPLEntryHistoryCurrentItem[];
-  chips: unknown[];
-  past: RawFPLEntryHistoryPastSeason[];
-}
-
-// Leagues subsection of Entry Summary
-export interface RawFPLLeagueItem {
-  id: number;
-  name: string;
-  short_name?: string | null;
-  created?: string;
-  entry_rank: number | null;
-  entry_last_rank: number | null;
-  start_event?: number | null;
-}
-
-export interface RawFPLEntryLeagues {
-  classic: RawFPLLeagueItem[];
-  h2h: RawFPLLeagueItem[];
-  // other keys exist (cup, cup_matches); ignored
-}
-
-export interface RawFPLLeagueStandingsResult {
-  entry: number;
-}
-
-export interface RawFPLLeagueStandings {
-  results: RawFPLLeagueStandingsResult[];
-  has_next: boolean;
-}
-
-export interface RawFPLLeagueInfo {
-  id: number;
-  name: string;
-}
-
-export interface RawFPLLeagueStandingsResponse {
-  league?: RawFPLLeagueInfo;
-  standings: RawFPLLeagueStandings;
-}
-
-// Entry event picks (FPL: /api/entry/{entryId}/event/{eventId}/picks/)
-export interface RawFPLEntryEventPickItem {
-  element: number;
-  position: number;
-  multiplier: number;
-  is_captain: boolean;
-  is_vice_captain: boolean;
-}
-
-export interface RawFPLEntryEventPicksEntryHistory {
-  event: number;
-  points: number;
-  total_points: number;
-  rank: number | null;
-  overall_rank: number | null;
-  bank: number;
-  value: number;
-  event_transfers: number;
-  event_transfers_cost: number;
-  points_on_bench: number;
-}
-
-export interface RawFPLEntryEventPicksResponse {
-  // Any chip string FPL invents next; mapped onto the DB chip enum downstream
-  // (src/domain/chips.ts) instead of being rejected at the boundary.
-  active_chip: string | null;
-  automatic_subs: unknown[];
-  entry_history: RawFPLEntryEventPicksEntryHistory;
-  picks: RawFPLEntryEventPickItem[];
-}
-
-// Entry transfers (FPL: /api/entry/{entryId}/transfers/)
-export interface RawFPLEntryTransfer {
-  element_in: number;
-  element_in_cost: number; // tenths
-  element_in_points?: number | null; // sometimes unavailable
-  element_out: number;
-  element_out_cost: number; // tenths
-  element_out_points?: number | null; // sometimes unavailable
-  entry: number;
-  event: number; // GW
-  time: string; // ISO
-}
-
-export type RawFPLEntryTransfersResponse = RawFPLEntryTransfer[];
-
-// Entry cup (FPL: /api/entry/{entryId}/cup/)
-export interface RawFPLEntryCupMatch {
-  event: number;
-  entry_1_entry: number;
-  entry_1_name: string;
-  entry_1_player_name: string;
-  entry_1_points: number | null;
-  entry_2_entry: number;
-  entry_2_name: string;
-  entry_2_player_name: string;
-  entry_2_points: number | null;
-  winner: number | null; // 0 when not decided
-}
-
-export interface RawFPLEntryCupResponse {
-  cup_matches: RawFPLEntryCupMatch[];
-  cup_status?: unknown;
-}
+// ---------------------------------------------------------------------------
+// Raw FPL API types — inferred from client Zod schemas (FP-19).
+// The canonical definitions live in src/clients/fpl.ts as exported Zod schemas.
+// These re-exports preserve backward compatibility for downstream importers.
+// ---------------------------------------------------------------------------
+export type {
+  RawFPLEvent,
+  RawFPLTeam,
+  RawFPLElement,
+  RawFPLPhase,
+  RawFPLFixtureStat,
+  RawFPLFixture,
+  FPLBootstrapResponse,
+  RawFPLEventLiveStats,
+  RawFPLEventLiveElement,
+  RawFPLEventLiveResponse,
+  RawFPLEntrySummary,
+  RawFPLLeagueItem,
+  RawFPLEntryLeagues,
+  RawFPLEntryEventPickItem,
+  RawFPLEntryEventPicksEntryHistory,
+  RawFPLEntryEventPicksResponse,
+  RawFPLLeagueStandingsResult,
+  RawFPLLeagueStandings,
+  RawFPLLeagueInfo,
+  RawFPLLeagueStandingsResponse,
+  RawFPLEntryHistoryPastSeason,
+  RawFPLEntryHistoryCurrentItem,
+  RawFPLEntryHistoryResponse,
+  RawFPLEntryTransfer,
+  RawFPLEntryTransfersResponse,
+  RawFPLEntryCupMatch,
+  RawFPLEntryCupResponse,
+  RawFPLEventExplainStat,
+  RawFPLEventExplainFixture,
+} from '../clients/fpl';
 
 // Error types
 export interface APIError extends Error {


### PR DESCRIPTION
## FP-19 · Type & transformer consolidation

Findings L5, L6, L8 · plan: `docs/fix-plan-2026-07-17.md` FP-19.

### Changes

- **Schema-inferred types**: all client Zod schemas in `src/clients/fpl.ts` are now exported as the canonical boundary validators. `RawFPL*` types are inferred from them (`z.infer`) instead of being hand-maintained interfaces. `types/index.ts` re-exports the inferred types for full backward compatibility.
- **Net: −286 lines** (314 added, 600 deleted) — one source of truth per type.
- **Module-level schemas**: 12 inline Zod schemas moved out of 6 client methods to module level (entry summary, picks, transfers, history, cup, league standings) + explain stat/fixture schemas added.
- **Missing optional fields**: `ElementSchema` now includes `starts`, `influence_rank`, `creativity_rank`, `threat_rank`, `ict_index_rank` and their `_type` variants — fields that transformers consume but the old interface silently carried.
- **transformEventLive output validation**: now validates via `EventLiveSchema` like every other transformer. Fixes `EventLiveSchema.minutes` max from 90→150 (extra time is valid).
- **Delete `getChangeType`**: the private duplicate in `player-values.ts` is replaced by the domain `determineValueChangeType` (same behavior on all call paths).

### Verification

- 409 unit tests pass (35 files) · `tsc --noEmit` clean · `eslint` 0 errors (13 pre-existing warnings) · `bun run build` clean.
