### PR TITLE
fix: harden FPL live data readiness

### DIFF
--- a/src/cache/cache-season.ts
+++ b/src/cache/cache-season.ts
@@ -45,7 +45,23 @@ export function resetActiveSeasonMemo(): void {
   activeSeasonMemo = null;
 }
 
-const SEASON_CACHE_PREFIXES = ['Event', 'Team', 'Player', 'Phase', 'Fixtures', 'FixturesByTeam'];
+export const SEASON_CACHE_PREFIXES = [
+  'Event',
+  'Team',
+  'Player',
+  'Phase',
+  'Fixtures',
+  'FixturesByTeam',
+  'EventLive',
+  'EventLiveSummary',
+  'EventLiveExplain',
+  'LiveFixture',
+  'LiveBonus',
+  'LiveBonusV2',
+  'EventOverallResult',
+  'EntryInfo',
+  'PlayerStat',
+] as const;
 
 type EventLike = Pick<RawFPLEvent, 'id' | 'deadline_time'> | Pick<Event, 'id' | 'deadlineTime'>;
 
@@ -190,7 +206,12 @@ export async function clearStaleSeasonCache(
 
   for (const prefix of prefixes) {
     const keys = await scanKeys(redis, `${prefix}:*`);
-    staleKeys.push(...keys.filter((key) => !key.startsWith(`${prefix}:${activeSeason}`)));
+    const currentSeasonPrefix = `${prefix}:${activeSeason}`;
+    staleKeys.push(
+      ...keys.filter(
+        (key) => key !== currentSeasonPrefix && !key.startsWith(`${currentSeasonPrefix}:`),
+      ),
+    );
   }
 
   if (staleKeys.length === 0) {
@@ -214,5 +235,6 @@ export async function finalizeSeasonCacheWrite(
   if (!changed) {
     return;
   }
-  await clearStaleSeasonCache(season, prefixes);
+  const rolloverPrefixes = [...new Set([...SEASON_CACHE_PREFIXES, ...prefixes])];
+  await clearStaleSeasonCache(season, rolloverPrefixes);
 }

--- a/src/domain/post-match-results.ts
+++ b/src/domain/post-match-results.ts
@@ -1,0 +1,47 @@
+import type { Event, Fixture } from '../types';
+
+const MATCH_DURATION_MS = 2 * 60 * 60 * 1000;
+const RESULT_SLOT_MS = 60 * 60 * 1000;
+
+export const POST_MATCH_RESULTS_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the bounded, idempotent post-match result slot for an event.
+ *
+ * The first 24 hours after the final fixture are split into hourly provisional
+ * slots. Once FPL marks the event data checked, every remaining cron tick maps
+ * to one stable final slot instead. Callers use the slot in the BullMQ job ID.
+ */
+export function getPostMatchResultsSlot(
+  event: Pick<Event, 'dataChecked'>,
+  fixtures: readonly Fixture[],
+  date = new Date(),
+): string | null {
+  const kickoffTimes = fixtures
+    .map((fixture) => fixture.kickoffTime?.getTime())
+    .filter(
+      (kickoffTime): kickoffTime is number =>
+        kickoffTime !== undefined && Number.isFinite(kickoffTime),
+    );
+
+  if (kickoffTimes.length === 0) {
+    return null;
+  }
+
+  const matchEndMs = Math.max(...kickoffTimes) + MATCH_DURATION_MS;
+  const currentTimeMs = date.getTime();
+  if (!Number.isFinite(currentTimeMs)) {
+    return null;
+  }
+
+  const elapsedMs = currentTimeMs - matchEndMs;
+  if (elapsedMs <= 0 || elapsedMs >= POST_MATCH_RESULTS_WINDOW_MS) {
+    return null;
+  }
+
+  if (event.dataChecked) {
+    return 'final';
+  }
+
+  return `provisional-${Math.floor(elapsedMs / RESULT_SLOT_MS)}`;
+}

--- a/src/domain/post-match-results.ts
+++ b/src/domain/post-match-results.ts
@@ -9,8 +9,9 @@ export const POST_MATCH_RESULTS_WINDOW_MS = 24 * 60 * 60 * 1000;
  * Resolve the bounded, idempotent post-match result slot for an event.
  *
  * The first 24 hours after the final fixture are split into hourly provisional
- * slots. Once FPL marks the event data checked, every remaining cron tick maps
- * to one stable final slot instead. Callers use the slot in the BullMQ job ID.
+ * slots. Once FPL marks the event data checked, slots become final but remain
+ * hourly so later live-data consolidation can publish a corrected snapshot.
+ * Callers use the slot in the BullMQ job ID.
  */
 export function getPostMatchResultsSlot(
   event: Pick<Event, 'dataChecked'>,
@@ -40,7 +41,7 @@ export function getPostMatchResultsSlot(
   }
 
   if (event.dataChecked) {
-    return 'final';
+    return `final-${Math.floor(elapsedMs / RESULT_SLOT_MS)}`;
   }
 
   return `provisional-${Math.floor(elapsedMs / RESULT_SLOT_MS)}`;

--- a/src/domain/tournament-event-results.ts
+++ b/src/domain/tournament-event-results.ts
@@ -1,0 +1,7 @@
+export type TournamentEventResultsSummary = {
+  totalEntries: number;
+};
+
+export function shouldEnqueueTournamentCascade(result: TournamentEventResultsSummary): boolean {
+  return result.totalEntries > 0;
+}

--- a/src/jobs/current-event-gate.ts
+++ b/src/jobs/current-event-gate.ts
@@ -1,0 +1,36 @@
+import type { Event } from '../types';
+import { getCurrentEvent } from '../services/events.service';
+import { isFPLSeason } from '../utils/conditions';
+import { logDebug, logInfo } from '../utils/logger';
+
+export type CurrentEventGateDependencies = {
+  isFPLSeason: (date: Date) => Promise<boolean>;
+  getCurrentEvent: () => Promise<Event | null>;
+};
+
+const defaultDependencies: CurrentEventGateDependencies = {
+  isFPLSeason,
+  getCurrentEvent,
+};
+
+export async function shouldRunCurrentEventJob(
+  jobName: string,
+  date = new Date(),
+  dependencies: CurrentEventGateDependencies = defaultDependencies,
+): Promise<boolean> {
+  if (!(await dependencies.isFPLSeason(date))) {
+    logDebug('Skipping current-event job - not FPL season', {
+      jobName,
+      month: date.getMonth() + 1,
+    });
+    return false;
+  }
+
+  const currentEvent = await dependencies.getCurrentEvent();
+  if (!currentEvent) {
+    logInfo('Skipping current-event job - no current event', { jobName });
+    return false;
+  }
+
+  return true;
+}

--- a/src/jobs/data-sync.jobs.ts
+++ b/src/jobs/data-sync.jobs.ts
@@ -9,29 +9,16 @@ import {
   enqueuePlayersSyncJob,
   enqueueTeamsSyncJob,
 } from './data-sync-enqueue';
-import { isFPLSeason } from '../utils/conditions';
+import { shouldRunCurrentEventJob } from './current-event-gate';
 import { executeTrackedCron } from '../utils/job-run-logger';
-import { logDebug, logInfo } from '../utils/logger';
+import { logInfo } from '../utils/logger';
 import { CRON_TIMEZONE } from '../utils/timezone';
-
-async function shouldRunSeasonDataSync(jobName: string) {
-  const now = new Date();
-  if (!(await isFPLSeason(now))) {
-    logDebug('Skipping data sync job - not FPL season', {
-      jobName,
-      month: now.getMonth() + 1,
-    });
-    return false;
-  }
-
-  return true;
-}
 
 /**
  * Core entity syncs (events/teams/fixtures/players/phases) run year-round so a
  * newly published FPL season is picked up before the calendar season window
  * opens. Services short-circuit on empty pre-season payloads. Player-stats
- * remains gated by isFPLSeason via shouldRunSeasonDataSync.
+ * remains gated by the season window and the presence of a current event.
  */
 export function registerDataSyncJobs(app: Elysia) {
   return app
@@ -111,7 +98,7 @@ export function registerDataSyncJobs(app: Elysia) {
         async run() {
           try {
             await executeTrackedCron('player-stats-sync', async () => {
-              if (!(await shouldRunSeasonDataSync('player-stats-sync'))) {
+              if (!(await shouldRunCurrentEventJob('player-stats-sync'))) {
                 return;
               }
               const job = await enqueuePlayerStatsSyncJob('cron');

--- a/src/jobs/league-event-results.jobs.ts
+++ b/src/jobs/league-event-results.jobs.ts
@@ -1,8 +1,9 @@
 import { cron } from '@elysiajs/cron';
 import type { Elysia } from 'elysia';
 
+import { getPostMatchResultsSlot } from '../domain/post-match-results';
 import { getCurrentEvent } from '../services/events.service';
-import { isAfterMatchDay, isFPLSeason } from '../utils/conditions';
+import { isFPLSeason } from '../utils/conditions';
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
@@ -14,7 +15,8 @@ import { CRON_TIMEZONE } from '../utils/timezone';
  * League Event Results Sync Trigger
  *
  * Strategy:
- * - Runs every 10 minutes during after-match-day window (aligned with live-events-db-sync)
+ * - Polls every 10 minutes for a bounded post-match result slot
+ * - Uses deterministic hourly/final job IDs so duplicate cron ticks are idempotent
  * - Enqueues coordinator job which fans out to per-tournament jobs
  * - Uses fresh event_lives data from DB for calculations
  */
@@ -40,7 +42,10 @@ export async function runLeagueEventResultsSync(options?: {
   }
 
   const fixtures = await fixtureRepository.findByEvent(currentEvent.id);
-  if (!skipMatchWindowCheck && !isAfterMatchDay(currentEvent, fixtures, now)) {
+  const resultSlot = skipMatchWindowCheck
+    ? null
+    : getPostMatchResultsSlot(currentEvent, fixtures, now);
+  if (!skipMatchWindowCheck && !resultSlot) {
     logInfo('Skipping league event results sync - conditions not met', {
       eventId: currentEvent.id,
     });
@@ -48,12 +53,17 @@ export async function runLeagueEventResultsSync(options?: {
   }
 
   // Enqueue coordinator job (will fan out to per-tournament jobs)
-  const job = await enqueueLeagueEventResults(currentEvent.id, source);
+  const job = await enqueueLeagueEventResults(currentEvent.id, source, {
+    ...(resultSlot
+      ? { jobId: `league-event-results-e${currentEvent.id}-coordinator-${resultSlot}` }
+      : {}),
+  });
   logInfo('League event results coordinator job enqueued', {
     jobId: job.id,
     eventId: currentEvent.id,
     source,
     skipMatchWindowCheck,
+    resultSlot,
   });
 }
 

--- a/src/jobs/league-event-results.jobs.ts
+++ b/src/jobs/league-event-results.jobs.ts
@@ -3,10 +3,9 @@ import type { Elysia } from 'elysia';
 
 import { getPostMatchResultsSlot } from '../domain/post-match-results';
 import { getCurrentEvent } from '../services/events.service';
-import { isFPLSeason } from '../utils/conditions';
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
-import { logDebug, logInfo } from '../utils/logger';
+import { logInfo } from '../utils/logger';
 import { enqueueLeagueEventResults } from './league-sync.jobs';
 import type { LeagueSyncJobSource } from './league-sync.jobs';
 import { CRON_TIMEZONE } from '../utils/timezone';
@@ -28,13 +27,6 @@ export async function runLeagueEventResultsSync(options?: {
   const source = options?.source ?? 'cron';
   const skipMatchWindowCheck = options?.skipMatchWindowCheck ?? false;
   const now = new Date();
-  if (!(await isFPLSeason(now))) {
-    logDebug('Skipping league event results sync - not FPL season', {
-      month: now.getMonth() + 1,
-    });
-    return;
-  }
-
   const currentEvent = await getCurrentEvent();
   if (!currentEvent) {
     logInfo('Skipping league event results sync - no current event');

--- a/src/jobs/league-sync.jobs.ts
+++ b/src/jobs/league-sync.jobs.ts
@@ -9,11 +9,17 @@ import { logError, logInfo } from '../utils/logger';
 
 export type LeagueSyncJobSource = 'cron' | 'manual' | 'cascade';
 
+export type LeagueSyncEnqueueOptions = {
+  tournamentId?: number;
+  delay?: number;
+  jobId?: string;
+};
+
 async function enqueueLeagueSyncJob(
   jobName: LeagueSyncJobName,
   eventId: number,
   source: LeagueSyncJobSource = 'cron',
-  options: { tournamentId?: number; delay?: number } = {},
+  options: LeagueSyncEnqueueOptions = {},
 ) {
   try {
     const tier = getLeagueSyncJobPriority(jobName as LeagueSyncPriorityJobName);
@@ -25,19 +31,23 @@ async function enqueueLeagueSyncJob(
       triggeredAt: new Date().toISOString(),
     };
 
-    // Use unique IDs so cron/cascade runs for the same event are not deduped
-    // while completed jobs are still retained in BullMQ.
+    // Callers may provide a deterministic ID for bounded recurring slots.
+    // Other cron, manual, and cascade runs retain unique IDs.
     const runId = Date.now();
-    let jobId: string;
-    if (options.tournamentId) {
-      jobId = `${jobName}-e${eventId}-t${options.tournamentId}-${runId}`;
-    } else {
-      jobId = `${jobName}-e${eventId}-coordinator-${runId}`;
-    }
+    const generatedJobId = options.tournamentId
+      ? `${jobName}-e${eventId}-t${options.tournamentId}-${runId}`
+      : `${jobName}-e${eventId}-coordinator-${runId}`;
+    const jobId = options.jobId ?? generatedJobId;
 
     const job = await queue.add(jobName, jobData, {
       jobId,
       delay: options.delay,
+      ...(options.jobId
+        ? {
+            removeOnComplete: { age: 86_400 },
+            removeOnFail: { age: 172_800 },
+          }
+        : {}),
     });
 
     logInfo('League sync job enqueued', {
@@ -67,11 +77,11 @@ async function enqueueLeagueSyncJob(
 export const enqueueLeagueEventPicks = (
   eventId: number,
   source?: LeagueSyncJobSource,
-  options?: { tournamentId?: number },
+  options?: LeagueSyncEnqueueOptions,
 ) => enqueueLeagueSyncJob(LEAGUE_JOBS.LEAGUE_EVENT_PICKS, eventId, source, options);
 
 export const enqueueLeagueEventResults = (
   eventId: number,
   source?: LeagueSyncJobSource,
-  options?: { tournamentId?: number },
+  options?: LeagueSyncEnqueueOptions,
 ) => enqueueLeagueSyncJob(LEAGUE_JOBS.LEAGUE_EVENT_RESULTS, eventId, source, options);

--- a/src/jobs/league-sync.jobs.ts
+++ b/src/jobs/league-sync.jobs.ts
@@ -45,7 +45,7 @@ async function enqueueLeagueSyncJob(
       ...(options.jobId
         ? {
             removeOnComplete: { age: 86_400 },
-            removeOnFail: { age: 172_800 },
+            removeOnFail: true,
           }
         : {}),
     });

--- a/src/jobs/live.jobs.ts
+++ b/src/jobs/live.jobs.ts
@@ -1,8 +1,9 @@
 import { cron } from '@elysiajs/cron';
 import { Elysia } from 'elysia';
 
+import { getPostMatchResultsSlot } from '../domain/post-match-results';
 import { getCurrentEvent } from '../services/events.service';
-import { isAfterMatchDay, isFPLSeason, isMatchDayTime } from '../utils/conditions';
+import { isFPLSeason, isMatchDayTime } from '../utils/conditions';
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
@@ -119,24 +120,24 @@ async function runEventLivesDbSync() {
 // scores, data_checked flag). Runs on match days in the morning AFTER isMatchDayTime has ended.
 export async function runPostMatchConsolidation() {
   const now = new Date();
-  if (!(await isFPLSeason(now))) {
-    return;
-  }
-
   const currentEvent = await getCurrentEvent();
   if (!currentEvent) {
     return;
   }
 
   const fixtures = await fixtureRepository.findByEvent(currentEvent.id);
-
-  if (!isAfterMatchDay(currentEvent, fixtures, now)) {
+  const resultSlot = getPostMatchResultsSlot(currentEvent, fixtures, now);
+  if (!resultSlot) {
     return;
   }
 
   const job = await enqueueEventLivesDbSync(currentEvent.id, 'cron');
   if (job) {
-    logInfo('Post-match consolidation job enqueued', { jobId: job.id, eventId: currentEvent.id });
+    logInfo('Post-match consolidation job enqueued', {
+      jobId: job.id,
+      eventId: currentEvent.id,
+      resultSlot,
+    });
   }
 }
 

--- a/src/jobs/player-values-window.jobs.ts
+++ b/src/jobs/player-values-window.jobs.ts
@@ -1,25 +1,37 @@
 import { cron } from '@elysiajs/cron';
 import { Elysia } from 'elysia';
 
+import { shouldRunCurrentEventJob } from './current-event-gate';
 import { enqueuePlayerValuesSyncJob } from './data-sync-enqueue';
 import { playerValuesRepository } from '../repositories/player-values';
-import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
-import { logDebug, logInfo } from '../utils/logger';
+import { logInfo } from '../utils/logger';
 import { CRON_TIMEZONE } from '../utils/timezone';
 
 function getChangeDateKey(date: Date) {
   return date.toISOString().split('T')[0].replace(/-/g, '');
 }
 
-async function shouldRunPlayerValuesSync(now: Date) {
-  if (!(await isFPLSeason(now))) {
-    logDebug('Skipping player values sync - not FPL season', { month: now.getMonth() + 1 });
+export type PlayerValuesWindowDependencies = {
+  shouldRunCurrentEventJob: (jobName: string, date: Date) => Promise<boolean>;
+  hasChangesForDate: (changeDate: string) => Promise<boolean>;
+};
+
+const defaultDependencies: PlayerValuesWindowDependencies = {
+  shouldRunCurrentEventJob,
+  hasChangesForDate: (changeDate) => playerValuesRepository.hasChangesForDate(changeDate),
+};
+
+export async function shouldRunPlayerValuesSync(
+  now: Date,
+  dependencies: PlayerValuesWindowDependencies = defaultDependencies,
+) {
+  if (!(await dependencies.shouldRunCurrentEventJob('player-values-sync', now))) {
     return false;
   }
 
   const changeDate = getChangeDateKey(now);
-  const alreadySynced = await playerValuesRepository.hasChangesForDate(changeDate);
+  const alreadySynced = await dependencies.hasChangesForDate(changeDate);
   if (alreadySynced) {
     logInfo('Skipping player values sync - price changes already recorded for today', {
       changeDate,

--- a/src/jobs/tournament-event-results.jobs.ts
+++ b/src/jobs/tournament-event-results.jobs.ts
@@ -3,10 +3,9 @@ import type { Elysia } from 'elysia';
 
 import { getPostMatchResultsSlot } from '../domain/post-match-results';
 import { getCurrentEvent } from '../services/events.service';
-import { isFPLSeason } from '../utils/conditions';
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
-import { logDebug, logInfo } from '../utils/logger';
+import { logInfo } from '../utils/logger';
 import { enqueueTournamentEventResults } from './tournament-sync.jobs';
 import { CRON_TIMEZONE } from '../utils/timezone';
 
@@ -22,13 +21,6 @@ import { CRON_TIMEZONE } from '../utils/timezone';
 
 export async function runTournamentEventResultsSync() {
   const now = new Date();
-  if (!(await isFPLSeason(now))) {
-    logDebug('Skipping tournament event results sync - not FPL season', {
-      month: now.getMonth() + 1,
-    });
-    return;
-  }
-
   const currentEvent = await getCurrentEvent();
   if (!currentEvent) {
     logInfo('Skipping tournament event results sync - no current event');

--- a/src/jobs/tournament-event-results.jobs.ts
+++ b/src/jobs/tournament-event-results.jobs.ts
@@ -1,8 +1,9 @@
 import { cron } from '@elysiajs/cron';
 import type { Elysia } from 'elysia';
 
+import { getPostMatchResultsSlot } from '../domain/post-match-results';
 import { getCurrentEvent } from '../services/events.service';
-import { isAfterMatchDay, isFPLSeason } from '../utils/conditions';
+import { isFPLSeason } from '../utils/conditions';
 import { fixtureRepository } from '../repositories/fixtures';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logDebug, logInfo } from '../utils/logger';
@@ -13,7 +14,8 @@ import { CRON_TIMEZONE } from '../utils/timezone';
  * Tournament Event Results Sync Trigger
  *
  * Strategy:
- * - Runs every 10 minutes during after-match-day window
+ * - Polls every 10 minutes for a bounded post-match result slot
+ * - Uses deterministic hourly/final job IDs so duplicate cron ticks are idempotent
  * - Enqueues base job which triggers cascade (points-race, battle-race, knockout, etc.)
  * - Aligned with league-event-results for consistency
  */
@@ -34,7 +36,8 @@ export async function runTournamentEventResultsSync() {
   }
 
   const fixtures = await fixtureRepository.findByEvent(currentEvent.id);
-  if (!isAfterMatchDay(currentEvent, fixtures, now)) {
+  const resultSlot = getPostMatchResultsSlot(currentEvent, fixtures, now);
+  if (!resultSlot) {
     logInfo('Skipping tournament event results sync - conditions not met', {
       eventId: currentEvent.id,
     });
@@ -42,10 +45,13 @@ export async function runTournamentEventResultsSync() {
   }
 
   // Enqueue base job (will trigger cascade on completion)
-  const job = await enqueueTournamentEventResults(currentEvent.id, 'cron');
+  const job = await enqueueTournamentEventResults(currentEvent.id, 'cron', {
+    jobId: `tournament-event-results-e${currentEvent.id}-${resultSlot}`,
+  });
   logInfo('Tournament event results job enqueued, will trigger cascade', {
     jobId: job.id,
     eventId: currentEvent.id,
+    resultSlot,
   });
 }
 

--- a/src/jobs/tournament-sync.jobs.ts
+++ b/src/jobs/tournament-sync.jobs.ts
@@ -260,7 +260,7 @@ async function enqueueTournamentSyncJob(
       ...(options.jobId
         ? {
             removeOnComplete: { age: 86_400 },
-            removeOnFail: { age: 172_800 },
+            removeOnFail: true,
           }
         : {}),
     });

--- a/src/jobs/tournament-sync.jobs.ts
+++ b/src/jobs/tournament-sync.jobs.ts
@@ -16,6 +16,7 @@ export type TournamentSyncJobSource = 'cron' | 'manual' | 'cascade';
 export type TournamentSyncEnqueueOptions = {
   delay?: number;
   cascadeId?: string;
+  jobId?: string;
 };
 
 /** Structure cascade jobs that feed tournament MVs and hold tournament-structure:global. */
@@ -249,12 +250,19 @@ async function enqueueTournamentSyncJob(
       ...(options.cascadeId ? { cascadeId: options.cascadeId } : {}),
     };
 
-    // Use unique IDs so recurring schedules are not deduped by completed jobs.
-    const jobId = `${jobName}-e${eventId}-${Date.now()}`;
+    // Callers may provide a deterministic ID for bounded recurring slots.
+    // Other cron, manual, and cascade runs retain unique IDs.
+    const jobId = options.jobId ?? `${jobName}-e${eventId}-${Date.now()}`;
 
     const job = await queue.add(jobName, jobData, {
       jobId,
       delay: options.delay,
+      ...(options.jobId
+        ? {
+            removeOnComplete: { age: 86_400 },
+            removeOnFail: { age: 172_800 },
+          }
+        : {}),
     });
 
     logInfo('Tournament sync job enqueued', {
@@ -281,8 +289,11 @@ async function enqueueTournamentSyncJob(
 }
 
 // Base job (triggers cascade)
-export const enqueueTournamentEventResults = (eventId: number, source?: TournamentSyncJobSource) =>
-  enqueueTournamentSyncJob(TOURNAMENT_JOBS.EVENT_RESULTS, eventId, source);
+export const enqueueTournamentEventResults = (
+  eventId: number,
+  source?: TournamentSyncJobSource,
+  options?: TournamentSyncEnqueueOptions,
+) => enqueueTournamentSyncJob(TOURNAMENT_JOBS.EVENT_RESULTS, eventId, source, options);
 
 // Cascade jobs
 export const enqueueTournamentPointsRace = (

--- a/src/services/live-data-cascade.service.ts
+++ b/src/services/live-data-cascade.service.ts
@@ -22,6 +22,21 @@ export type MatchWindowDeps = {
   isMatchDayTime: (currentEvent: Event, fixtures: Fixture[], now: Date) => boolean;
 };
 
+export type FinalLeagueResultsDeps = {
+  getCurrentEvent: () => Promise<Event | null>;
+  findFixturesByEvent: (eventId: number) => Promise<Fixture[]>;
+  getPostMatchResultsSlot: (
+    event: Pick<Event, 'dataChecked'>,
+    fixtures: readonly Fixture[],
+    date: Date,
+  ) => string | null;
+  enqueueLeagueEventResults: (
+    eventId: number,
+    source: 'cascade',
+    options: { jobId: string },
+  ) => Promise<unknown>;
+};
+
 /**
  * Enqueue cascade jobs after event-lives DB sync completes.
  * These jobs depend on fresh event_lives data.
@@ -133,6 +148,36 @@ export async function isLiveMatchWindowForEvent(
   return resolved.isMatchDayTime(currentEvent, fixtures, new Date());
 }
 
+/**
+ * Publish final league results only after fresh event_lives have been persisted.
+ * The live-sync suffix keeps this correction distinct from the scheduler slot.
+ */
+export async function enqueueFinalLeagueResultsAfterLiveSync(
+  eventId: number,
+  deps?: FinalLeagueResultsDeps,
+): Promise<unknown | null> {
+  const resolved = deps ?? (await loadDefaultFinalLeagueResultsDeps());
+  const currentEvent = await resolved.getCurrentEvent();
+  if (!currentEvent || currentEvent.id !== eventId || !currentEvent.dataChecked) {
+    return null;
+  }
+
+  const fixtures = await resolved.findFixturesByEvent(eventId);
+  const resultSlot = resolved.getPostMatchResultsSlot(currentEvent, fixtures, new Date());
+  if (!resultSlot?.startsWith('final-')) {
+    return null;
+  }
+
+  const job = await resolved.enqueueLeagueEventResults(eventId, 'cascade', {
+    jobId: `league-event-results-e${eventId}-coordinator-live-${resultSlot}`,
+  });
+  logInfo('Final league event results enqueued after live DB consolidation', {
+    eventId,
+    resultSlot,
+  });
+  return job;
+}
+
 async function loadDefaultMatchWindowDeps() {
   const [{ getCurrentEvent }, { isMatchDayTime }, { fixtureRepository }] = await Promise.all([
     import('./events.service'),
@@ -144,6 +189,22 @@ async function loadDefaultMatchWindowDeps() {
     getCurrentEvent,
     findFixturesByEvent: (id: number) => fixtureRepository.findByEvent(id),
     isMatchDayTime,
+  };
+}
+
+async function loadDefaultFinalLeagueResultsDeps(): Promise<FinalLeagueResultsDeps> {
+  const [eventsService, fixturesRepository, postMatchResults, leagueJobs] = await Promise.all([
+    import('./events.service'),
+    import('../repositories/fixtures'),
+    import('../domain/post-match-results'),
+    import('../jobs/league-sync.jobs'),
+  ]);
+
+  return {
+    getCurrentEvent: eventsService.getCurrentEvent,
+    findFixturesByEvent: (id: number) => fixturesRepository.fixtureRepository.findByEvent(id),
+    getPostMatchResultsSlot: postMatchResults.getPostMatchResultsSlot,
+    enqueueLeagueEventResults: leagueJobs.enqueueLeagueEventResults,
   };
 }
 

--- a/src/workers/live-data.worker.ts
+++ b/src/workers/live-data.worker.ts
@@ -10,6 +10,7 @@ import {
 } from '../queues/live-data.queue';
 import {
   enqueueCascadeJobs,
+  enqueueFinalLeagueResultsAfterLiveSync,
   isLiveMatchWindowForEvent,
 } from '../services/live-data-cascade.service';
 import { syncEventLives, updateEventLivesCache } from '../services/event-lives.service';
@@ -79,6 +80,7 @@ async function processLiveDataJob(job: Job<LiveDataJobData>) {
               await syncEventLives(eventId);
               // After DB sync completes, trigger dependent jobs
               await enqueueCascadeJobs(eventId);
+              await enqueueFinalLeagueResultsAfterLiveSync(eventId);
             }
             break;
 

--- a/src/workers/tournament-sync.worker.ts
+++ b/src/workers/tournament-sync.worker.ts
@@ -1,6 +1,7 @@
 import { Worker, Job, QueueEvents } from 'bullmq';
 
 import { MUTATION_PRIORITY_ORDER, type MutationPriorityTier } from '../domain/job-priority';
+import { shouldEnqueueTournamentCascade } from '../domain/tournament-event-results';
 import {
   getTournamentSyncQueueName,
   isTournamentSyncTieredQueueEnabled,
@@ -209,11 +210,16 @@ async function processTournamentSyncJob(job: Job<TournamentSyncJobData>) {
     () =>
       runTrackedJob(context, async () => {
         switch (job.name) {
-          case TOURNAMENT_JOBS.EVENT_RESULTS:
+          case TOURNAMENT_JOBS.EVENT_RESULTS: {
             // Base job: sync results then trigger cascade
-            await syncTournamentEventResults(eventId);
+            const result = await syncTournamentEventResults(eventId);
+            if (!shouldEnqueueTournamentCascade(result)) {
+              logInfo('Skipping tournament cascade - no active tournament entries', { eventId });
+              break;
+            }
             await enqueueTournamentCascade(eventId);
             break;
+          }
 
           case TOURNAMENT_JOBS.POINTS_RACE:
             await syncTournamentPointsRaceResults(eventId);

--- a/tests/unit/cache-hygiene.test.ts
+++ b/tests/unit/cache-hygiene.test.ts
@@ -2,8 +2,11 @@ import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import { cache } from '../../src/cache/cache-operations';
 import {
+  clearStaleSeasonCache,
+  finalizeSeasonCacheWrite,
   getActiveCacheSeason,
   resetActiveSeasonMemo,
+  SEASON_CACHE_PREFIXES,
   setActiveCacheSeason,
 } from '../../src/cache/cache-season';
 import { parseHashEntries, parseHashValues } from '../../src/cache/hash-read';
@@ -18,11 +21,15 @@ function installFakeRedis(overrides: {
   get?: (key: string) => Promise<string | null>;
   set?: (key: string, value: string) => Promise<string>;
   setex?: (key: string, ttl: number, value: string) => Promise<string>;
+  scan?: (...args: Array<string | number>) => Promise<[string, string[]]>;
+  del?: (...keys: string[]) => Promise<number>;
 }) {
   const fake = {
     get: mock(overrides.get ?? (async () => null)),
     set: mock(overrides.set ?? (async () => 'OK')),
     setex: mock(overrides.setex ?? (async () => 'OK')),
+    scan: mock(overrides.scan ?? (async () => ['0', []])),
+    del: mock(overrides.del ?? (async () => 0)),
   };
   redisSingleton.getClient = async () => fake as never;
   return fake;
@@ -151,5 +158,67 @@ describe('getActiveCacheSeason memo', () => {
     expect(await setActiveCacheSeason('2526')).toBe(false);
     expect(await getActiveCacheSeason()).toBe('2627');
     expect(redis.get).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('season rollover cleanup', () => {
+  test('covers every durable season cache family', () => {
+    expect(SEASON_CACHE_PREFIXES).toEqual([
+      'Event',
+      'Team',
+      'Player',
+      'Phase',
+      'Fixtures',
+      'FixturesByTeam',
+      'EventLive',
+      'EventLiveSummary',
+      'EventLiveExplain',
+      'LiveFixture',
+      'LiveBonus',
+      'LiveBonusV2',
+      'EventOverallResult',
+      'EntryInfo',
+      'PlayerStat',
+    ]);
+  });
+
+  test('deletes stale families while preserving exact current-season keys', async () => {
+    const staleKeys = SEASON_CACHE_PREFIXES.map((prefix) => `${prefix}:2526`);
+    const currentKeys = SEASON_CACHE_PREFIXES.map((prefix) => `${prefix}:2627`);
+    const keys = [...staleKeys, ...currentKeys, 'Event:2627:1', 'Event:26270', 'PlayerValue:2526'];
+    const redis = installFakeRedis({
+      scan: async (...args) => {
+        const pattern = String(args[2]);
+        const prefix = pattern.slice(0, -1);
+        return ['0', keys.filter((key) => key.startsWith(prefix))];
+      },
+      del: async (...deletedKeys) => deletedKeys.length,
+    });
+
+    await clearStaleSeasonCache('2627');
+
+    expect(redis.scan).toHaveBeenCalledTimes(SEASON_CACHE_PREFIXES.length);
+    expect(redis.del).toHaveBeenCalledTimes(1);
+    expect(new Set(redis.del.mock.calls[0])).toEqual(new Set([...staleKeys, 'Event:26270']));
+    expect(redis.del.mock.calls[0]).not.toContain('Event:2627');
+    expect(redis.del.mock.calls[0]).not.toContain('Event:2627:1');
+    expect(redis.del.mock.calls[0]).not.toContain('PlayerValue:2526');
+  });
+
+  test('cleans every family when the first core write advances the season', async () => {
+    const redis = installFakeRedis({
+      get: async () => '2526',
+      scan: async (...args) => {
+        const pattern = String(args[2]);
+        return ['0', pattern === 'EventOverallResult:*' ? ['EventOverallResult:2526'] : []];
+      },
+      del: async (...deletedKeys) => deletedKeys.length,
+    });
+
+    await finalizeSeasonCacheWrite('2627', ['Event']);
+
+    expect(redis.set).toHaveBeenCalledWith('Season:active', '2627');
+    expect(redis.scan).toHaveBeenCalledTimes(SEASON_CACHE_PREFIXES.length);
+    expect(redis.del).toHaveBeenCalledWith('EventOverallResult:2526');
   });
 });

--- a/tests/unit/live-data-cascade.test.ts
+++ b/tests/unit/live-data-cascade.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, mock, test } from 'bun:test';
 
 import {
   enqueueCascadeJobs,
+  enqueueFinalLeagueResultsAfterLiveSync,
   type CascadeEnqueueDeps,
 } from '../../src/services/live-data-cascade.service';
+import type { Event } from '../../src/types';
 
 function createEnqueueMock(): CascadeEnqueueDeps['enqueueEventLiveSummary'] {
   return mock(async () => ({
@@ -65,5 +67,35 @@ describe('event-lives-db cascade enqueue', () => {
     ]);
     expect(enqueueLiveFixtureCache).toHaveBeenCalledWith(12, 'cascade');
     expect(enqueueLiveBonusCache).toHaveBeenCalledWith(12, 'cascade');
+  });
+
+  test('enqueues a distinct final league correction after fresh live data is persisted', async () => {
+    const enqueueLeagueEventResults = mock(async () => ({ id: 'league-final' }));
+
+    const result = await enqueueFinalLeagueResultsAfterLiveSync(12, {
+      getCurrentEvent: async () => ({ id: 12, dataChecked: true }) as Event,
+      findFixturesByEvent: async () => [],
+      getPostMatchResultsSlot: () => 'final-10',
+      enqueueLeagueEventResults,
+    });
+
+    expect(result).toEqual({ id: 'league-final' });
+    expect(enqueueLeagueEventResults).toHaveBeenCalledWith(12, 'cascade', {
+      jobId: 'league-event-results-e12-coordinator-live-final-10',
+    });
+  });
+
+  test('does not enqueue a live-data final correction before data is checked', async () => {
+    const enqueueLeagueEventResults = mock(async () => ({ id: 'unexpected' }));
+
+    const result = await enqueueFinalLeagueResultsAfterLiveSync(12, {
+      getCurrentEvent: async () => ({ id: 12, dataChecked: false }) as Event,
+      findFixturesByEvent: async () => [],
+      getPostMatchResultsSlot: () => 'provisional-10',
+      enqueueLeagueEventResults,
+    });
+
+    expect(result).toBeNull();
+    expect(enqueueLeagueEventResults).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/manual-job-ids.test.ts
+++ b/tests/unit/manual-job-ids.test.ts
@@ -4,6 +4,8 @@ type AddCall = { name: string; data: Record<string, unknown>; opts: Record<strin
 
 const liveDataAddCalls: AddCall[] = [];
 const entrySyncAddCalls: AddCall[] = [];
+const tournamentSyncAddCalls: AddCall[] = [];
+const leagueSyncAddCalls: AddCall[] = [];
 
 mock.module('../../src/queues/live-data.queue', () => ({
   LIVE_JOBS: {
@@ -38,10 +40,49 @@ mock.module('../../src/queues/entry-sync.queue', () => ({
   }),
 }));
 
+mock.module('../../src/queues/tournament-sync.queue', () => ({
+  TOURNAMENT_JOBS: {
+    EVENT_RESULTS: 'tournament-event-results',
+    POINTS_RACE: 'tournament-points-race',
+    BATTLE_RACE: 'tournament-battle-race',
+    KNOCKOUT: 'tournament-knockout',
+    TRANSFERS_POST: 'tournament-transfers-post',
+    CUP_RESULTS: 'tournament-cup-results',
+    SELECTION_STATS: 'tournament-selection-stats',
+    MATERIALIZED_VIEWS_REFRESH: 'tournament-materialized-views-refresh',
+    EVENT_PICKS: 'tournament-event-picks',
+    TRANSFERS_PRE: 'tournament-transfers-pre',
+    INFO: 'tournament-info',
+  },
+  getTournamentSyncQueue: () => ({
+    name: 'tournament-sync-p2',
+    add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
+      tournamentSyncAddCalls.push({ name, data, opts });
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+    },
+  }),
+}));
+
+mock.module('../../src/queues/league-sync.queue', () => ({
+  LEAGUE_JOBS: {
+    LEAGUE_EVENT_PICKS: 'league-event-picks',
+    LEAGUE_EVENT_RESULTS: 'league-event-results',
+  },
+  getLeagueSyncQueue: () => ({
+    name: 'league-sync-p3',
+    add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
+      leagueSyncAddCalls.push({ name, data, opts });
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+    },
+  }),
+}));
+
 const { enqueueEventLivesDbSync, enqueueEventLivesCacheUpdate } = await import(
   '../../src/jobs/live-data.jobs'
 );
 const { enqueueEntryPicksSyncJob } = await import('../../src/jobs/entry-sync-enqueue');
+const { enqueueTournamentEventResults } = await import('../../src/jobs/tournament-sync.jobs');
+const { enqueueLeagueEventResults } = await import('../../src/jobs/league-sync.jobs');
 const { stableHash } = await import('../../src/utils/stable-hash');
 
 describe('live-data manual job IDs', () => {
@@ -164,6 +205,27 @@ describe('entry-sync entry-list job IDs', () => {
     expect(second!.id).toBe(first!.id as string);
     expect(entrySyncAddCalls[0].opts.removeOnComplete).toBe(true);
     expect(entrySyncAddCalls[0].opts.removeOnFail).toBe(true);
+  });
+});
+
+describe('deterministic result job retention', () => {
+  beforeEach(() => {
+    tournamentSyncAddCalls.length = 0;
+    leagueSyncAddCalls.length = 0;
+  });
+
+  test('retains successful jobs for dedupe but removes failed jobs for cron retry', async () => {
+    await enqueueTournamentEventResults(12, 'cron', {
+      jobId: 'tournament-event-results-e12-final-10',
+    });
+    await enqueueLeagueEventResults(12, 'cron', {
+      jobId: 'league-event-results-e12-coordinator-final-10',
+    });
+
+    for (const call of [tournamentSyncAddCalls[0], leagueSyncAddCalls[0]]) {
+      expect(call.opts.removeOnComplete).toEqual({ age: 86_400 });
+      expect(call.opts.removeOnFail).toBe(true);
+    }
   });
 });
 

--- a/tests/unit/post-match-readiness.test.ts
+++ b/tests/unit/post-match-readiness.test.ts
@@ -73,14 +73,40 @@ describe('bounded post-match result slots', () => {
     ).toBe('provisional-1');
   });
 
-  test('uses one final slot after FPL checks the event data', () => {
+  test('keeps final slots hourly after FPL checks the event data', () => {
     expect(
       getPostMatchResultsSlot(
         { dataChecked: true },
         fixtures,
         new Date('2026-08-22T22:00:00.000Z'),
       ),
-    ).toBe('final');
+    ).toBe('final-2');
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: true },
+        fixtures,
+        new Date('2026-08-22T22:50:00.000Z'),
+      ),
+    ).toBe('final-2');
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: true },
+        fixtures,
+        new Date('2026-08-22T23:00:00.000Z'),
+      ),
+    ).toBe('final-3');
+  });
+
+  test('keeps the GW38 final window open on the next UTC day', () => {
+    const gw38Fixtures = [buildFixture('2027-05-23T18:00:00.000Z', 38)];
+
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: true },
+        gw38Fixtures,
+        new Date('2027-05-24T06:35:00.000Z'),
+      ),
+    ).toBe('final-10');
   });
 
   test('closes after 24 hours and rejects missing or invalid kickoff data', () => {

--- a/tests/unit/post-match-readiness.test.ts
+++ b/tests/unit/post-match-readiness.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import {
+  getPostMatchResultsSlot,
+  POST_MATCH_RESULTS_WINDOW_MS,
+} from '../../src/domain/post-match-results';
+import { shouldEnqueueTournamentCascade } from '../../src/domain/tournament-event-results';
+import { shouldRunCurrentEventJob } from '../../src/jobs/current-event-gate';
+import { shouldRunPlayerValuesSync } from '../../src/jobs/player-values-window.jobs';
+import type { Event, Fixture } from '../../src/types';
+
+function buildFixture(kickoffIso: string, id: number): Fixture {
+  return {
+    id,
+    code: id,
+    event: 1,
+    finished: false,
+    finishedProvisional: false,
+    kickoffTime: new Date(kickoffIso),
+    minutes: 0,
+    provisionalStartTime: false,
+    started: null,
+    teamA: 1,
+    teamAScore: null,
+    teamH: 2,
+    teamHScore: null,
+    stats: [],
+    teamHDifficulty: null,
+    teamADifficulty: null,
+    pulseId: id,
+    createdAt: null,
+    updatedAt: null,
+  };
+}
+
+describe('bounded post-match result slots', () => {
+  const fixtures = [
+    buildFixture('2026-08-22T14:00:00.000Z', 1),
+    buildFixture('2026-08-22T18:00:00.000Z', 2),
+  ];
+
+  test('does not open until the final fixture nominally ends', () => {
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: false },
+        fixtures,
+        new Date('2026-08-22T19:59:59.999Z'),
+      ),
+    ).toBeNull();
+  });
+
+  test('maps all cron ticks in an hour to one deterministic provisional slot', () => {
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: false },
+        fixtures,
+        new Date('2026-08-22T20:10:00.000Z'),
+      ),
+    ).toBe('provisional-0');
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: false },
+        fixtures,
+        new Date('2026-08-22T20:50:00.000Z'),
+      ),
+    ).toBe('provisional-0');
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: false },
+        fixtures,
+        new Date('2026-08-22T21:00:00.000Z'),
+      ),
+    ).toBe('provisional-1');
+  });
+
+  test('uses one final slot after FPL checks the event data', () => {
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: true },
+        fixtures,
+        new Date('2026-08-22T22:00:00.000Z'),
+      ),
+    ).toBe('final');
+  });
+
+  test('closes after 24 hours and rejects missing or invalid kickoff data', () => {
+    const matchEndMs = new Date('2026-08-22T20:00:00.000Z').getTime();
+    expect(
+      getPostMatchResultsSlot(
+        { dataChecked: false },
+        fixtures,
+        new Date(matchEndMs + POST_MATCH_RESULTS_WINDOW_MS),
+      ),
+    ).toBeNull();
+    expect(getPostMatchResultsSlot({ dataChecked: false }, [], new Date())).toBeNull();
+    expect(
+      getPostMatchResultsSlot({ dataChecked: false }, [buildFixture('invalid', 3)], new Date()),
+    ).toBeNull();
+  });
+});
+
+describe('current-event job gate', () => {
+  test('does not look up a current event outside the season window', async () => {
+    const isFPLSeason = mock(async () => false);
+    const getCurrentEvent = mock(async () => null);
+
+    expect(
+      await shouldRunCurrentEventJob('player-stats-sync', new Date(), {
+        isFPLSeason,
+        getCurrentEvent,
+      }),
+    ).toBe(false);
+    expect(getCurrentEvent).not.toHaveBeenCalled();
+  });
+
+  test('skips jobs until a current event exists', async () => {
+    expect(
+      await shouldRunCurrentEventJob('player-stats-sync', new Date(), {
+        isFPLSeason: async () => true,
+        getCurrentEvent: async () => null,
+      }),
+    ).toBe(false);
+  });
+
+  test('allows jobs once the season and current event are both active', async () => {
+    expect(
+      await shouldRunCurrentEventJob('player-stats-sync', new Date(), {
+        isFPLSeason: async () => true,
+        getCurrentEvent: async () => ({ id: 1 }) as Event,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('player-values current-event guard', () => {
+  test('does not query daily values when there is no current event', async () => {
+    const hasChangesForDate = mock(async () => false);
+    const shouldRun = await shouldRunPlayerValuesSync(new Date('2026-08-21T01:25:00.000Z'), {
+      shouldRunCurrentEventJob: async () => false,
+      hasChangesForDate,
+    });
+
+    expect(shouldRun).toBe(false);
+    expect(hasChangesForDate).not.toHaveBeenCalled();
+  });
+
+  test('runs only when a current event exists and today has not been recorded', async () => {
+    const date = new Date('2026-08-22T01:25:00.000Z');
+    const shouldRunCurrentEvent = async () => true;
+
+    expect(
+      await shouldRunPlayerValuesSync(date, {
+        shouldRunCurrentEventJob: shouldRunCurrentEvent,
+        hasChangesForDate: async () => true,
+      }),
+    ).toBe(false);
+    expect(
+      await shouldRunPlayerValuesSync(date, {
+        shouldRunCurrentEventJob: shouldRunCurrentEvent,
+        hasChangesForDate: async () => false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('empty tournament result sync', () => {
+  test('does not fan out a cascade when there are no active entries', () => {
+    expect(shouldEnqueueTournamentCascade({ totalEntries: 0 })).toBe(false);
+    expect(shouldEnqueueTournamentCascade({ totalEntries: 2 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- bound tournament and league result scheduling to deterministic hourly/final slots during the first 24 hours after the last fixture
- skip tournament cascades when there are no active tournament entries
- gate player-stat and player-value jobs until a current FPL event exists
- clear all durable season-scoped Redis families when the active season advances

## Root cause

The previous post-match predicate remained true until the next event became current, producing repeated jobs. Current-event consumers could also run on the GW1 kickoff date before FPL exposed a current event, and rollover cleanup only covered the first core cache family written.

## Impact

Live-season schedulers become bounded and idempotent, empty tournament setups do not fan out work, pre-deadline jobs skip safely, and stale prior-season derived caches are removed during rollover.

## Validation

- `bun run test`: 450 passed, 0 failed
- `bun run typecheck`: passed
- `bun run lint`: 0 errors, 7 pre-existing warnings
- `bun run build`: passed for API and worker entry points
- `git diff --check`: passed

Integration tests were not pointed at production; the repository guard requires isolated writable PostgreSQL and Redis test services.