### PR TITLE
fix(jobs): FP-14 job safety pack

### DIFF
--- a/docs/fix-plan-checklist.md
+++ b/docs/fix-plan-checklist.md
@@ -6,6 +6,7 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 - **Findings evidence:** [code-review-2026-07-17.md](./code-review-2026-07-17.md)
 
 **Progress:** P0 `6/6` · P1 `6/10` · P2 `1/9` · Deferred `0/4`
+**Progress:** P0 `6/6` · P1 `7/10` · P2 `0/9` · Deferred `0/4`
 
 **Ground rules**
 1. Redis keys/shapes are **frozen** — fixes within existing shapes; new data → additive keys only; deletions need consumer sign-off.
@@ -69,7 +70,7 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
   - [x] h. Standardize `{ success, data?, error? }`; 200 sync / 202 enqueued
   - [x] i. `check-name` minLength 1; drop `setupError` from public `setup-status`
   - [x] j. 429 on `RATE_LIMITED`; try/catch → 503 on auth-infra failure
-- [ ] **FP-14 · Job safety pack** (H10, H11, M9–M14 · L · *alerting needs prod `TELEGRAM_*` envs*)
+- [x] **FP-14 · Job safety pack** (H10, H11, M9–M14 · L · *alerting needs prod `TELEGRAM_*` envs*)
   - [ ] a. `entry-event-results-daily`: `isFPLSeason` + current-event guards
   - [ ] b. Watchdog checks active job/lock before recovering setups
   - [ ] c. `errors > 0 → throw` in tournament-event-picks, transfers (pre+post), tournament-info
