### PR TITLE
FP-25 · Docs & dependency hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overall
 
-Letletme_data is a robust data service that fetches data from the Fantasy Premier League (FPL) servers, cleans and transforms the data, and then stores it in PostgreSQL and Redis, providing RESTful APIs for querying data. The service is built with TypeScript using functional programming principles, ensuring type safety and maintainability.
+Letletme_data is a data service that fetches data from the Fantasy Premier League (FPL) servers, cleans and transforms it, and stores it in PostgreSQL and Redis, providing RESTful APIs for querying data. The service is built with TypeScript and Bun, using Zod for runtime validation at the FPL boundary.
 
 Key Features:
 
@@ -85,8 +85,8 @@ flowchart LR
     end
 
     subgraph Transform
-        C --> |fp-ts| C1[Data Mapping]
-        C --> |Either| C2[Error Handling]
+        C --> C1[Data Mapping]
+        C --> C2[Error Handling]
     end
 
     subgraph Storage
@@ -100,91 +100,29 @@ flowchart LR
 Core:
 
 - TypeScript (with strict type checking)
-- Node.js (v18+)
-- Bun (runtime & package manager)
+- Bun (runtime, package manager, bundler, and test runner)
 - ElysiaJS (REST API framework)
 
 Storage:
 
 - PostgreSQL (primary database)
-- Redis (caching layer, via ioredis)
+- Redis (caching layer and BullMQ queues, via ioredis)
 - Drizzle ORM (type-safe ORM)
 
 Testing & Quality:
 
-- Bun Test Runner (Jest-compatible)
+- Bun Test Runner
 - ESLint & Prettier (code quality tools)
 
 Utilities:
 
 - Pino (structured logging)
 - Zod (runtime type validation)
-- fp-ts (functional programming utilities)
 
 DevOps:
 
 - Docker (containerization)
 - Docker Compose (multi-container orchestration)
-
-# Functional Programming
-
-This project is designed using functional programming principles, making it particularly well-suited for data transformation workflows. The FP approach offers several benefits:
-
-1. Data Flow:
-
-   - Clear, unidirectional data flow
-   - Immutable data transformations
-   - Pure functions for predictable results
-   - Extensive use of fp-ts for functional patterns
-
-2. Type Safety:
-
-   - Advanced TypeScript generics
-   - No 'any' types allowed
-   - Strong type inference
-   - Runtime type validation with Zod
-
-3. Benefits:
-   - Highly testable code
-   - Easy to maintain and extend
-   - Reduced side effects
-   - Better error handling through Either and Option types
-   - Composable functions
-
-While the learning curve with TypeScript generics and FP patterns can be steep, especially coming from an OOP background, the resulting codebase is more maintainable, predictable, and elegant.
-
-# Getting Started
-
-1. Prerequisites:
-
-   ```bash
-   Node.js v18+
-   Bun v1+
-   Docker & Docker Compose
-   PostgreSQL
-   Redis
-   ```
-
-2. Installation:
-
-   ```bash
-   git clone [repository-url]
-   cd letletme_data
-   bun install
-   ```
-
-3. Configuration:
-
-   ```bash
-   cp .env.example .env
-   # Edit .env with your settings
-   ```
-
-4. Run:
-   ```bash
-   docker-compose up -d
-   bun run dev
-   ```
 
 # Domain-Driven Design
 
