### PR TITLE
fix(ops): never load pino-pretty in production runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN bun install --frozen-lockfile --production
 
 # Build the application
 FROM deps AS build
+# Ensure `bun build` inlines production NODE_ENV so the prod logger path is used
+# and pino-pretty (devDependency) is not required at runtime.
+ENV NODE_ENV=production
 COPY . ./
 RUN bun run build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
     command: bun dist/index.js
     env_file: .env.deploy
     environment:
+      # Force production even if .env.deploy omits/overrides NODE_ENV — logger
+      # must not load pino-pretty (devDependency) in the runtime image.
+      - NODE_ENV=production
       - TZ=Asia/Shanghai
     logging: *default-logging
     ports:
@@ -42,6 +45,7 @@ services:
     command: bun dist/worker.js
     env_file: .env.deploy
     environment:
+      - NODE_ENV=production
       - TZ=Asia/Shanghai
     logging: *default-logging
     volumes:

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,7 +3,17 @@ import pino from 'pino';
 import { getJobLogContext } from './job-log-context';
 import { formatUtc8Timestamp } from './timezone';
 
-const isDevelopment = process.env.NODE_ENV !== 'production';
+/**
+ * Production detection must survive bundling: `bun build` can inline
+ * `process.env.NODE_ENV` at compile time. Prefer an explicit production path
+ * and never require `pino-pretty` (devDependency) at runtime.
+ */
+function isProductionRuntime(): boolean {
+  // Read via dynamic key so some bundlers leave this as a real env lookup.
+  const nodeEnv = process.env['NODE_ENV'];
+  return nodeEnv === 'production';
+}
+
 const logLevel = process.env.LOG_LEVEL || 'info';
 
 const MAX_ERROR_MESSAGE_LENGTH = 2_000;
@@ -96,8 +106,15 @@ const loggerOptions: pino.LoggerOptions = {
   },
 };
 
-export const logger = isDevelopment
-  ? pino(
+function createLogger(): pino.Logger {
+  // Always JSON in production (and when NODE_ENV is unset in a prod image).
+  if (isProductionRuntime()) {
+    return pino(loggerOptions);
+  }
+
+  // Local/dev: pretty logs when pino-pretty is installed; fall back to JSON.
+  try {
+    return pino(
       loggerOptions,
       pino.transport({
         target: 'pino-pretty',
@@ -107,8 +124,13 @@ export const logger = isDevelopment
           ignore: 'pid,hostname',
         },
       }),
-    )
-  : pino(loggerOptions);
+    );
+  } catch {
+    return pino(loggerOptions);
+  }
+}
+
+export const logger = createLogger();
 
 function mergeJobContext(data?: object): object | undefined {
   const jobContext = getJobLogContext();


### PR DESCRIPTION
## Summary
After the RLS migration fix, deploy progressed past `db:apply-sql` but failed health/start with:

```text
error: unable to determine transport target for "pino-pretty"
```

`pino-pretty` is a **devDependency** and is not in the production image. The worker still tried to load it when `NODE_ENV` was not reliably `production`.

## Changes
- **logger**: production → JSON only; dev tries pretty and falls back to JSON
- **Dockerfile build**: `ENV NODE_ENV=production` before `bun run build`
- **docker-compose**: force `NODE_ENV=production` for api + worker (overrides `.env.deploy`)

## Test plan
- [x] `bun test tests/unit/logger.test.ts tests/unit/errors.test.ts`
- [x] `NODE_ENV=production bun run build`
- [ ] Merge → Deploy: migrations + containers healthy