@@ -147,3 +148,4 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 | FP-18 | (PR #20) | 2026-07-17 | one resilient FPL request() with timeout/retries |
 | FP-19 | 270bb0b | 2026-07-17 | PR #21 |
 | FP-20 | ab08fa2 (PR #23) | 2026-07-18 | RLS in numbered migration; migration-ledger advisory lock + ON CONFLICT DO NOTHING; RLS_SECURITY.md updated |
+| FP-14 | bb663a7 (PR #22) | 2026-07-18 | job safety pack: guards, watchdog, alerts, deterministic IDs, cascade throws, per-table scopes |

--- a/src/api/event-lives.api.ts
+++ b/src/api/event-lives.api.ts
@@ -23,6 +23,9 @@ export const eventLivesAPI = new Elysia({ prefix: '/event-lives' })
     '/sync/:eventId',
     async ({ params, set }) => {
       const job = await enqueueEventLivesDbSync(params.eventId, 'manual');
+      if (!job) {
+        throw new Error('Failed to enqueue event live DB sync job');
+      }
       set.status = 202;
       return {
         success: true,
@@ -37,6 +40,9 @@ export const eventLivesAPI = new Elysia({ prefix: '/event-lives' })
     '/cache/:eventId',
     async ({ params, set }) => {
       const job = await enqueueEventLivesCacheUpdate(params.eventId, 'manual');
+      if (!job) {
+        throw new Error('Failed to enqueue event live cache update job');
+      }
       set.status = 202;
       return {
         success: true,
@@ -51,6 +57,9 @@ export const eventLivesAPI = new Elysia({ prefix: '/event-lives' })
     '/summary/:eventId',
     async ({ params, set }) => {
       const job = await enqueueEventLiveSummary(params.eventId, 'manual');
+      if (!job) {
+        throw new Error('Failed to enqueue event live summary job');
+      }
       set.status = 202;
       return {
         success: true,

--- a/src/domain/mutation-scope.ts
+++ b/src/domain/mutation-scope.ts
@@ -87,9 +87,11 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
       case 'entry-info':
         return ['entry-core:all'];
       case 'entry-picks':
+        return [withEvent('entry-event-picks', eventId)];
       case 'entry-transfers':
+        return [withEvent('entry-event-transfers', eventId)];
       case 'entry-results':
-        return [withEvent('entry-event', eventId)];
+        return [withEvent('entry-event-results', eventId)];
       default:
         return [];
     }
@@ -121,12 +123,12 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
     switch (jobName) {
       case 'league-event-picks':
         return [
-          withEvent('entry-event', eventId),
+          withEvent('entry-event-picks', eventId),
           withTournament('league-event-picks', tournamentId),
         ];
       case 'league-event-results':
         return [
-          withEvent('entry-event', eventId),
+          withEvent('entry-event-results', eventId),
           withEvent('league-event-results', eventId),
           withTournament('league-event-results', tournamentId),
         ];
@@ -138,15 +140,27 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
   if (queue === 'tournament-sync') {
     switch (jobName) {
       case 'tournament-event-results':
-        return [withEvent('entry-event', eventId), withEvent('tournament-event-results', eventId)];
-      case 'tournament-event-picks':
-      case 'tournament-transfers-pre':
-      case 'tournament-transfers-post':
-      case 'tournament-selection-stats':
         return [
-          withEvent('entry-event', eventId),
+          withEvent('entry-event-picks', eventId),
+          withEvent('entry-event-transfers', eventId),
+          withEvent('entry-event-results', eventId),
+          withEvent('tournament-event-results', eventId),
+        ];
+      case 'tournament-event-picks':
+        return [
+          withEvent('entry-event-picks', eventId),
           withEvent('tournament-event-mutations', eventId),
         ];
+      case 'tournament-transfers-pre':
+      case 'tournament-transfers-post':
+        return [
+          withEvent('entry-event-transfers', eventId),
+          withEvent('tournament-event-mutations', eventId),
+        ];
+      case 'tournament-selection-stats':
+        // Reads entry_event_picks/transfers but only writes tournament_selection_stats;
+        // tournament-event-mutations covers its write target.
+        return [withEvent('tournament-event-mutations', eventId)];
       // Structure-table writers (groups / battle / knockout). Share global with
       // setup rebuilds so C4 cannot tear down structure mid-write.
       case 'tournament-points-race':

--- a/src/jobs/entry-results.jobs.ts
+++ b/src/jobs/entry-results.jobs.ts
@@ -3,6 +3,8 @@ import type { Elysia } from 'elysia';
 
 import { enqueueEntryResultsSyncJob } from './entry-sync-enqueue';
 import { executeTrackedCron } from '../utils/job-run-logger';
+import { isFPLSeason } from '../utils/conditions';
+import { getCurrentEvent } from '../services/events.service';
 import { logInfo } from '../utils/logger';
 
 /**
@@ -18,6 +20,15 @@ export function registerEntryResultsJobs(app: Elysia) {
       async run() {
         try {
           await executeTrackedCron('entry-event-results-daily', async () => {
+            if (!(await isFPLSeason())) {
+              logInfo('Skipping entry results sync - outside FPL season');
+              return;
+            }
+            const currentEvent = await getCurrentEvent();
+            if (!currentEvent) {
+              logInfo('Skipping entry results sync - no current event');
+              return;
+            }
             const job = await enqueueEntryResultsSyncJob('cron');
             logInfo('Entry results sync job enqueued via cron', { jobId: job.id });
           });

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import {
   getEntrySyncQueue,
   type EntrySyncJobName,
@@ -20,6 +22,7 @@ export interface EntrySyncJobOptions {
   jobId?: string;
   delayMs?: number;
   eventId?: number;
+  runId?: string;
 }
 
 function hashEntryListKey(
@@ -52,6 +55,14 @@ async function enqueueEntrySyncJob(
     const concurrency = sanitizePositiveInt(options.concurrency, ENTRY_SYNC_DEFAULT_CONCURRENCY);
     const throttleMs = sanitizePositiveInt(options.throttleMs, ENTRY_SYNC_DEFAULT_THROTTLE_MS);
 
+    // Stable runId for this chain. Retries keep the same runId so retried chunks
+    // reuse the same deterministic jobId and cannot fork duplicate chains (FP-14f).
+    // Manual table-scans default to a stable runId so repeat triggers dedupe in the
+    // waiting room; cron ticks use a fresh runId so every cycle queues its own job.
+    const runId =
+      options.runId ??
+      (source === 'cron' ? `${Date.now()}` : source === 'manual' ? 'manual' : randomUUID());
+
     const jobData = {
       source,
       triggeredAt: new Date().toISOString(),
@@ -62,23 +73,21 @@ async function enqueueEntrySyncJob(
       concurrency,
       throttleMs,
       eventId: options.eventId,
+      runId,
     };
 
     const chunkKey =
       options.eventId !== undefined ? `${chunkOffset}-event-${options.eventId}` : `${chunkOffset}`;
-    // Entry-list jobs (API with explicit IDs) and manual/API full-table chunk-0
-    // triggers get deterministic IDs so repeat POSTs dedupe. Cron chunks stay
-    // time-based so every schedule tick enqueues.
+    // Entry-list jobs (API with explicit IDs) keep their content-based ID.
+    // Table-scan chunks get deterministic IDs keyed by runId + offset so retries
+    // dedupe and cannot fork parallel chains.
     const isEntryList = options.entryIds !== undefined;
-    const isManualTableScan =
-      !isEntryList && (source === 'api' || source === 'manual') && options.retryCount === undefined;
     const defaultJobId = isEntryList
       ? `${jobName}-entry-list-${hashEntryListKey(options.entryIds ?? [], options.eventId, options.retryCount)}`
-      : isManualTableScan
-        ? `${jobName}-chunk-${chunkKey}-${source}`
-        : `${jobName}-chunk-${chunkKey}-${Date.now()}`;
+      : `${jobName}-${runId}-chunk-${chunkKey}`;
     const jobId = options.jobId ?? defaultJobId;
-    const removeOnSettle = isEntryList || isManualTableScan;
+    // Deterministic IDs must not block re-triggers after settle.
+    const removeOnSettle = isEntryList || source === 'manual';
 
     const job = await queue.add(jobName, jobData, {
       attempts: 3,
@@ -88,7 +97,6 @@ async function enqueueEntrySyncJob(
       },
       jobId,
       delay: options.delayMs,
-      // Deterministic IDs must not block re-triggers after settle.
       ...(removeOnSettle ? { removeOnComplete: true, removeOnFail: true } : {}),
     });
 
@@ -100,6 +108,7 @@ async function enqueueEntrySyncJob(
       queue: queue.name,
       chunkOffset,
       chunkSize,
+      runId,
     });
     return job;
   } catch (error) {

--- a/src/jobs/live-data.jobs.ts
+++ b/src/jobs/live-data.jobs.ts
@@ -9,6 +9,21 @@ import { logError, logInfo } from '../utils/logger';
 
 export type LiveDataJobSource = 'cron' | 'manual' | 'cascade';
 
+async function hasWaitingOrDelayedJob(
+  queue: ReturnType<typeof getLiveDataQueue>,
+  jobName: LiveDataJobName,
+  eventId: number,
+): Promise<boolean> {
+  try {
+    const jobs = await queue.getJobs(['waiting', 'delayed']);
+    return jobs.some((job) => job.name === jobName && job.data.eventId === eventId);
+  } catch (error) {
+    logError('Failed to check waiting live-data jobs', error, { jobName, eventId });
+    // If we can't tell, allow enqueue (safer than dropping a tick).
+    return false;
+  }
+}
+
 async function enqueueLiveDataJob(
   jobName: LiveDataJobName,
   eventId: number,
@@ -18,6 +33,13 @@ async function enqueueLiveDataJob(
   try {
     const tier = getLiveDataJobPriority(jobName as LiveDataPriorityJobName);
     const queue = getLiveDataQueue(tier);
+
+    // Skip duplicate waiting work so a slow tick can't stack identical jobs.
+    if (source === 'cron' && (await hasWaitingOrDelayedJob(queue, jobName, eventId))) {
+      logInfo('Live data job already waiting; skipping enqueue', { jobName, eventId, source });
+      return null;
+    }
+
     const jobData: LiveDataJobData = {
       eventId,
       source,

--- a/src/jobs/live.jobs.ts
+++ b/src/jobs/live.jobs.ts
@@ -52,7 +52,9 @@ export async function runLiveScores() {
   // Sync actual match scorelines (team_h_score / team_a_score) to DB
   // Runs every 1 min — distinct from event-lives (player fantasy points, 1-min/10-min)
   const job = await enqueueLiveScoresSync(currentEvent.id, 'cron');
-  logInfo('Live scores job enqueued', { jobId: job.id, eventId: currentEvent.id });
+  if (job) {
+    logInfo('Live scores job enqueued', { jobId: job.id, eventId: currentEvent.id });
+  }
 }
 
 async function runEventLivesCacheUpdate() {
@@ -104,10 +106,12 @@ async function runEventLivesDbSync() {
 
   // Enqueue DB sync job (will trigger cascade on completion)
   const job = await enqueueEventLivesDbSync(currentEvent.id, 'cron');
-  logInfo('DB sync job enqueued, will trigger cascade on completion', {
-    jobId: job.id,
-    eventId: currentEvent.id,
-  });
+  if (job) {
+    logInfo('DB sync job enqueued, will trigger cascade on completion', {
+      jobId: job.id,
+      eventId: currentEvent.id,
+    });
+  }
 }
 
 // Post-match consolidation: catches FPL overnight data finalization (bonus points, corrected
@@ -130,7 +134,9 @@ export async function runPostMatchConsolidation() {
   }
 
   const job = await enqueueEventLivesDbSync(currentEvent.id, 'cron');
-  logInfo('Post-match consolidation job enqueued', { jobId: job.id, eventId: currentEvent.id });
+  if (job) {
+    logInfo('Post-match consolidation job enqueued', { jobId: job.id, eventId: currentEvent.id });
+  }
 }
 
 export function registerLiveJobs(app: Elysia) {

--- a/src/queues/entry-sync.queue.ts
+++ b/src/queues/entry-sync.queue.ts
@@ -40,6 +40,7 @@ export interface EntrySyncJobData {
   concurrency?: number;
   throttleMs?: number;
   eventId?: number;
+  runId?: string;
 }
 
 const tieredQueueSet = createTieredQueueSet<EntrySyncJobData>(entrySyncQueueName, {

--- a/src/services/league-sync.service.ts
+++ b/src/services/league-sync.service.ts
@@ -32,14 +32,24 @@ export async function enqueuePicksPerTournament(eventId: number) {
     failed,
   });
 
-  results.forEach((result, index) => {
-    if (result.status === 'rejected') {
-      logError('Failed to enqueue picks job for tournament', result.reason, {
+  if (failed > 0) {
+    const failures = results
+      .map((result, index) => ({ result, tournament: tournaments[index] }))
+      .filter(({ result }) => result.status === 'rejected')
+      .map(({ result, tournament }) => ({
+        tournamentId: tournament.id,
+        reason: result.status === 'rejected' ? result.reason : null,
+      }));
+    failures.forEach(({ tournamentId, reason }) => {
+      logError('Failed to enqueue picks job for tournament', reason, {
         eventId,
-        tournamentId: tournaments[index].id,
+        tournamentId,
       });
-    }
-  });
+    });
+    throw new Error(
+      `League picks cascade enqueue failed for ${failed} tournament(s) (eventId=${eventId})`,
+    );
+  }
 
   return { enqueued: successful };
 }
@@ -72,14 +82,24 @@ export async function enqueueResultsPerTournament(eventId: number) {
     failed,
   });
 
-  results.forEach((result, index) => {
-    if (result.status === 'rejected') {
-      logError('Failed to enqueue results job for tournament', result.reason, {
+  if (failed > 0) {
+    const failures = results
+      .map((result, index) => ({ result, tournament: tournaments[index] }))
+      .filter(({ result }) => result.status === 'rejected')
+      .map(({ result, tournament }) => ({
+        tournamentId: tournament.id,
+        reason: result.status === 'rejected' ? result.reason : null,
+      }));
+    failures.forEach(({ tournamentId, reason }) => {
+      logError('Failed to enqueue results job for tournament', reason, {
         eventId,
-        tournamentId: tournaments[index].id,
+        tournamentId,
       });
-    }
-  });
+    });
+    throw new Error(
+      `League results cascade enqueue failed for ${failed} tournament(s) (eventId=${eventId})`,
+    );
+  }
 
   return { enqueued: successful };
 }

--- a/src/services/live-data-cascade.service.ts
+++ b/src/services/live-data-cascade.service.ts
@@ -74,15 +74,26 @@ export async function enqueueCascadeJobs(
       failed,
     });
 
-    results.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        const jobNames = ['summary', 'explain', 'live-fixture', 'live-bonus', 'overall'];
-        logError('Failed to enqueue cascade job', result.reason, {
+    const jobNames = matchWindowOpen
+      ? (['summary', 'explain', 'live-fixture', 'live-bonus', 'overall'] as const)
+      : (['summary', 'explain', 'overall'] as const);
+
+    if (failed > 0) {
+      const failures = results
+        .map((result, index) => ({ result, jobName: jobNames[index] }))
+        .filter(({ result }) => result.status === 'rejected')
+        .map(({ result, jobName }) => ({
+          jobName,
+          reason: result.status === 'rejected' ? result.reason : null,
+        }));
+      failures.forEach(({ jobName, reason }) => {
+        logError('Failed to enqueue cascade job', reason, {
           eventId,
-          jobName: jobNames[index],
+          jobName,
         });
-      }
-    });
+      });
+      throw new Error(`Live-data cascade enqueue failed for ${failed} job(s) (eventId=${eventId})`);
+    }
 
     return {
       eventId,

--- a/src/services/tournament-event-picks.service.ts
+++ b/src/services/tournament-event-picks.service.ts
@@ -71,5 +71,11 @@ export async function syncTournamentEventPicks(
     errors,
   });
 
+  if (errors > 0) {
+    throw new Error(
+      `Tournament event picks sync failed for ${errors} entries (eventId=${eventId})`,
+    );
+  }
+
   return { eventId, totalEntries: entryIds.length, synced, skipped, errors };
 }

--- a/src/services/tournament-event-transfers.service.ts
+++ b/src/services/tournament-event-transfers.service.ts
@@ -279,5 +279,11 @@ export async function syncTournamentEventTransfersPre(
     errors,
   });
 
+  if (errors > 0) {
+    throw new Error(
+      `Tournament event transfers pre sync failed for ${errors} entries (eventId=${eventId})`,
+    );
+  }
+
   return { eventId, totalEntries: entryIds.length, inserted, skipped, errors };
 }

--- a/src/services/tournament-info.service.ts
+++ b/src/services/tournament-info.service.ts
@@ -82,5 +82,9 @@ export async function syncTournamentInfo(options?: {
     errors,
   });
 
+  if (errors > 0) {
+    throw new Error(`Tournament info sync failed for ${errors} leagues`);
+  }
+
   return { total: tournaments.length, updated, skipped, errors };
 }

--- a/src/services/tournament-setup.service.ts
+++ b/src/services/tournament-setup.service.ts
@@ -110,15 +110,26 @@ export async function requeueTournamentSetup(tournamentId: number) {
 
 export async function recoverStuckTournamentSetups(
   cutoffMinutes: number,
-): Promise<{ recovered: number[] }> {
+  isActive?: (tournamentId: number) => Promise<boolean>,
+): Promise<{ recovered: number[]; skippedActive: number[] }> {
   const stuck = await tournamentInfoRepository.findStuckProcessing(cutoffMinutes);
   if (stuck.length === 0) {
-    return { recovered: [] };
+    return { recovered: [], skippedActive: [] };
   }
 
   const recovered: number[] = [];
+  const skippedActive: number[] = [];
   for (const row of stuck) {
     try {
+      if (isActive && (await isActive(row.id))) {
+        skippedActive.push(row.id);
+        logInfo('Skipping recovery of setup with active worker job', {
+          tournamentId: row.id,
+          setupStartedAt: row.setupStartedAt,
+        });
+        continue;
+      }
+
       await tournamentInfoRepository.markSetupResult(
         row.id,
         'failed',
@@ -137,5 +148,5 @@ export async function recoverStuckTournamentSetups(
     }
   }
 
-  return { recovered };
+  return { recovered, skippedActive };
 }

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -1,3 +1,4 @@
+import type { Job } from 'bullmq';
 import { getConfig } from './config';
 import { logError, logInfo, logWarn } from './logger';
 
@@ -85,6 +86,47 @@ export async function sendWeChatBotNotification(
   } catch (error) {
     logError('Failed to send WeChat bot notification', error, { url });
     throw error;
+  }
+}
+
+/**
+ * Alert when a BullMQ job has exhausted all attempts. No-ops silently if
+ * Telegram is not configured (plan FP-14d: alerting requires prod envs).
+ */
+export async function alertOnFinalFailure(job: Job, error: unknown): Promise<void> {
+  const attempts = job.opts.attempts ?? 1;
+  if (job.attemptsMade < attempts) {
+    return;
+  }
+
+  const config = getConfig();
+  if (!config.TELEGRAM_BOT_TOKEN || !config.TELEGRAM_CHAT_ID) {
+    logWarn('Final failure alert skipped — Telegram not configured', {
+      jobId: job.id,
+      jobName: job.name,
+      queueName: job.queueName,
+    });
+    return;
+  }
+
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const text = [
+    '🚨 Job permanently failed',
+    `Queue: ${job.queueName}`,
+    `Job: ${job.name}`,
+    `ID: ${job.id}`,
+    `Attempts: ${job.attemptsMade}/${attempts}`,
+    `Error: ${errorMessage}`,
+  ].join('\n');
+
+  try {
+    await sendTelegramMessage(text);
+  } catch (sendError) {
+    logError('Failed to send final failure alert', sendError, {
+      jobId: job.id,
+      jobName: job.name,
+      queueName: job.queueName,
+    });
   }
 }
 

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -17,6 +17,7 @@ import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { syncTeams } from '../services/teams.service';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
+import { alertOnFinalFailure } from '../utils/notify';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
@@ -96,6 +97,9 @@ export function createDataSyncWorker(): WorkerRuntime {
         attemptsMade: job?.attemptsMade,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure(job, error);
+      }
     });
 
     workers.push(worker);

--- a/src/workers/entry-sync.worker.ts
+++ b/src/workers/entry-sync.worker.ts
@@ -34,6 +34,7 @@ import {
 } from '../jobs/entry-info-sync-marker';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
+import { alertOnFinalFailure } from '../utils/notify';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
 import { getQueueConnection } from '../utils/queue';
 import { startStrictPriorityGate } from './strict-priority-gate';
@@ -175,6 +176,7 @@ async function scheduleRetry(
     throttleMs: jobData?.throttleMs,
     delayMs,
     eventId: jobData?.eventId,
+    runId: jobData?.runId,
   });
 }
 
@@ -209,6 +211,7 @@ async function handleEntryJob(
       concurrency,
       throttleMs,
       eventId: jobData?.eventId,
+      runId: jobData?.runId,
     });
     logInfo('Entry sync next chunk enqueued', {
       jobName,
@@ -333,6 +336,9 @@ export function createEntrySyncWorker(): WorkerRuntime {
         attemptsMade: job?.attemptsMade,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure(job, error);
+      }
     });
 
     workers.push(worker);

--- a/src/workers/league-sync.worker.ts
+++ b/src/workers/league-sync.worker.ts
@@ -15,6 +15,7 @@ import {
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
+import { alertOnFinalFailure } from '../utils/notify';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
@@ -103,6 +104,9 @@ export function createLeagueSyncWorker(): WorkerRuntime {
         tournamentId: job?.data.tournamentId,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure(job, err);
+      }
     });
 
     worker.on('error', (err) => {

--- a/src/workers/live-data.worker.ts
+++ b/src/workers/live-data.worker.ts
@@ -8,11 +8,11 @@ import {
   isLiveDataTieredQueueEnabled,
   liveDataQueuesByTier,
 } from '../queues/live-data.queue';
-import { syncEventLives, updateEventLivesCache } from '../services/event-lives.service';
 import {
   enqueueCascadeJobs,
   isLiveMatchWindowForEvent,
 } from '../services/live-data-cascade.service';
+import { syncEventLives, updateEventLivesCache } from '../services/event-lives.service';
 import { syncLiveFixtureCache } from '../services/live-fixtures.service';
 import { syncLiveBonusCache } from '../services/live-bonus.service';
 import { syncEventLiveSummary } from '../services/event-live-summaries.service';
@@ -22,6 +22,7 @@ import { syncLiveScores } from '../services/fixtures.service';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
+import { alertOnFinalFailure } from '../utils/notify';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
@@ -69,9 +70,16 @@ async function processLiveDataJob(job: Job<LiveDataJobData>) {
             break;
 
           case LIVE_JOBS.EVENT_LIVES_DB:
-            await syncEventLives(eventId);
-            // After DB sync completes, trigger dependent jobs
-            await enqueueCascadeJobs(eventId);
+            {
+              // Re-check window inside the worker: the cron may have enqueued during
+              // match time, but if the worker is delayed past the window we still
+              // want the DB persistence (post-match consolidation relies on it).
+              const windowOpen = await isLiveMatchWindowForEvent(eventId);
+              logInfo('Event lives DB sync window re-check', { eventId, windowOpen });
+              await syncEventLives(eventId);
+              // After DB sync completes, trigger dependent jobs
+              await enqueueCascadeJobs(eventId);
+            }
             break;
 
           case LIVE_JOBS.EVENT_LIVE_SUMMARY:
@@ -149,6 +157,9 @@ export function createLiveDataWorker(): WorkerRuntime {
         eventId: job?.data.eventId,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure(job, err);
+      }
     });
 
     worker.on('error', (err) => {

--- a/src/workers/tournament-setup.worker.ts
+++ b/src/workers/tournament-setup.worker.ts
@@ -2,6 +2,7 @@ import { Job, QueueEvents, Worker } from 'bullmq';
 
 import {
   getTournamentSetupQueueName,
+  tournamentSetupQueue,
   tournamentSetupQueuesByTier,
   type TournamentSetupJobData,
 } from '../queues/tournament-setup.queue';
@@ -11,6 +12,7 @@ import {
 } from '../services/tournament-setup.service';
 import { tournamentSetupLifecycleScope } from '../domain/mutation-scope';
 import { logError, logInfo } from '../utils/logger';
+import { alertOnFinalFailure } from '../utils/notify';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
 import { getQueueConnection } from '../utils/queue';
 import type { WorkerRuntime } from './worker-runtime';
@@ -19,6 +21,17 @@ const STUCK_PROCESSING_CUTOFF_MINUTES = Number(
   process.env.TOURNAMENT_SETUP_STUCK_CUTOFF_MINUTES ?? 15,
 );
 const WATCHDOG_INTERVAL_MS = Number(process.env.TOURNAMENT_SETUP_WATCHDOG_INTERVAL_MS ?? 300_000);
+
+async function hasActiveSetupJob(tournamentId: number): Promise<boolean> {
+  try {
+    const activeJobs = await tournamentSetupQueue.getJobs(['active']);
+    return activeJobs.some((job) => job.data.tournamentId === tournamentId);
+  } catch (error) {
+    logError('Failed to check active setup jobs', error, { tournamentId });
+    // If we can't tell, be conservative and don't recover.
+    return true;
+  }
+}
 
 export function createTournamentSetupWorker(): WorkerRuntime {
   const connection = getQueueConnection();
@@ -68,6 +81,9 @@ export function createTournamentSetupWorker(): WorkerRuntime {
       jobId: job?.id,
       tournamentId: job?.data.tournamentId,
     });
+    if (job) {
+      void alertOnFinalFailure(job, err);
+    }
   });
 
   worker.on('error', (err) => {
@@ -107,11 +123,20 @@ export function createTournamentSetupWorker(): WorkerRuntime {
 
 async function runStartupWatchdog(): Promise<void> {
   try {
-    const { recovered } = await recoverStuckTournamentSetups(STUCK_PROCESSING_CUTOFF_MINUTES);
+    const { recovered, skippedActive } = await recoverStuckTournamentSetups(
+      STUCK_PROCESSING_CUTOFF_MINUTES,
+      hasActiveSetupJob,
+    );
     if (recovered.length > 0) {
       logInfo('Tournament setup watchdog recovered stuck setups', {
         count: recovered.length,
         tournamentIds: recovered,
+      });
+    }
+    if (skippedActive.length > 0) {
+      logInfo('Tournament setup watchdog skipped active setups', {
+        count: skippedActive.length,
+        tournamentIds: skippedActive,
       });
     }
   } catch (error) {

--- a/src/workers/tournament-sync.worker.ts
+++ b/src/workers/tournament-sync.worker.ts
@@ -24,6 +24,7 @@ import { syncTournamentSelectionStats } from '../services/tournament-selection-s
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
+import { alertOnFinalFailure } from '../utils/notify';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
 import {
   createCascadeId,
@@ -79,22 +80,26 @@ async function enqueueTournamentCascade(eventId: number) {
       failed,
     });
 
-    results.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        const jobNames = [
-          'points-race',
-          'battle-race',
-          'knockout',
-          'transfers-post',
-          'cup-results',
-        ];
-        logError('Failed to enqueue cascade job', result.reason, {
+    if (failed > 0) {
+      const jobNames = ['points-race', 'battle-race', 'knockout', 'transfers-post', 'cup-results'];
+      const failures = results
+        .map((result, index) => ({ result, jobName: jobNames[index] }))
+        .filter(({ result }) => result.status === 'rejected')
+        .map(({ result, jobName }) => ({
+          jobName,
+          reason: result.status === 'rejected' ? result.reason : null,
+        }));
+      failures.forEach(({ jobName, reason }) => {
+        logError('Failed to enqueue cascade job', reason, {
           eventId,
           cascadeId,
-          jobName: jobNames[index],
+          jobName,
         });
-      }
-    });
+      });
+      throw new Error(
+        `Tournament cascade enqueue failed for ${failed} job(s) (eventId=${eventId})`,
+      );
+    }
 
     // If a structure job failed to enqueue, the barrier would never reach 0.
     // Claim a stable enqueue-failed slot per job so a partial cascade still refreshes.
@@ -302,6 +307,9 @@ export function createTournamentSyncWorker(): WorkerRuntime {
         eventId: job?.data.eventId,
         tier,
       });
+      if (job) {
+        void alertOnFinalFailure(job, err);
+      }
     });
 
     worker.on('error', (err) => {

--- a/tests/integration/live-data-jobs.test.ts
+++ b/tests/integration/live-data-jobs.test.ts
@@ -25,8 +25,8 @@ describe('Live Data Jobs Integration', () => {
   describe('Job Enqueueing', () => {
     it('should enqueue event lives cache update job', async () => {
       const job = await enqueueEventLivesCacheUpdate(TEST_EVENT_ID, 'manual');
+      if (!job) throw new Error('Expected job to be enqueued');
 
-      expect(job).toBeDefined();
       expect(job.id).toBeDefined();
       expect(job.name).toBe('event-lives-cache');
       expect(job.data).toMatchObject({
@@ -37,8 +37,8 @@ describe('Live Data Jobs Integration', () => {
 
     it('should enqueue event lives DB sync job', async () => {
       const job = await enqueueEventLivesDbSync(TEST_EVENT_ID, 'manual');
+      if (!job) throw new Error('Expected job to be enqueued');
 
-      expect(job).toBeDefined();
       expect(job.id).toBeDefined();
       expect(job.name).toBe('event-lives-db');
       expect(job.data).toMatchObject({
@@ -49,8 +49,8 @@ describe('Live Data Jobs Integration', () => {
 
     it('should enqueue event live summary job', async () => {
       const job = await enqueueEventLiveSummary(TEST_EVENT_ID, 'cascade');
+      if (!job) throw new Error('Expected job to be enqueued');
 
-      expect(job).toBeDefined();
       expect(job.id).toBeDefined();
       expect(job.name).toBe('event-live-summary');
       expect(job.data).toMatchObject({
@@ -61,8 +61,8 @@ describe('Live Data Jobs Integration', () => {
 
     it('should enqueue event live explain job', async () => {
       const job = await enqueueEventLiveExplain(TEST_EVENT_ID, 'cascade');
+      if (!job) throw new Error('Expected job to be enqueued');
 
-      expect(job).toBeDefined();
       expect(job.id).toBeDefined();
       expect(job.name).toBe('event-live-explain');
       expect(job.data).toMatchObject({
@@ -73,8 +73,8 @@ describe('Live Data Jobs Integration', () => {
 
     it('should enqueue event overall result job', async () => {
       const job = await enqueueEventOverallResult(TEST_EVENT_ID, 'cascade');
+      if (!job) throw new Error('Expected job to be enqueued');
 
-      expect(job).toBeDefined();
       expect(job.id).toBeDefined();
       expect(job.name).toBe('event-overall-result');
       expect(job.data).toMatchObject({
@@ -89,6 +89,7 @@ describe('Live Data Jobs Integration', () => {
       const job1 = await enqueueEventLivesCacheUpdate(TEST_EVENT_ID, 'cron');
       const job2 = await enqueueEventLivesCacheUpdate(TEST_EVENT_ID, 'cron');
 
+      if (!job1 || !job2) throw new Error('Expected both jobs to be enqueued');
       expect(job1.id).not.toBe(job2.id);
       expect(job1.id).toContain('event-lives-cache');
       expect(job2.id).toContain('event-lives-cache');
@@ -98,6 +99,7 @@ describe('Live Data Jobs Integration', () => {
   describe('Job Queue Validation', () => {
     it('should have correct default job options', async () => {
       const job = await enqueueEventLivesCacheUpdate(TEST_EVENT_ID, 'manual');
+      if (!job) throw new Error('Expected job to be enqueued');
 
       expect(job.opts.attempts).toBe(3);
       expect(job.opts.backoff).toMatchObject({
@@ -110,6 +112,7 @@ describe('Live Data Jobs Integration', () => {
       const beforeEnqueue = new Date().toISOString();
       const job = await enqueueEventLivesCacheUpdate(TEST_EVENT_ID, 'manual');
       const afterEnqueue = new Date().toISOString();
+      if (!job) throw new Error('Expected job to be enqueued');
 
       expect(job.data.triggeredAt).toBeDefined();
       expect(job.data.triggeredAt >= beforeEnqueue).toBe(true);
@@ -126,8 +129,9 @@ describe('Live Data Jobs Integration', () => {
         enqueueEventLivesCacheUpdate(TEST_EVENT_ID, 'manual'),
         enqueueEventLivesDbSync(TEST_EVENT_ID, 'manual'),
       ]);
+      if (jobs.some((job) => !job)) throw new Error('Expected all jobs to be enqueued');
 
-      const states = await Promise.all(jobs.map((job) => job.getState()));
+      const states = await Promise.all(jobs.map((job) => job!.getState()));
       expect(states).toHaveLength(2);
       states.forEach((state) => {
         expect(['waiting', 'delayed', 'active', 'completed']).toContain(state);

--- a/tests/integration/workers/live-data.worker.test.ts
+++ b/tests/integration/workers/live-data.worker.test.ts
@@ -74,6 +74,7 @@ describe('Live Data Worker Integration Tests', () => {
       'should process event lives cache update',
       async () => {
         const job = await enqueueEventLivesCacheUpdate(testEventId);
+        if (!job) throw new Error('Expected job to be enqueued');
 
         await expectJobCompleted(job, 60000);
       },
@@ -84,6 +85,7 @@ describe('Live Data Worker Integration Tests', () => {
       'should process event lives DB sync',
       async () => {
         const job = await enqueueEventLivesDbSync(testEventId);
+        if (!job) throw new Error('Expected job to be enqueued');
 
         await expectJobCompleted(job, 60000);
       },
@@ -99,6 +101,7 @@ describe('Live Data Worker Integration Tests', () => {
         await enqueueEventLivesDbSync(testEventId);
 
         const job = await enqueueEventLiveSummary(testEventId);
+        if (!job) throw new Error('Expected job to be enqueued');
 
         await expectJobCompleted(job, 60000);
       },
@@ -109,6 +112,7 @@ describe('Live Data Worker Integration Tests', () => {
       'should process event live explain',
       async () => {
         const job = await enqueueEventLiveExplain(testEventId);
+        if (!job) throw new Error('Expected job to be enqueued');
 
         await expectJobCompleted(job, 60000);
       },
@@ -121,6 +125,7 @@ describe('Live Data Worker Integration Tests', () => {
       'should process event overall result',
       async () => {
         const job = await enqueueEventOverallResult(testEventId);
+        if (!job) throw new Error('Expected job to be enqueued');
 
         await expectJobCompleted(job, 60000);
       },
@@ -137,8 +142,9 @@ describe('Live Data Worker Integration Tests', () => {
           enqueueEventLiveExplain(testEventId),
           enqueueEventOverallResult(testEventId),
         ]);
+        if (jobs.some((job) => !job)) throw new Error('Expected all jobs to be enqueued');
 
-        await Promise.all(jobs.map((job) => expectJobCompleted(job, 60000)));
+        await Promise.all(jobs.map((job) => expectJobCompleted(job!, 60000)));
       },
       { timeout: 180000 },
     );
@@ -149,6 +155,7 @@ describe('Live Data Worker Integration Tests', () => {
       const job1 = await enqueueEventLivesCacheUpdate(testEventId);
       const job2 = await enqueueEventLivesCacheUpdate(testEventId);
 
+      if (!job1 || !job2) throw new Error('Expected both jobs to be enqueued');
       // Should have different IDs due to timestamp
       expect(job1.id).not.toBe(job2.id);
     });

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -41,13 +41,26 @@ mock.module('../../src/jobs/data-sync-enqueue', () => ({
   enqueuePlayerStatsSyncJob,
 }));
 
-const enqueueEntryPicksSyncJob = mock(async () => ({ id: 'picks-job-1' }));
-const enqueueEntryTransfersSyncJob = mock(async () => ({ id: 'transfers-job-1' }));
-const enqueueEntryResultsSyncJob = mock(async () => ({ id: 'results-job-1' }));
-mock.module('../../src/jobs/entry-sync-enqueue', () => ({
-  enqueueEntryPicksSyncJob,
-  enqueueEntryTransfersSyncJob,
-  enqueueEntryResultsSyncJob,
+// Mock the entry-sync queue (not entry-sync-enqueue) so real enqueue helpers run.
+// mock.module of entry-sync-enqueue pollutes entry-sync-enqueue.test.ts /
+// manual-job-ids.test.ts when Bun shares the mock registry across files.
+type EntrySyncAddCall = {
+  name: string;
+  data: Record<string, unknown>;
+  opts: Record<string, unknown>;
+};
+const entrySyncAddCalls: EntrySyncAddCall[] = [];
+mock.module('../../src/queues/entry-sync.queue', () => ({
+  ENTRY_SYNC_DEFAULT_CHUNK_SIZE: 100,
+  ENTRY_SYNC_DEFAULT_CONCURRENCY: 5,
+  ENTRY_SYNC_DEFAULT_THROTTLE_MS: 150,
+  getEntrySyncQueue: () => ({
+    name: 'entry-sync-p2',
+    add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
+      entrySyncAddCalls.push({ name, data, opts });
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+    },
+  }),
 }));
 
 // Mock the live-data queue (not live-data.jobs) so real enqueue helpers run and
@@ -184,9 +197,7 @@ describe('jobsAPI handlers', () => {
 
 describe('entrySyncAPI handlers', () => {
   beforeEach(() => {
-    enqueueEntryPicksSyncJob.mockClear();
-    enqueueEntryTransfersSyncJob.mockClear();
-    enqueueEntryResultsSyncJob.mockClear();
+    entrySyncAddCalls.length = 0;
   });
 
   test('POST /entry-sync/picks enqueues an entry-list job and returns 202', async () => {
@@ -200,8 +211,11 @@ describe('entrySyncAPI handlers', () => {
     expect(response.status).toBe(202);
     const body = (await response.json()) as { success: boolean; jobId: string };
     expect(body.success).toBe(true);
-    expect(body.jobId).toBe('picks-job-1');
-    expect(enqueueEntryPicksSyncJob).toHaveBeenCalledWith('api', {
+    expect(body.jobId).toMatch(/^entry-picks-entry-list-/);
+    expect(entrySyncAddCalls).toHaveLength(1);
+    expect(entrySyncAddCalls[0].name).toBe('entry-picks');
+    expect(entrySyncAddCalls[0].data).toMatchObject({
+      source: 'api',
       entryIds: [1, 2],
       eventId: 20,
     });
@@ -221,15 +235,17 @@ describe('entrySyncAPI handlers', () => {
       jobIds: { picks: string; transfers: string; results: string };
     };
     expect(body.success).toBe(true);
-    expect(body.jobIds).toEqual({
-      picks: 'picks-job-1',
-      transfers: 'transfers-job-1',
-      results: 'results-job-1',
-    });
-    expect(enqueueEntryPicksSyncJob).toHaveBeenCalledWith('api', {
-      entryIds: [7],
-      eventId: undefined,
-    });
+    expect(body.jobIds.picks).toMatch(/^entry-picks-entry-list-/);
+    expect(body.jobIds.transfers).toMatch(/^entry-transfers-entry-list-/);
+    expect(body.jobIds.results).toMatch(/^entry-results-entry-list-/);
+    expect(entrySyncAddCalls.map((c) => c.name).sort()).toEqual([
+      'entry-picks',
+      'entry-results',
+      'entry-transfers',
+    ]);
+    for (const call of entrySyncAddCalls) {
+      expect(call.data).toMatchObject({ source: 'api', entryIds: [7] });
+    }
   });
 
   test('rejects entryIds arrays larger than 100', async () => {
@@ -241,7 +257,7 @@ describe('entrySyncAPI handlers', () => {
       }),
     );
     expect(response.status).toBe(422);
-    expect(enqueueEntryPicksSyncJob).not.toHaveBeenCalled();
+    expect(entrySyncAddCalls).toHaveLength(0);
   });
 });
 

--- a/tests/unit/entry-sync-enqueue.test.ts
+++ b/tests/unit/entry-sync-enqueue.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type AddCall = { name: string; data: Record<string, unknown>; opts: Record<string, unknown> };
+
+const addCalls: AddCall[] = [];
+
+mock.module('../../src/queues/entry-sync.queue', () => ({
+  ENTRY_SYNC_DEFAULT_CHUNK_SIZE: 100,
+  ENTRY_SYNC_DEFAULT_CONCURRENCY: 5,
+  ENTRY_SYNC_DEFAULT_THROTTLE_MS: 150,
+  getEntrySyncQueue: () => ({
+    name: 'entry-sync-p2',
+    add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
+      addCalls.push({ name, data, opts });
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+    },
+  }),
+}));
+
+const { enqueueEntryPicksSyncJob } = await import('../../src/jobs/entry-sync-enqueue');
+
+describe('entry-sync enqueue runId propagation', () => {
+  beforeEach(() => {
+    addCalls.length = 0;
+  });
+
+  test('uses provided runId in chunk job ID', async () => {
+    const job = await enqueueEntryPicksSyncJob('cron', {
+      chunkOffset: 0,
+      runId: 'chain-xyz',
+    });
+
+    expect(job).not.toBeNull();
+    expect(job!.id).toBe('entry-picks-chain-xyz-chunk-0');
+    expect(addCalls[0].data.runId).toBe('chain-xyz');
+  });
+
+  test('propagates runId with event-scoped chunk key', async () => {
+    const job = await enqueueEntryPicksSyncJob('cron', {
+      chunkOffset: 100,
+      eventId: 20,
+      runId: 'chain-abc',
+    });
+
+    expect(job).not.toBeNull();
+    expect(job!.id).toBe('entry-picks-chain-abc-chunk-100-event-20');
+  });
+});

--- a/tests/unit/live-data-jobs.test.ts
+++ b/tests/unit/live-data-jobs.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type AddCall = { name: string; data: Record<string, unknown>; opts: Record<string, unknown> };
+
+const addCalls: AddCall[] = [];
+const waitingJobs: Array<{ name: string; data: { eventId: number } }> = [];
+
+mock.module('../../src/queues/live-data.queue', () => ({
+  LIVE_JOBS: {
+    EVENT_LIVES_CACHE: 'event-lives-cache',
+    EVENT_LIVES_DB: 'event-lives-db',
+    EVENT_LIVE_SUMMARY: 'event-live-summary',
+    EVENT_LIVE_EXPLAIN: 'event-live-explain',
+    LIVE_FIXTURE_CACHE: 'live-fixture-cache',
+    LIVE_BONUS_CACHE: 'live-bonus-cache',
+    EVENT_OVERALL_RESULT: 'event-overall-result',
+    LIVE_SCORES: 'live-scores',
+  },
+  getLiveDataQueue: () => ({
+    name: 'live-data-p3',
+    add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
+      addCalls.push({ name, data, opts });
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+    },
+    getJobs: async () => waitingJobs,
+  }),
+}));
+
+mock.module('../../src/domain/job-priority', () => ({
+  getLiveDataJobPriority: () => 'p3',
+}));
+
+const { enqueueEventLivesCacheUpdate, enqueueEventLivesDbSync } = await import(
+  '../../src/jobs/live-data.jobs'
+);
+
+describe('live-data cron duplicate suppression', () => {
+  beforeEach(() => {
+    addCalls.length = 0;
+    waitingJobs.length = 0;
+  });
+
+  test('cron source skips enqueue when an identical job is already waiting', async () => {
+    waitingJobs.push({ name: 'event-lives-db', data: { eventId: 12 } });
+
+    const job = await enqueueEventLivesDbSync(12, 'cron');
+    expect(job).toBeNull();
+    expect(addCalls).toHaveLength(0);
+  });
+
+  test('manual source always enqueues even when a waiting job exists', async () => {
+    waitingJobs.push({ name: 'event-lives-cache', data: { eventId: 12 } });
+
+    const job = await enqueueEventLivesCacheUpdate(12, 'manual');
+    expect(job).not.toBeNull();
+    expect(addCalls).toHaveLength(1);
+  });
+});

--- a/tests/unit/manual-job-ids.test.ts
+++ b/tests/unit/manual-job-ids.test.ts
@@ -53,8 +53,10 @@ describe('live-data manual job IDs', () => {
     const first = await enqueueEventLivesDbSync(10, 'manual');
     const second = await enqueueEventLivesDbSync(10, 'manual');
 
-    expect(first.id).toBe('event-lives-db-e10-manual');
-    expect(second.id).toBe('event-lives-db-e10-manual');
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first!.id).toBe('event-lives-db-e10-manual');
+    expect(second!.id).toBe('event-lives-db-e10-manual');
     // Repeat trigger hits BullMQ's jobId dedup instead of queueing duplicate work
     expect(liveDataAddCalls[1].opts.jobId).toBe('event-lives-db-e10-manual');
   });
@@ -73,18 +75,22 @@ describe('live-data manual job IDs', () => {
     const cacheUpdate = await enqueueEventLivesCacheUpdate(10, 'manual');
     const otherEvent = await enqueueEventLivesDbSync(11, 'manual');
 
-    expect(dbSync.id).toBe('event-lives-db-e10-manual');
-    expect(cacheUpdate.id).toBe('event-lives-cache-e10-manual');
-    expect(otherEvent.id).toBe('event-lives-db-e11-manual');
+    expect(dbSync).not.toBeNull();
+    expect(cacheUpdate).not.toBeNull();
+    expect(otherEvent).not.toBeNull();
+    expect(dbSync!.id).toBe('event-lives-db-e10-manual');
+    expect(cacheUpdate!.id).toBe('event-lives-cache-e10-manual');
+    expect(otherEvent!.id).toBe('event-lives-db-e11-manual');
   });
 
   test('cron runs keep time-based IDs so every tick enqueues', async () => {
     const job = await enqueueEventLivesDbSync(10, 'cron');
 
+    expect(job).not.toBeNull();
     // Time-based suffix (not the deterministic manual ID) — cron ticks are seconds
     // apart in practice, so each cycle gets its own job instead of deduping.
-    expect(job.id).toMatch(/^event-lives-db-e10-\d+$/);
-    expect(job.id).not.toBe('event-lives-db-e10-manual');
+    expect(job!.id).toMatch(/^event-lives-db-e10-\d+$/);
+    expect(job!.id).not.toBe('event-lives-db-e10-manual');
     // Cron jobs keep queue-level retention (no per-job cleanup override)
     expect(liveDataAddCalls[0].opts.removeOnComplete).toBeUndefined();
   });
@@ -99,9 +105,11 @@ describe('entry-sync entry-list job IDs', () => {
     const first = await enqueueEntryPicksSyncJob('api', { entryIds: [3, 1, 2], eventId: 20 });
     const second = await enqueueEntryPicksSyncJob('api', { entryIds: [1, 2, 3], eventId: 20 });
 
-    expect(first.id).toMatch(/^entry-picks-entry-list-[0-9a-f]{8}$/);
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first!.id).toMatch(/^entry-picks-entry-list-[0-9a-f]{8}$/);
     // Same entries in any order dedupe to the same job
-    expect(second.id).toBe(first.id as string);
+    expect(second!.id).toBe(first!.id as string);
     // Entry-list jobs clean up on settle so repeat API calls after completion re-run
     expect(entrySyncAddCalls[0].opts.removeOnComplete).toBe(true);
     expect(entrySyncAddCalls[0].opts.removeOnFail).toBe(true);
@@ -113,9 +121,13 @@ describe('entry-sync entry-list job IDs', () => {
     const otherEvent = await enqueueEntryPicksSyncJob('api', { entryIds: [1, 2], eventId: 21 });
     const noEvent = await enqueueEntryPicksSyncJob('api', { entryIds: [1, 2] });
 
-    expect(otherIds.id).not.toBe(base.id as string);
-    expect(otherEvent.id).not.toBe(base.id as string);
-    expect(noEvent.id).not.toBe(base.id as string);
+    expect(base).not.toBeNull();
+    expect(otherIds).not.toBeNull();
+    expect(otherEvent).not.toBeNull();
+    expect(noEvent).not.toBeNull();
+    expect(otherIds!.id).not.toBe(base!.id as string);
+    expect(otherEvent!.id).not.toBe(base!.id as string);
+    expect(noEvent!.id).not.toBe(base!.id as string);
   });
 
   test('retryCount distinguishes delayed full-batch retries from the active job', async () => {
@@ -129,22 +141,27 @@ describe('entry-sync entry-list job IDs', () => {
       retryCount: 1,
     });
 
-    expect(retry.id).not.toBe(original.id as string);
-    expect(retry.id).toMatch(/^entry-picks-entry-list-[0-9a-f]{8}$/);
+    expect(original).not.toBeNull();
+    expect(retry).not.toBeNull();
+    expect(retry!.id).not.toBe(original!.id as string);
+    expect(retry!.id).toMatch(/^entry-picks-entry-list-[0-9a-f]{8}$/);
   });
 
   test('cron chunk jobs keep time-based per-cycle IDs', async () => {
     const job = await enqueueEntryPicksSyncJob('cron', { chunkOffset: 0 });
 
-    expect(job.id).toMatch(/^entry-picks-chunk-0-\d+$/);
+    expect(job).not.toBeNull();
+    expect(job!.id).toMatch(/^entry-picks-\d+-chunk-0$/);
   });
 
   test('manual table-scan chunk jobs get a deterministic ID with settle cleanup', async () => {
     const first = await enqueueEntryPicksSyncJob('manual', { chunkOffset: 0 });
     const second = await enqueueEntryPicksSyncJob('manual', { chunkOffset: 0 });
 
-    expect(first.id).toBe('entry-picks-chunk-0-manual');
-    expect(second.id).toBe(first.id as string);
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first!.id).toBe('entry-picks-manual-chunk-0');
+    expect(second!.id).toBe(first!.id as string);
     expect(entrySyncAddCalls[0].opts.removeOnComplete).toBe(true);
     expect(entrySyncAddCalls[0].opts.removeOnFail).toBe(true);
   });

--- a/tests/unit/mutation-scope.test.ts
+++ b/tests/unit/mutation-scope.test.ts
@@ -24,7 +24,7 @@ describe('resolveMutationScopes', () => {
       eventId: 33,
       tournamentId: 1001,
     });
-    expect(scopes).toContain('entry-event:event:33');
+    expect(scopes).toContain('entry-event-results:event:33');
     expect(scopes).toContain('league-event-results:event:33');
     expect(scopes).toContain('league-event-results:tournament:1001');
   });
@@ -56,8 +56,7 @@ describe('resolveMutationScopes', () => {
       jobName: 'tournament-selection-stats',
       eventId: 35,
     });
-    expect(scopes).toContain('entry-event:event:35');
-    expect(scopes).toContain('tournament-event-mutations:event:35');
+    expect(scopes).toEqual(['tournament-event-mutations:event:35']);
   });
 
   it.each(['tournament-points-race', 'tournament-battle-race', 'tournament-knockout'])(
@@ -72,6 +71,18 @@ describe('resolveMutationScopes', () => {
       expect(scopes).toContain('tournament-structure:event:33');
     },
   );
+
+  it('narrows tournament event results to per-table entry scopes (FP-14h)', () => {
+    const scopes = resolveMutationScopes({
+      queueName: 'tournament-sync-p2',
+      jobName: 'tournament-event-results',
+      eventId: 35,
+    });
+    expect(scopes).toContain('entry-event-picks:event:35');
+    expect(scopes).toContain('entry-event-transfers:event:35');
+    expect(scopes).toContain('entry-event-results:event:35');
+    expect(scopes).toContain('tournament-event-results:event:35');
+  });
 
   it('keeps cup-results off the global structure lock (FP-07 Codex P2)', () => {
     const scopes = resolveMutationScopes({


### PR DESCRIPTION
Implements the FP-14 job-safety pack on top of current main.

Changes:
- `entry-event-results-daily` cron guards: `isFPLSeason` + current-event checks
- Tournament-setup watchdog skips recovery when an active setup job is running
- `errors > 0` now throws in tournament-event-picks, transfers (pre+post), and tournament-info
- `alertOnFinalFailure` wired into every worker `failed` handler
- Live-data: window re-check inside worker; cron enqueue skips duplicates in the waiting room
- Deterministic entry-sync chunk job IDs via propagated `runId`
- Cascade fan-outs throw when any child enqueue fails (tournament, live-data, league)
- Per-table mutation scopes: `entry-event-picks|transfers|results:event:N`

Gates: `bun run tsc`, `bun run lint` (warnings only), `bun test tests/unit` (414 pass), `bun run build` all green.