### PR TITLE
Validate production auth before Data rollout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,7 @@ jobs:
             git checkout --force main
             git reset --hard "$DEPLOY_SHA"
             APP_IMAGE="$IMAGE_REF" docker compose pull api worker
+            APP_IMAGE="$IMAGE_REF" docker compose run --rm -T api bun run env:check
             APP_IMAGE="$IMAGE_REF" docker compose run --rm -T api bun run db:migrate
             APP_IMAGE="$IMAGE_REF" docker compose run --rm -T api bun scripts/apply-sql-migrations.ts
             APP_IMAGE="$IMAGE_REF" docker compose run --rm -T api bun run db:migrate:status

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -110,6 +110,7 @@ export function getConfig(): AppConfig {
 export function validateEnvForCli(): { ok: boolean; errors?: unknown } {
   try {
     const conf = getConfig();
+    resolveAuthConfig(conf);
     logInfo('[env] OK', {
       PORT: conf.PORT,
       DATABASE_URL: conf.DATABASE_URL ? 'set' : 'missing',

--- a/tests/unit/config-validation.test.ts
+++ b/tests/unit/config-validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const baseEnv = {
+  ...process.env,
+  DATABASE_URL: 'postgresql://localhost:5432/letletme_test',
+  ENABLE_AUTH: 'true',
+  NODE_ENV: 'production',
+  REDIS_DB: '9',
+};
+
+async function runEnvCheck(dataApiKeyHashes: string): Promise<number> {
+  const child = Bun.spawn(['bun', 'validate-env.ts'], {
+    cwd: process.cwd(),
+    env: { ...baseEnv, DATA_API_KEY_HASHES: dataApiKeyHashes },
+    stderr: 'ignore',
+    stdout: 'ignore',
+  });
+  return child.exited;
+}
+
+describe('production environment preflight', () => {
+  test('rejects enabled API auth without a configured key digest', async () => {
+    expect(await runEnvCheck('')).not.toBe(0);
+  });
+
+  test('accepts a valid SHA-256 API key digest', async () => {
+    expect(await runEnvCheck('a'.repeat(64))).toBe(0);
+  });
+
+  test('runs before production migrations and service replacement', () => {
+    const workflow = readFileSync('.github/workflows/deploy.yml', 'utf8');
+    const preflight = workflow.indexOf('bun run env:check');
+    const migrate = workflow.indexOf('bun run db:migrate');
+    const replaceServices = workflow.indexOf('docker compose up -d');
+
+    expect(preflight).toBeGreaterThan(0);
+    expect(preflight).toBeLessThan(migrate);
+    expect(preflight).toBeLessThan(replaceServices);
+  });
+});


### PR DESCRIPTION
## Purpose

Prevent a Data deploy from replacing healthy services when production API authentication is enabled but no SHA-256 key digest is configured.

## Changes

- make the existing environment checker validate the API auth contract
- run that check before migrations and container replacement
- cover missing and valid digest cases plus workflow ordering

## Verification

- production API restored with authentication enabled and a managed key
- 437 unit tests passed
- typecheck, lint, formatting, and build passed