### PR TITLE
Fix 2627 event deadline normalization

### DIFF
--- a/src/cache/events-cache.ts
+++ b/src/cache/events-cache.ts
@@ -1,5 +1,6 @@
 import {
   neighbourEventId,
+  normalizeEventDeadline,
   selectCurrentEventByDeadline,
   selectNextEventByDeadline,
 } from '../domain/events';
@@ -10,21 +11,8 @@ import { redisSingleton } from './singleton';
 
 import type { Event } from '../types';
 
-function normalizeDeadlineTime(event: Event): string | null {
-  if (typeof event.deadlineTime === 'string' && event.deadlineTime.length > 0) {
-    return event.deadlineTime;
-  }
-  if (event.deadlineTimeEpoch) {
-    return new Date(event.deadlineTimeEpoch * 1000).toISOString();
-  }
-  return null;
-}
-
 function serializeEvent(event: Event): string {
-  return JSON.stringify({
-    ...event,
-    deadlineTime: normalizeDeadlineTime(event),
-  });
+  return JSON.stringify(normalizeEventDeadline(event));
 }
 
 async function loadEventsFromCache(): Promise<Event[] | null> {
@@ -39,7 +27,7 @@ async function loadEventsFromCache(): Promise<Event[] | null> {
       return null;
     }
 
-    const events = parseHashValues<Event>(hash, { key });
+    const events = parseHashValues<Event>(hash, { key }).map(normalizeEventDeadline);
     logDebug('Events cache hit', { count: events.length });
     return events;
   } catch (error) {
@@ -81,7 +69,7 @@ async function getNeighbourEvent(offset: number, label: string): Promise<Event |
       logDebug(`${label} event cache miss`, { targetId });
       return null;
     }
-    const event = JSON.parse(value) as Event;
+    const event = normalizeEventDeadline(JSON.parse(value) as Event);
     logDebug(`${label} event cache hit`, { id: event.id });
     return event;
   } catch (error) {
@@ -99,7 +87,7 @@ export const eventsCache = {
       const value = await redis.get(key);
       if (value) {
         logDebug('Current event cache hit (dedicated key)');
-        return JSON.parse(value) as Event;
+        return normalizeEventDeadline(JSON.parse(value) as Event);
       }
       // Fallback: derive from full hash using deadline-based logic
       const allEvents = await loadEventsFromCache();

--- a/src/domain/events.ts
+++ b/src/domain/events.ts
@@ -41,6 +41,40 @@ export function safeValidateEvent(data: unknown): Event | null {
   return result.success ? (result.data as Event) : null;
 }
 
+export function normalizeEventDeadlineTime(
+  deadlineTime: string | null,
+  deadlineTimeEpoch: number | null,
+): string | null {
+  if (typeof deadlineTime === 'string' && deadlineTime.trim().length > 0) {
+    const normalizedInput = deadlineTime
+      .trim()
+      .replace(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})/, '$1T$2')
+      .replace(/([+-]\d{2})$/, '$1:00');
+    const timestamp = Date.parse(normalizedInput);
+    if (Number.isFinite(timestamp)) {
+      const date = new Date(timestamp);
+      if (Number.isFinite(date.getTime())) return date.toISOString();
+    }
+  }
+
+  if (deadlineTimeEpoch !== null && Number.isFinite(deadlineTimeEpoch)) {
+    const timestamp = deadlineTimeEpoch * 1000;
+    if (Number.isFinite(timestamp)) {
+      const date = new Date(timestamp);
+      if (Number.isFinite(date.getTime())) return date.toISOString();
+    }
+  }
+
+  return null;
+}
+
+export function normalizeEventDeadline(event: Event): Event {
+  return {
+    ...event,
+    deadlineTime: normalizeEventDeadlineTime(event.deadlineTime, event.deadlineTimeEpoch),
+  };
+}
+
 export const isCurrent = (event: Event): boolean => event.isCurrent;
 export const isNext = (event: Event): boolean => event.isNext;
 export const isPrevious = (event: Event): boolean => event.isPrevious;

