### PR TITLE
FP-22 · Config & logging hygiene

### DIFF
--- a/src/queues/tiered-queue.ts
+++ b/src/queues/tiered-queue.ts
@@ -2,25 +2,11 @@ import { Queue, type JobsOptions } from 'bullmq';
 
 import type { MutationPriorityTier } from '../domain/job-priority';
 import { MUTATION_PRIORITY_ORDER } from '../domain/job-priority';
+import { getConfig } from '../utils/config';
 import { getQueueConnection } from '../utils/queue';
 
-function parseBoolean(value: string | undefined, fallback: boolean): boolean {
-  if (!value) {
-    return fallback;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
-    return true;
-  }
-  if (['0', 'false', 'no', 'off'].includes(normalized)) {
-    return false;
-  }
-  return fallback;
-}
-
 export function isTieredMutationQueueEnabled(): boolean {
-  return parseBoolean(process.env.ENABLE_TIERED_MUTATION_QUEUES, false);
+  return getConfig().ENABLE_TIERED_MUTATION_QUEUES;
 }
 
 type TieredQueueSet<T> = {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,25 @@
 import { z } from 'zod';
 import { logError, logInfo, logWarn } from './logger';
 
+function booleanEnv(defaultValue: boolean) {
+  return z
+    .union([z.boolean(), z.string()])
+    .optional()
+    .transform((value) => {
+      if (value === undefined) {
+        return defaultValue;
+      }
+      if (typeof value === 'boolean') {
+        return value;
+      }
+      return ['true', '1', 'yes', 'on'].includes(value.toLowerCase());
+    });
+}
+
+function integerEnv(defaultValue: number) {
+  return z.coerce.number().int().default(defaultValue);
+}
+
 const EnvSchema = z.object({
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
   // Redis
@@ -21,23 +40,19 @@ const EnvSchema = z.object({
     .optional()
     .default('info'),
   // Auth (Better Auth + API keys)
-  ENABLE_AUTH: z
-    .union([z.boolean(), z.string()])
-    .optional()
-    .transform((value) => {
-      if (value === undefined) {
-        return process.env.NODE_ENV === 'production';
-      }
-      if (typeof value === 'boolean') {
-        return value;
-      }
-      return value === 'true' || value === '1';
-    }),
+  ENABLE_AUTH: booleanEnv(process.env.NODE_ENV === 'production'),
   BETTER_AUTH_SECRET: z.string().optional(),
   BETTER_AUTH_URL: z.string().url().optional(),
   CORS_ORIGINS: z.string().optional(),
   // HTTP mutation rate limit (fixed window per client IP; 0 disables)
   RATE_LIMIT_MUTATIONS_PER_MINUTE: z.coerce.number().int().min(0).default(60),
+  // Mutation conflict guard + tiered mutation queues (feature flags)
+  ENABLE_TIERED_MUTATION_QUEUES: booleanEnv(false),
+  ENABLE_MUTATION_CONFLICT_GUARD: booleanEnv(true),
+  MUTATION_LOCK_TTL_MS: integerEnv(30_000),
+  MUTATION_LOCK_WAIT_TIMEOUT_MS: integerEnv(120_000),
+  MUTATION_LOCK_RETRY_DELAY_MS: integerEnv(250),
+  MUTATION_LOCK_HEARTBEAT_MS: integerEnv(10_000),
   // Optional Supabase hints (DB provider)
   SUPABASE_URL: z.string().optional(),
   SUPABASE_KEY: z.string().optional(),

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -91,14 +91,7 @@ const loggerOptions: pino.LoggerOptions = {
   },
   timestamp: () => `,"time":"${formatUtc8Timestamp()}"`,
   redact: {
-    paths: [
-      '*.token',
-      '*.secret',
-      '*.password',
-      '*.key',
-      '*.apiKey',
-      'req.headers["x-api-key"]',
-    ],
+    paths: ['*.token', '*.secret', '*.password', '*.key', '*.apiKey', 'req.headers["x-api-key"]'],
     censor: '[REDACTED]',
   },
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -90,6 +90,17 @@ const loggerOptions: pino.LoggerOptions = {
     },
   },
   timestamp: () => `,"time":"${formatUtc8Timestamp()}"`,
+  redact: {
+    paths: [
+      '*.token',
+      '*.secret',
+      '*.password',
+      '*.key',
+      '*.apiKey',
+      'req.headers["x-api-key"]',
+    ],
+    censor: '[REDACTED]',
+  },
 };
 
 export const logger = isDevelopment

--- a/src/utils/mutation-lock.ts
+++ b/src/utils/mutation-lock.ts
@@ -1,15 +1,16 @@
 import Redis from 'ioredis';
 
 import { resolveMutationScopes } from '../domain/mutation-scope';
+import { getConfig } from './config';
 import { logError, logInfo, logWarn } from './logger';
 import { getQueueConnection } from './queue';
 
-const DEFAULT_LOCK_TTL_MS = Number(process.env.MUTATION_LOCK_TTL_MS ?? 30_000);
-const DEFAULT_WAIT_TIMEOUT_MS = Number(process.env.MUTATION_LOCK_WAIT_TIMEOUT_MS ?? 120_000);
-const DEFAULT_RETRY_DELAY_MS = Number(process.env.MUTATION_LOCK_RETRY_DELAY_MS ?? 250);
-const DEFAULT_HEARTBEAT_MS = Number(process.env.MUTATION_LOCK_HEARTBEAT_MS ?? 10_000);
-const LOCK_ENABLED =
-  (process.env.ENABLE_MUTATION_CONFLICT_GUARD ?? 'true').toLowerCase() !== 'false';
+const config = getConfig();
+const DEFAULT_LOCK_TTL_MS = config.MUTATION_LOCK_TTL_MS;
+const DEFAULT_WAIT_TIMEOUT_MS = config.MUTATION_LOCK_WAIT_TIMEOUT_MS;
+const DEFAULT_RETRY_DELAY_MS = config.MUTATION_LOCK_RETRY_DELAY_MS;
+const DEFAULT_HEARTBEAT_MS = config.MUTATION_LOCK_HEARTBEAT_MS;
+const LOCK_ENABLED = config.ENABLE_MUTATION_CONFLICT_GUARD;
 
 type MutationLockInput = {
   queueName: string;

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -24,9 +24,9 @@ export async function sendTelegramMessage(message: string): Promise<void> {
       throw new Error(`Telegram API error: ${response.status} ${response.statusText}`);
     }
 
-    logInfo('Telegram notification sent', { chatId, message });
+    logInfo('Telegram notification sent', { messageLength: message.length });
   } catch (error) {
-    logError('Failed to send Telegram notification', error, { message });
+    logError('Failed to send Telegram notification', error, { messageLength: message.length });
     throw error;
   }
 }
@@ -51,9 +51,9 @@ export async function sendTelegramBotNotification(text: string): Promise<void> {
       throw new Error(`Telegram bot notification error: ${response.status} ${response.statusText}`);
     }
 
-    logInfo('Telegram bot notification sent', { url });
+    logInfo('Telegram bot notification sent');
   } catch (error) {
-    logError('Failed to send Telegram bot notification', error, { url });
+    logError('Failed to send Telegram bot notification', error);
     throw error;
   }
 }
