### PR TITLE
fix(test): avoid same-ms tournament job ID collision in CI

### DIFF
--- a/tests/integration/workers/tournament-sync.worker.test.ts
+++ b/tests/integration/workers/tournament-sync.worker.test.ts
@@ -110,7 +110,9 @@ describe('Tournament Sync Worker Integration Tests', () => {
 
   describe('Job ID Generation', () => {
     test('should create unique job IDs with timestamps', async () => {
+      // Job IDs include Date.now(); a 1ms gap avoids same-millisecond collisions.
       const job1 = await enqueueTournamentEventPicks(testEventId, 'manual');
+      await Bun.sleep(2);
       const job2 = await enqueueTournamentEventPicks(testEventId, 'manual');
 
       expect(job1.id).not.toBe(job2.id);


### PR DESCRIPTION
## Summary
- Main CI integration failed after #32 on a flaky uniqueness assertion: two consecutive `enqueueTournamentEventPicks` calls can share the same `Date.now()` millisecond, so BullMQ returns the same job id.
- Add a 2ms sleep between enqueues (same pattern as `tournament-sync-jobs.test.ts`, `league-sync-jobs.test.ts`, and `live-data.worker.test.ts`).

## Test plan
- [x] Local unit tests not required for this test-only change
- [ ] CI integration job on this PR
- [ ] Main CI + Deploy after merge