--- a/src/services/events.service.ts
+++ b/src/services/events.service.ts
@@ -1,5 +1,6 @@
 import { eventsCache } from '../cache/operations';
 import { fplClient } from '../clients/fpl';
+import { normalizeEventDeadline } from '../domain/events';
 import { eventRepository } from '../repositories/events';
 import { transformEvents } from '../transformers/events';
 import { resolvePublishedSeasonFromEvents } from './cache-season.service';
@@ -21,13 +22,13 @@ export async function getCurrentEvent(): Promise<Event | null> {
     const cached = await eventsCache.getCurrent();
     if (cached) {
       logDebug('Current event retrieved from cache', { id: cached.id });
-      return cached;
+      return normalizeEventDeadline(cached);
     }
 
     logDebug('Current event cache miss - fetching from database');
     const event = await eventRepository.findCurrent();
     logDebug('Current event fetched from database', { id: event?.id ?? null });
-    return event;
+    return event ? normalizeEventDeadline(event) : null;
   } catch (error) {
     logError('Failed to get current event', error);
     throw error;
@@ -40,13 +41,13 @@ export async function getNextEvent(): Promise<Event | null> {
     const cached = await eventsCache.getNext();
     if (cached) {
       logDebug('Next event retrieved from cache', { id: cached.id });
-      return cached;
+      return normalizeEventDeadline(cached);
     }
 
     logDebug('Next event cache miss - fetching from database');
     const event = await eventRepository.findNext();
     logDebug('Next event fetched from database', { id: event?.id ?? null });
-    return event;
+    return event ? normalizeEventDeadline(event) : null;
   } catch (error) {
     logError('Failed to get next event', error);
     throw error;
@@ -59,13 +60,13 @@ export async function getPreviousEvent(): Promise<Event | null> {
     const cached = await eventsCache.getPrevious();
     if (cached) {
       logDebug('Previous event retrieved from cache', { id: cached.id });
-      return cached;
+      return normalizeEventDeadline(cached);
     }
 
     logDebug('Previous event cache miss - fetching from database');
     const event = await eventRepository.findPrevious();
     logDebug('Previous event fetched from database', { id: event?.id ?? null });
-    return event;
+    return event ? normalizeEventDeadline(event) : null;
   } catch (error) {
     logError('Failed to get previous event', error);
     throw error;

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { selectNextEventByDeadline } from '../../src/domain/events';
+import { normalizeEventDeadlineTime, selectNextEventByDeadline } from '../../src/domain/events';
 import { transformEvents } from '../../src/transformers/events';
 import {
   rawFPLEventsFixture,
@@ -10,6 +10,18 @@ import {
 } from '../fixtures/events.fixtures';
 
 describe('Events Unit Tests', () => {
+  describe('deadline normalization', () => {
+    test.each([
+      ['RFC3339', '2026-08-21T17:30:00Z', null, '2026-08-21T17:30:00.000Z'],
+      ['PostgreSQL', '2026-08-21 17:30:00+00', null, '2026-08-21T17:30:00.000Z'],
+      ['null', null, null, null],
+      ['invalid with epoch fallback', 'not-a-date', 1_787_333_400, '2026-08-21T17:30:00.000Z'],
+      ['invalid without epoch', 'not-a-date', null, null],
+    ])('normalizes a %s deadline', (_label, deadline, epoch, expected) => {
+      expect(normalizeEventDeadlineTime(deadline, epoch)).toBe(expected);
+    });
+  });
+
   describe('transformEvents Function', () => {
     test('should transform single event correctly', () => {
       const result = transformEvents([singleRawEventFixture]);


### PR DESCRIPTION
## Summary\n- canonicalize parseable event deadlines to UTC RFC3339\n- fall back to deadlineTimeEpoch for invalid stored strings\n- normalize both cache writes and event API reads\n\n## Verification\n- lint and typecheck\n- 459 unit tests\n- production build\n- Drizzle schema check and migration status\n- focused ISO, PostgreSQL, null, epoch fallback, and invalid deadline tests