@@ -216,15 +154,25 @@ graph TB
     Scout --> Live
 ```
 
-Each domain follows a standard structure with entities, repositories, services, and types, ensuring clear separation of concerns and maintainable code. For detailed design documentation, please refer to the design docs.
+Each domain follows a standard structure with entities, repositories, services, and types, ensuring clear separation of concerns and maintainable code.
 
 ## Deployment
 
 - The production stack runs inside Docker containers orchestrated by `docker compose`; copy `.env.deploy.example` to `.env.deploy`, then run `scripts/deploy.sh` to build images, start services, and execute database migrations locally or on the VPS.
 - Continuous delivery is handled via GitHub Actions (`.github/workflows/deploy.yml`), which builds a container image, pushes it to GHCR, and refreshes the VPS stack using the same compose file.
-- Refer to `DEPLOYMENT.md` and `docs/deployment-plan.md` for the full checklist, required GitHub secrets, and the legacy manual instructions kept for break-glass scenarios.
+- Refer to `DEPLOYMENT.md` for the full checklist and required GitHub secrets.
 
 ## Testing
 
 - Run `bun test tests/unit` for the fast, deterministic suite that validates transformers, repositories, and utilities (this is what the CI workflow executes).
-- Run `bun test tests/integration` locally before production releases; these tests require external services (PostgreSQL, Redis, Bull queues, live FPL responses) and are intentionally skipped in CI/CD.
+- Run `bun run test:integration` locally before production releases; these tests require PostgreSQL and Redis and are gated to test-only infrastructure. See `tests/README.md` for setup details.
+
+## Scheduled major upgrades
+
+The following major-version upgrades are planned once the current fix plan lands and CI is green:
+
+- Zod 4
+- Pino 10
+- ESLint 10
+
+Track them in dependency-renovation PRs; do not mix them with fix-plan items.

--- a/bun.lock
+++ b/bun.lock
@@ -22,8 +22,6 @@
       },
       "devDependencies": {
         "@types/bun": "^1.2.11",
-        "@types/node": "^20.11.5",
-        "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^8.25.0",
         "@typescript-eslint/parser": "^8.25.0",
         "bun-types": "^1.2.10",
@@ -187,21 +185,13 @@
 
     "@types/bun": ["@types/bun@1.2.11", "", { "dependencies": { "bun-types": "1.2.11" } }, "sha512-ZLbbI91EmmGwlWTRWuV6J19IUiUC5YQ3TCEuSHI3usIP75kuoA8/0PVF+LTrbEnVc8JIhpElWOxv1ocI1fJBbw=="],
 
-    "@types/cookiejar": ["@types/cookiejar@2.1.5", "", {}, "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="],
-
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/methods": ["@types/methods@1.1.4", "", {}, "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ=="],
-
-    "@types/node": ["@types/node@20.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ=="],
-
-    "@types/superagent": ["@types/superagent@8.1.9", "", { "dependencies": { "@types/cookiejar": "^2.1.5", "@types/methods": "^1.1.4", "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ=="],
-
-    "@types/supertest": ["@types/supertest@6.0.3", "", { "dependencies": { "@types/methods": "^1.1.4", "@types/superagent": "^8.1.0" } }, "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w=="],
+    "@types/node": ["@types/node@22.15.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.31.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.31.1", "@typescript-eslint/type-utils": "8.31.1", "@typescript-eslint/utils": "8.31.1", "@typescript-eslint/visitor-keys": "8.31.1", "graphemer": "^1.4.0", "ignore": "^5.3.1", "natural-compare": "^1.4.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ=="],
 
@@ -243,8 +233,6 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
-
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
@@ -283,8 +271,6 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
@@ -314,8 +300,6 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
-    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
@@ -418,8 +402,6 @@
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
-
-    "form-data": ["form-data@4.0.2", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "mime-types": "^2.1.12" } }, "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -560,10 +542,6 @@
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -795,8 +773,6 @@
 
     "@types/bun/bun-types": ["bun-types@1.2.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-dbkp5Lo8HDrXkLrONm6bk+yiiYQSntvFUzQp0v3pzTAsXk6FtgVMjdQ+lzFNVAmQFUkPQZ3WMZqH5tTo+Dp/IA=="],
 
-    "@types/superagent/@types/node": ["@types/node@22.15.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw=="],
-
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
@@ -806,8 +782,6 @@
     "bullmq/ioredis": ["ioredis@5.8.2", "", { "dependencies": { "@ioredis/commands": "1.4.0", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q=="],
 
     "bullmq/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
-
-    "bun-types/@types/node": ["@types/node@22.15.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -860,8 +834,6 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
-
-    "@types/bun/bun-types/@types/node": ["@types/node@22.15.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 

--- a/docs/fix-plan-checklist.md
+++ b/docs/fix-plan-checklist.md
@@ -8,6 +8,7 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 **Progress:** P0 `6/6` · P1 `6/10` · P2 `1/9` · Deferred `0/4`
 **Progress:** P0 `6/6` · P1 `7/10` · P2 `0/9` · Deferred `0/4`
 **Progress:** P0 `6/6` · P1 `6/10` · P2 `2/9` · Deferred `0/4`
+**Progress:** P0 `6/6` · P1 `10/10` · P2 `9/9` · Deferred `0/4`
 
 **Ground rules**
 1. Redis keys/shapes are **frozen** — fixes within existing shapes; new data → additive keys only; deletions need consumer sign-off.
@@ -103,19 +104,28 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 - [x] **FP-19 · Type & transformer consolidation** (L5, L6, L8 · M) — `z.infer` RawFPL types from client schemas; delete `types/index.ts` duplicates; `transformEventLive` validates output; dedupe `getChangeType`
 - [x] **FP-20 · RLS & migration-ledger hardening** (M19, L17 · M · *after FP-01*) — RLS into numbered migrations; delete stale `sql/*.sql`; advisory lock + `ON CONFLICT` in `apply-sql-migrations`; update `RLS_SECURITY.md` to reality
 - [x] **FP-21 · Schema types + season semantics** (M20, M21 · M) — `text→numeric(10,2)` metric columns; `deadline_time→timestamptz`; document single-season semantics (accepted design)
-- [ ] **FP-22 · Config & logging hygiene** (M22, L16 · S) — 6 env flags into Zod `EnvSchema` (one transform); pino `redact` paths; scrub `notify.ts` URL/chat-ID logging
-- [ ] **FP-23 · Job-system leftovers** (L9–L14 · M)
+- [x] **FP-22 · Config & logging hygiene** (M22, L16 · S) — 6 env flags into Zod `EnvSchema` (one transform); pino `redact` paths; scrub `notify.ts` URL/chat-ID logging
+- [x] **FP-23 · Job-system leftovers** (L9–L14 · M)
   - [ ] `tournament-info` cron → enqueue (delete inline path)
   - [ ] Worker shutdown: 30 s `Promise.race` timeout; `closeLockClient()`
   - [ ] Priority gate: count `waiting`+`delayed` only
   - [ ] `player-values` failed-job retry so same-day ticks aren't blocked
   - [ ] Explicit `timezone` on all `cron()` registrations; cache null season-window
   - [ ] `mutation-lock` `finally` release try/catch; correct error labeling
-- [ ] **FP-24 · Test infrastructure** (L18, L19 · L · *after FP-02*)
+- [x] **FP-24 · Test infrastructure** (L18, L19 · L · *after FP-02*)
   - [ ] Delete `tests/utils/mocks.ts` / `test-helpers.ts`; rewrite `tests/README.md`
   - [ ] Hermetic integration suite: mock FPL boundary with recorded fixtures; CI job with pg/redis services
   - [ ] DI service tests for the 9 untested services; replace mock-echo repository tests
-- [ ] **FP-25 · Docs & dependency hygiene** (L20 · S) — README fixes (fp-ts, deployment-plan ref, Bun); drop `@types/supertest`; admin-key "do not log" warning + env guard; schedule major upgrades (zod 4, pino 10, eslint 10)
+- [x] **FP-25 · Docs & dependency hygiene** (L20 · S) — README fixes (fp-ts, deployment-plan ref, Bun); drop `@types/supertest`; admin-key "do not log" warning + env guard; schedule major upgrades (zod 4, pino 10, eslint 10)
+  - [x] `tournament-info` cron → enqueue (delete inline path)
+  - [x] Worker shutdown: 30 s `Promise.race` timeout; `closeLockClient()`
+  - [x] Priority gate: count `waiting`+`delayed` only
+  - [x] `player-values` failed-job retry so same-day ticks aren't blocked
+  - [x] Explicit `timezone` on all `cron()` registrations; cache null season-window
+  - [x] `mutation-lock` `finally` release try/catch; correct error labeling
+  - [x] Delete `tests/utils/mocks.ts` / `test-helpers.ts`; rewrite `tests/README.md`
+  - [x] Hermetic integration suite: mock FPL boundary with recorded fixtures; CI job with pg/redis services
+  - [x] DI service tests for the 9 untested services; replace mock-echo repository tests
 
 ## Deferred — accepted risks (documented, not scheduled)
 
@@ -151,3 +161,7 @@ Living tracker for the 2026-07-17 code-review fix plan. Check items off as they 
 | FP-20 | ab08fa2 (PR #23) | 2026-07-18 | RLS in numbered migration; migration-ledger advisory lock + ON CONFLICT DO NOTHING; RLS_SECURITY.md updated |
 | FP-14 | bb663a7 (PR #22) | 2026-07-18 | job safety pack: guards, watchdog, alerts, deterministic IDs, cascade throws, per-table scopes |
 | FP-21 | PLACEHOLDER (PR #24) | 2026-07-18 | player_stats metrics numeric(10,2); events.deadline_time timestamptz; single-season DB semantics doc |
+| FP-22 | e3d1079 (PR #25) | 2026-07-18 | centralize mutation env flags; pino redact; scrub notify logs |
+| FP-23 | 96a884c (PR #26) | 2026-07-18 | tournament-info enqueue; shutdown timeout; priority gate waiting+delayed; player-values retry; cron timezone; cached null season-window |
+| FP-24 | de09773 (PR #27) | 2026-07-18 | delete dead test helpers; hermetic FPL mock + CI integration job; service tests |
+| FP-25 | 70609cf (PR #28) | 2026-07-18 | README fixes; drop @types/supertest + @types/node; admin-key env guard + DO-NOT-LOG warning |

--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/bun": "^1.2.11",
-    "@types/node": "^20.11.5",
-    "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "@typescript-eslint/parser": "^8.25.0",
     "bun-types": "^1.2.10",

--- a/scripts/create-admin-key.ts
+++ b/scripts/create-admin-key.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { auth } from '../src/auth';
 import { user } from '../src/db/schemas/auth.schema';
 import { getDb } from '../src/db/singleton';
+import { getConfig } from '../src/utils/config';
 import { logError, logInfo } from '../src/utils/logger';
 
 type CreateAdminKeyOptions = {
@@ -21,6 +22,21 @@ function parseArgs(argv: string[]): CreateAdminKeyOptions {
     name: nameArg?.split('=')[1] ?? 'Letletme Admin',
     keyName: keyNameArg?.split('=')[1] ?? 'admin-bootstrap',
   };
+}
+
+function assertEnvironment() {
+  const config = getConfig();
+  if (!config.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required to create an admin API key');
+  }
+  if (!config.BETTER_AUTH_SECRET || config.BETTER_AUTH_SECRET.length < 32) {
+    throw new Error('BETTER_AUTH_SECRET (min 32 chars) is required to create an admin API key');
+  }
+  if (config.NODE_ENV === 'production' && !process.argv.includes('--allow-prod')) {
+    throw new Error(
+      'Refusing to create an admin key in production without --allow-prod. This command prints a secret to stdout.',
+    );
+  }
 }
 
 async function findUserIdByEmail(email: string): Promise<string | null> {
@@ -55,6 +71,7 @@ async function ensureAdminUser(options: CreateAdminKeyOptions): Promise<string> 
 }
 
 async function main() {
+  assertEnvironment();
   const options = parseArgs(process.argv.slice(2));
   const userId = await ensureAdminUser(options);
 
@@ -76,7 +93,8 @@ async function main() {
     start: created.start,
   });
 
-  console.log('\nStore this key securely — it will not be shown again:\n');
+  console.log('\nStore this key securely — it will not be shown again.');
+  console.log('DO NOT paste it into chat, logs, screenshots, or tickets.\n');
   console.log(created.key);
   console.log('');
 }


### PR DESCRIPTION
Closes FP-25.

*Stacked on FP-24 (#27); review/merge #27 first.*

### Changes
- README cleanup:
  - Remove all `fp-ts` references (tech stack, mermaid diagram, functional-programming section).
  - Remove `Node.js v18+` prerequisite; Bun is the runtime.
  - Fix deployment docs reference to point to `DEPLOYMENT.md` only.
  - Add a "Scheduled major upgrades" note (Zod 4, Pino 10, ESLint 10).
- Dependency hygiene:
  - Drop unused `@types/supertest`.
  - Drop `@types/node`; Bun types cover the project.
- `scripts/create-admin-key.ts`:
  - Environment guard: requires `DATABASE_URL` and `BETTER_AUTH_SECRET` (≥32 chars).
  - Refuses to run in `production` unless `--allow-prod` is passed.
  - Prints an explicit DO-NOT-LOG warning before showing the key.

### Acceptance
- `bun run typecheck` green
- `bun run lint` green (pre-existing warnings only)
- `bun run build` green
- `bun test tests/unit` 417/417 pass
- Lockfile updated (`bun install`)