@@ -81,9 +81,9 @@ export async function sendWeChatBotNotification(
       throw new Error(`WeChat bot notification error: ${response.status} ${response.statusText}`);
     }
 
-    logInfo('WeChat bot notification sent', { url, targetsCount: targets.length });
+    logInfo('WeChat bot notification sent', { targetsCount: targets.length });
   } catch (error) {
-    logError('Failed to send WeChat bot notification', error, { url });
+    logError('Failed to send WeChat bot notification', error);
     throw error;
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,15 +12,14 @@ import type { WorkerRuntime } from './workers/worker-runtime';
 
 getConfig();
 
-const mutationConflictGuardEnabled =
-  (process.env.ENABLE_MUTATION_CONFLICT_GUARD ?? 'true').toLowerCase() !== 'false';
-const tieredMutationQueuesEnabled =
-  (process.env.ENABLE_TIERED_MUTATION_QUEUES ?? 'false').toLowerCase() === 'true';
+const config = getConfig();
+const mutationConflictGuardEnabled = config.ENABLE_MUTATION_CONFLICT_GUARD;
+const tieredMutationQueuesEnabled = config.ENABLE_TIERED_MUTATION_QUEUES;
 const mutationLockConfig = {
-  ttlMs: Number(process.env.MUTATION_LOCK_TTL_MS ?? 30_000),
-  waitTimeoutMs: Number(process.env.MUTATION_LOCK_WAIT_TIMEOUT_MS ?? 120_000),
-  retryDelayMs: Number(process.env.MUTATION_LOCK_RETRY_DELAY_MS ?? 250),
-  heartbeatMs: Number(process.env.MUTATION_LOCK_HEARTBEAT_MS ?? 10_000),
+  ttlMs: config.MUTATION_LOCK_TTL_MS,
+  waitTimeoutMs: config.MUTATION_LOCK_WAIT_TIMEOUT_MS,
+  retryDelayMs: config.MUTATION_LOCK_RETRY_DELAY_MS,
+  heartbeatMs: config.MUTATION_LOCK_HEARTBEAT_MS,
 };
 
 const runtimes: WorkerRuntime[] = [


### PR DESCRIPTION
Closes FP-22.

### Changes
- Move mutation feature flags and lock timing envs into Zod `EnvSchema`:
  - `ENABLE_TIERED_MUTATION_QUEUES` (default false)
  - `ENABLE_MUTATION_CONFLICT_GUARD` (default true)
  - `MUTATION_LOCK_TTL_MS`, `MUTATION_LOCK_WAIT_TIMEOUT_MS`, `MUTATION_LOCK_RETRY_DELAY_MS`, `MUTATION_LOCK_HEARTBEAT_MS`
- Replace ad-hoc `process.env` parsing in `mutation-lock.ts`, `tiered-queue.ts`, and `worker.ts` with `getConfig()` reads.
- Add shared `booleanEnv()` / `integerEnv()` helpers for consistent env coercion.
- Add pino `redact` paths for sensitive fields: `*.token`, `*.secret`, `*.password`, `*.key`, `*.apiKey`, `req.headers[\"x-api-key\"]`.
- Scrub `notify.ts`: no more webhook URLs or Telegram chat IDs in info/error logs.

### Acceptance
- `bun run typecheck` green
- `bun run lint` green (pre-existing warnings only)
- `bun run build` green
- `bun test tests/unit` 409/409 pass