### PR TITLE
FP-23 · Job-system leftovers

### DIFF
--- a/src/jobs/data-sync.jobs.ts
+++ b/src/jobs/data-sync.jobs.ts
@@ -12,6 +12,7 @@ import {
 import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 async function shouldRunSeasonDataSync(jobName: string) {
   const now = new Date();
@@ -38,6 +39,7 @@ export function registerDataSyncJobs(app: Elysia) {
       cron({
         name: 'events-sync',
         pattern: '35 6 * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('events-sync', async () => {
@@ -54,6 +56,7 @@ export function registerDataSyncJobs(app: Elysia) {
       cron({
         name: 'teams-sync',
         pattern: '37 6 * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('teams-sync', async () => {
@@ -70,6 +73,7 @@ export function registerDataSyncJobs(app: Elysia) {
       cron({
         name: 'fixtures-sync',
         pattern: '40 6 * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('fixtures-sync', async () => {
@@ -86,6 +90,7 @@ export function registerDataSyncJobs(app: Elysia) {
       cron({
         name: 'players-sync',
         pattern: '43 6 * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('players-sync', async () => {
@@ -102,6 +107,7 @@ export function registerDataSyncJobs(app: Elysia) {
       cron({
         name: 'player-stats-sync',
         pattern: '40 9 * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('player-stats-sync', async () => {
@@ -121,6 +127,7 @@ export function registerDataSyncJobs(app: Elysia) {
       cron({
         name: 'phases-sync',
         pattern: '45 6 * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('phases-sync', async () => {

--- a/src/jobs/entry-info.jobs.ts
+++ b/src/jobs/entry-info.jobs.ts
@@ -6,12 +6,14 @@ import { getEntryInfoSyncDateKey, hasEntryInfoSyncedToday } from './entry-info-s
 import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 export function registerEntryInfoJobs(app: Elysia) {
   return app.use(
     cron({
       name: 'entry-info-daily',
       pattern: '30 10 * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('entry-info-daily', async () => {

--- a/src/jobs/entry-picks.jobs.ts
+++ b/src/jobs/entry-picks.jobs.ts
@@ -7,6 +7,7 @@ import { isFPLSeason, isSelectTime } from '../utils/conditions';
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * Entry Event Picks Cron Jobs
@@ -19,6 +20,7 @@ export function registerEntryPicksJobs(app: Elysia) {
     cron({
       name: 'entry-event-picks-daily',
       pattern: '35 10 * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('entry-event-picks-daily', async () => {

--- a/src/jobs/entry-results.jobs.ts
+++ b/src/jobs/entry-results.jobs.ts
@@ -6,6 +6,7 @@ import { executeTrackedCron } from '../utils/job-run-logger';
 import { isFPLSeason } from '../utils/conditions';
 import { getCurrentEvent } from '../services/events.service';
 import { logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * Entry Event Results Cron Jobs
@@ -17,6 +18,7 @@ export function registerEntryResultsJobs(app: Elysia) {
     cron({
       name: 'entry-event-results-daily',
       pattern: '45 10 * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('entry-event-results-daily', async () => {

--- a/src/jobs/entry-transfers.jobs.ts
+++ b/src/jobs/entry-transfers.jobs.ts
@@ -7,6 +7,7 @@ import { isAfterMatchDay, isFPLSeason } from '../utils/conditions';
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * Entry Event Transfers Cron Jobs
@@ -18,6 +19,7 @@ export function registerEntryTransfersJobs(app: Elysia) {
     cron({
       name: 'entry-event-transfers-daily',
       pattern: '40 10 * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('entry-event-transfers-daily', async () => {

--- a/src/jobs/event-current-refresh.job.ts
+++ b/src/jobs/event-current-refresh.job.ts
@@ -6,6 +6,7 @@ import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logInfo } from '../utils/logger';
 import { enqueueEventsSyncJob } from './data-sync-enqueue';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 export type ManualEventCurrentRefreshResult = {
   refreshed: boolean;
@@ -59,6 +60,7 @@ export function registerEventCurrentRefreshJobs(app: Elysia) {
     cron({
       name: 'event-current-refresh',
       pattern: '* * * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('event-current-refresh', runEventCurrentRefresh);

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -7,6 +7,7 @@ import { fplClient } from '../clients/fpl';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { sendTelegramMessage } from '../utils/notify';
 import { logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * Launch Monitor Jobs
@@ -70,6 +71,7 @@ export function registerLaunchJobs(app: Elysia) {
       cron({
         name: 'launch-warning',
         pattern: '* * * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('launch-warning', runLaunchWarning);
@@ -83,6 +85,7 @@ export function registerLaunchJobs(app: Elysia) {
       cron({
         name: 'launch-happening',
         pattern: '* * * * *',
+        timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('launch-happening', runLaunchHappening);

--- a/src/jobs/league-event-picks.jobs.ts
+++ b/src/jobs/league-event-picks.jobs.ts
@@ -7,6 +7,7 @@ import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
 import { enqueueLeagueEventPicks } from './league-sync.jobs';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * League Event Picks Sync Trigger
@@ -53,6 +54,7 @@ export function registerLeagueEventPicksJobs(app: Elysia) {
     cron({
       name: 'league-event-picks-trigger',
       pattern: '*/5 * * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('league-event-picks-sync', runLeagueEventPicksSync);

--- a/src/jobs/league-event-results.jobs.ts
+++ b/src/jobs/league-event-results.jobs.ts
@@ -8,6 +8,7 @@ import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
 import { enqueueLeagueEventResults } from './league-sync.jobs';
 import type { LeagueSyncJobSource } from './league-sync.jobs';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * League Event Results Sync Trigger
@@ -61,6 +62,7 @@ export function registerLeagueEventResultsJobs(app: Elysia) {
     cron({
       name: 'league-event-results-trigger',
       pattern: '*/10 * * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('league-event-results-sync', runLeagueEventResultsSync);

--- a/src/jobs/live.jobs.ts
+++ b/src/jobs/live.jobs.ts
@@ -6,6 +6,7 @@ import { isAfterMatchDay, isFPLSeason, isMatchDayTime } from '../utils/condition
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 import {
   enqueueEventLivesCacheUpdate,
   enqueueEventLivesDbSync,
@@ -148,6 +149,7 @@ export function registerLiveJobs(app: Elysia) {
         cron({
           name: 'event-lives-cache-trigger',
           pattern: '* * * * *',
+          timezone: CRON_TIMEZONE,
           async run() {
             try {
               const now = new Date();
@@ -176,6 +178,7 @@ export function registerLiveJobs(app: Elysia) {
         cron({
           name: 'event-lives-db-trigger',
           pattern: '*/10 * * * *',
+          timezone: CRON_TIMEZONE,
           async run() {
             try {
               await executeTrackedCron('event-lives-db-sync', runEventLivesDbSync);
@@ -191,6 +194,7 @@ export function registerLiveJobs(app: Elysia) {
         cron({
           name: 'live-scores',
           pattern: '* * * * *',
+          timezone: CRON_TIMEZONE,
           async run() {
             try {
               await executeTrackedCron('live-scores', runLiveScores);
@@ -208,6 +212,7 @@ export function registerLiveJobs(app: Elysia) {
         cron({
           name: 'post-match-consolidation',
           pattern: '0 6,8,10 * * *',
+          timezone: CRON_TIMEZONE,
           async run() {
             try {
               await executeTrackedCron('post-match-consolidation', runPostMatchConsolidation);

--- a/src/jobs/player-values-window.jobs.ts
+++ b/src/jobs/player-values-window.jobs.ts
@@ -6,6 +6,7 @@ import { playerValuesRepository } from '../repositories/player-values';
 import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 function getChangeDateKey(date: Date) {
   return date.toISOString().split('T')[0].replace(/-/g, '');
@@ -42,6 +43,7 @@ export function registerPlayerValuesWindowJobs(app: Elysia) {
     cron({
       name: 'player-values-sync',
       pattern: '25-35 9 * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('player-values-sync', async () => {

--- a/src/jobs/tournament-event-picks.jobs.ts
+++ b/src/jobs/tournament-event-picks.jobs.ts
@@ -7,6 +7,7 @@ import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
 import { enqueueTournamentEventPicks } from './tournament-sync.jobs';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * Tournament Event Picks Sync Trigger
@@ -52,6 +53,7 @@ export function registerTournamentEventPicksJobs(app: Elysia) {
     cron({
       name: 'tournament-event-picks-trigger',
       pattern: '*/5 * * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('tournament-event-picks-sync', runTournamentEventPicksSync);

--- a/src/jobs/tournament-event-results.jobs.ts
+++ b/src/jobs/tournament-event-results.jobs.ts
@@ -7,6 +7,7 @@ import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
 import { enqueueTournamentEventResults } from './tournament-sync.jobs';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * Tournament Event Results Sync Trigger
@@ -53,6 +54,7 @@ export function registerTournamentEventResultsJobs(app: Elysia) {
     cron({
       name: 'tournament-event-results-trigger',
       pattern: '*/10 * * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('tournament-event-results-sync', runTournamentEventResultsSync);

--- a/src/jobs/tournament-event-transfers.jobs.ts
+++ b/src/jobs/tournament-event-transfers.jobs.ts
@@ -7,6 +7,7 @@ import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
 import { enqueueTournamentTransfersPre } from './tournament-sync.jobs';
+import { CRON_TIMEZONE } from '../utils/timezone';
 
 /**
  * Tournament Event Transfers Sync Triggers
@@ -69,6 +70,7 @@ export function registerTournamentEventTransfersPreJobs(app: Elysia) {
     cron({
       name: 'tournament-event-transfers-pre-trigger',
       pattern: '*/5 * * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron(

--- a/src/jobs/tournament-info.jobs.ts
+++ b/src/jobs/tournament-info.jobs.ts
@@ -1,10 +1,11 @@
 import { cron } from '@elysiajs/cron';
 import type { Elysia } from 'elysia';
 
-import { syncTournamentInfo } from '../services/tournament-info.service';
 import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
+import { CRON_TIMEZONE } from '../utils/timezone';
+import { enqueueTournamentInfo } from './tournament-sync.jobs';
 
 export async function runTournamentInfoSync() {
   const now = new Date();
@@ -15,9 +16,9 @@ export async function runTournamentInfoSync() {
     return;
   }
 
-  logInfo('Tournament info sync started');
-  const result = await syncTournamentInfo();
-  logInfo('Tournament info sync completed', result);
+  logInfo('Enqueueing tournament info sync job');
+  const job = await enqueueTournamentInfo(0, 'cron');
+  logInfo('Tournament info sync job enqueued', { jobId: job.id });
 }
 
 export function registerTournamentInfoJobs(app: Elysia) {
@@ -25,6 +26,7 @@ export function registerTournamentInfoJobs(app: Elysia) {
     cron({
       name: 'tournament-info-sync',
       pattern: '45 10 * * *',
+      timezone: CRON_TIMEZONE,
       async run() {
         try {
           await executeTrackedCron('tournament-info-sync', runTournamentInfoSync);

--- a/src/utils/conditions.ts
+++ b/src/utils/conditions.ts
@@ -19,6 +19,7 @@ type SeasonWindow = {
 };
 
 let cachedSeasonWindow: SeasonWindow | null = null;
+let cachedSeasonWindowNullAtMs: number | null = null;
 
 function toUtcDayStartMs(date: Date): number {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0);
@@ -42,6 +43,13 @@ async function loadSeasonWindow(now: Date): Promise<SeasonWindow | null> {
     return cachedSeasonWindow;
   }
 
+  if (
+    cachedSeasonWindowNullAtMs !== null &&
+    now.getTime() - cachedSeasonWindowNullAtMs < SEASON_WINDOW_CACHE_TTL_MS
+  ) {
+    return null;
+  }
+
   const [gw1Fixtures, gw38Fixtures] = await Promise.all([
     fixtureRepository.findByEvent(1),
     fixtureRepository.findByEvent(38),
@@ -49,6 +57,7 @@ async function loadSeasonWindow(now: Date): Promise<SeasonWindow | null> {
   const gw1Kickoffs = extractKickoffs(gw1Fixtures);
   const gw38Kickoffs = extractKickoffs(gw38Fixtures);
   if (gw1Kickoffs.length === 0 || gw38Kickoffs.length === 0) {
+    cachedSeasonWindowNullAtMs = now.getTime();
     cachedSeasonWindow = null;
     return null;
   }
@@ -64,6 +73,7 @@ async function loadSeasonWindow(now: Date): Promise<SeasonWindow | null> {
     loadedAtMs: now.getTime(),
   };
   cachedSeasonWindow = resolved;
+  cachedSeasonWindowNullAtMs = null;
   return resolved;
 }
 

--- a/src/utils/mutation-lock.ts
+++ b/src/utils/mutation-lock.ts
@@ -171,11 +171,13 @@ export async function withMutationConflictGuard<T>(
 
     return await operation();
   } catch (error) {
-    logError('Mutation conflict guard failed', error, {
+    // Don't label operation failures as guard failures; the guard held locks.
+    logInfo('Mutation conflict guard releasing locks after operation error', {
       queueName: input.queueName,
       jobName: input.jobName,
       jobId: input.jobId,
       lockKeys,
+      error: error instanceof Error ? error.message : String(error),
     });
     throw error;
   } finally {
@@ -183,13 +185,22 @@ export async function withMutationConflictGuard<T>(
       clearInterval(heartbeat);
     }
     if (acquiredKeys.length > 0) {
-      await Promise.all(acquiredKeys.map((key) => releaseLock(client, key, token)));
-      logInfo('Mutation conflict guard released locks', {
-        queueName: input.queueName,
-        jobName: input.jobName,
-        jobId: input.jobId,
-        lockKeys: acquiredKeys,
-      });
+      try {
+        await Promise.all(acquiredKeys.map((key) => releaseLock(client, key, token)));
+        logInfo('Mutation conflict guard released locks', {
+          queueName: input.queueName,
+          jobName: input.jobName,
+          jobId: input.jobId,
+          lockKeys: acquiredKeys,
+        });
+      } catch (releaseError) {
+        logError('Failed to release mutation locks (ignored)', releaseError, {
+          queueName: input.queueName,
+          jobName: input.jobName,
+          jobId: input.jobId,
+          lockKeys: acquiredKeys,
+        });
+      }
     }
   }
 }

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,3 +1,5 @@
+export const CRON_TIMEZONE = 'Asia/Shanghai';
+
 const utc8Formatter = new Intl.DateTimeFormat('en-CA', {
   timeZone: 'Asia/Shanghai',
   year: 'numeric',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,8 +6,9 @@ import { createTournamentSyncWorker } from './workers/tournament-sync.worker';
 import { createTournamentSetupWorker } from './workers/tournament-setup.worker';
 import { getConfig } from './utils/config';
 import { startQueueMonitor } from './utils/queue-monitor';
-import { logInfo } from './utils/logger';
+import { logError, logInfo } from './utils/logger';
 import { startWorkerHeartbeat } from './utils/worker-heartbeat';
+import { closeLockClient } from './utils/mutation-lock';
 import type { WorkerRuntime } from './workers/worker-runtime';
 
 getConfig();
@@ -48,15 +49,31 @@ const allQueueEvents = runtimes.flatMap((runtime) => runtime.queueEvents);
 // event loop is hung even if the process is still alive.
 const stopHeartbeat = startWorkerHeartbeat();
 
+const SHUTDOWN_TIMEOUT_MS = 30_000;
+
 async function shutdown(signal: string) {
   logInfo('Worker shutting down', { signal });
   stopHeartbeat();
   queueMonitors.forEach((monitor) => monitor.stop());
   runtimes.forEach((runtime) => runtime.stop?.());
-  await Promise.allSettled([
+
+  const closeAll = Promise.allSettled([
     ...allWorkers.map((worker) => worker.close()),
     ...allQueueEvents.map((events) => events.close()),
+    closeLockClient(),
   ]);
+
+  const timeout = new Promise<void>((_, reject) => {
+    setTimeout(() => reject(new Error('Shutdown timed out')), SHUTDOWN_TIMEOUT_MS).unref?.();
+  });
+
+  try {
+    await Promise.race([closeAll, timeout]);
+  } catch (error) {
+    logError('Worker shutdown did not complete within timeout; exiting uncleanly', error);
+    process.exit(1);
+  }
+
   process.exit(0);
 }
 

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -90,7 +90,7 @@ export function createDataSyncWorker(): WorkerRuntime {
       logInfo('Data sync job completed', { jobId: job.id, name: job.name, tier });
     });
 
-    worker.on('failed', (job, error) => {
+    worker.on('failed', async (job, error) => {
       logError('Data sync job failed', error, {
         jobId: job?.id,
         name: job?.name,
@@ -99,6 +99,16 @@ export function createDataSyncWorker(): WorkerRuntime {
       });
       if (job) {
         void alertOnFinalFailure(job, error);
+      }
+
+      // Same-day player-values ticks should not be blocked by a transient failure.
+      if (job && job.name === 'player-values' && job.attemptsMade < 3) {
+        try {
+          await job.retry();
+          logInfo('Retried failed player-values job', { jobId: job.id, attempt: job.attemptsMade });
+        } catch (retryError) {
+          logError('Failed to retry player-values job', retryError, { jobId: job.id });
+        }
       }
     });
 

--- a/src/workers/strict-priority-gate.ts
+++ b/src/workers/strict-priority-gate.ts
@@ -9,8 +9,8 @@ const DEFAULT_POLL_MS = 5_000;
 type GateWorkerSet<T> = Record<MutationPriorityTier, { queue: Queue<T>; worker: Worker<T> }>;
 
 async function getBacklogCount<T>(queue: Queue<T>): Promise<number> {
-  const counts = await queue.getJobCounts('waiting', 'active', 'delayed');
-  return (counts.waiting ?? 0) + (counts.active ?? 0) + (counts.delayed ?? 0);
+  const counts = await queue.getJobCounts('waiting', 'delayed');
+  return (counts.waiting ?? 0) + (counts.delayed ?? 0);
 }
 
 export function startStrictPriorityGate<T>(


### PR DESCRIPTION
Closes FP-23.

*Stacked on FP-22 (#25); review/merge #25 first.*

### Changes
- `tournament-info` cron now enqueues via the tournament-sync queue instead of calling `syncTournamentInfo` inline, so it gets BullMQ retries + mutation locking.
- Worker shutdown races worker/queue-event/lock-client close against a 30 s timeout and exits 1 if it does not finish cleanly.
- Strict priority gate pauses lower tiers based on `waiting + delayed` backlog only (active jobs no longer count).
- Data-sync worker retries failed `player-values` jobs up to 3 times so a transient failure doesn't block same-day ticks.
- All `cron()` registrations now carry an explicit `Asia/Shanghai` timezone.
- `isFPLSeason` caches a null season-window for the standard TTL, avoiding repeated DB hits before fixtures are loaded.
- `withMutationConflictGuard` wraps lock release in try/catch (log-only) and no longer labels operation errors as guard failures.

### Acceptance
- `bun run typecheck` green
- `bun run lint` green (pre-existing warnings only)
- `bun run build` green
- `bun test tests/unit` 409/409 pass