### PR TITLE
Add secure tournament management API

### DIFF
--- a/src/api/tournaments.api.ts
+++ b/src/api/tournaments.api.ts
@@ -8,6 +8,7 @@ import {
 } from '../services/tournament-create.service';
 import { validateTournamentCreateInput } from '../domain/tournament';
 import { requeueTournamentSetup } from '../services/tournament-setup.service';
+import { tournamentManagementService } from '../services/tournament-management.service';
 import { getErrorMessage, getHttpStatusFromError } from '../utils/errors';
 
 function mapErrorToResponse(error: unknown): { status: number; message: string } {
@@ -90,19 +91,66 @@ export const tournamentsAPI = new Elysia({ prefix: '/tournaments' })
     },
     {
       body: t.Object({
-        tournamentName: t.String(),
+        tournamentName: t.String({ minLength: 3, maxLength: 80 }),
         adminId: t.String(),
-        creator: t.String(),
+        creator: t.String({ minLength: 1, maxLength: 80 }),
         participantSource: t.Union([t.Literal('official'), t.Literal('custom')]),
         tournamentType: t.Optional(t.String()),
-        leagueUrl: t.String(),
+        leagueUrl: t.String({ minLength: 1, maxLength: 512 }),
         groupFormat: t.Union([t.Literal('none'), t.Literal('points')]),
         startGameweek: t.String(),
         endGameweek: t.String(),
         groupNum: t.Optional(t.String()),
         qualifiersPerGroup: t.Optional(t.String()),
         knockoutFormat: t.Union([t.Literal('none'), t.Literal('single'), t.Literal('double')]),
-        selectedParticipantIds: t.Optional(t.Array(t.String())),
+        selectedParticipantIds: t.Optional(t.Array(t.String(), { maxItems: 5000 })),
       }),
+    },
+  )
+  .patch(
+    '/:tournamentId',
+    async ({ params, body, set }) => {
+      try {
+        const tournament = await tournamentManagementService.updateTournament(
+          params.tournamentId,
+          body,
+        );
+        return { success: true, tournament };
+      } catch (error) {
+        const { status, message } = mapErrorToResponse(error);
+        set.status = status;
+        return { success: false, error: message };
+      }
+    },
+    {
+      params: t.Object({ tournamentId: t.Numeric() }),
+      body: t.Object({
+        name: t.String({ minLength: 3, maxLength: 80 }),
+        adminEntryId: t.Numeric(),
+      }),
+    },
+  )
+  .delete(
+    '/:tournamentId',
+    async ({ params, body, set }) => {
+      try {
+        const tournament = await tournamentManagementService.deleteTournament(
+          params.tournamentId,
+          body,
+        );
+        return {
+          success: true,
+          tournamentId: tournament.id,
+          deletedName: tournament.name,
+        };
+      } catch (error) {
+        const { status, message } = mapErrorToResponse(error);
+        set.status = status;
+        return { success: false, error: message };
+      }
+    },
+    {
+      params: t.Object({ tournamentId: t.Numeric() }),
+      body: t.Object({ adminEntryId: t.Numeric() }),
     },
   );

--- a/src/domain/tournament.ts
+++ b/src/domain/tournament.ts
@@ -6,21 +6,67 @@ export const MAX_RANK = 2147483647;
 
 const FPL_HOSTNAME = 'fantasy.premierleague.com';
 
-export const tournamentCreateInputSchema = z.object({
-  tournamentName: z.string().min(3),
-  adminId: z.string().regex(/^\d+$/),
-  creator: z.string().trim().min(1),
-  participantSource: z.enum(['official', 'custom']),
-  tournamentType: z.string().optional(),
-  leagueUrl: z.string().url(),
-  groupFormat: z.enum(['none', 'points']),
-  startGameweek: z.string(),
-  endGameweek: z.string(),
-  groupNum: z.string().optional(),
-  qualifiersPerGroup: z.string().optional(),
-  knockoutFormat: z.enum(['none', 'single', 'double']),
-  selectedParticipantIds: z.array(z.string()).optional(),
-});
+const gameweekSchema = z.string().regex(/^GW(?:[1-9]|[12]\d|3[0-8])$/i);
+const optionalPositiveIntegerStringSchema = z.union([
+  z.literal(''),
+  z.string().regex(/^[1-9]\d*$/),
+]);
+
+export const tournamentCreateInputSchema = z
+  .object({
+    tournamentName: z.string().trim().min(3).max(80),
+    adminId: z.string().regex(/^\d+$/),
+    creator: z.string().trim().min(1).max(80),
+    participantSource: z.enum(['official', 'custom']),
+    tournamentType: z.literal('standard').optional(),
+    leagueUrl: z
+      .string()
+      .max(512)
+      .url()
+      .refine((value) => {
+        const url = new URL(value);
+        return url.protocol === 'https:' && url.hostname === FPL_HOSTNAME;
+      }, 'Only secure Fantasy Premier League URLs are allowed.'),
+    groupFormat: z.enum(['none', 'points']),
+    startGameweek: gameweekSchema,
+    endGameweek: gameweekSchema,
+    groupNum: optionalPositiveIntegerStringSchema.optional(),
+    qualifiersPerGroup: optionalPositiveIntegerStringSchema.optional(),
+    knockoutFormat: z.enum(['none', 'single', 'double']),
+    selectedParticipantIds: z
+      .array(z.string().regex(/^[1-9]\d*$/))
+      .max(5000)
+      .optional(),
+  })
+  .superRefine((values, context) => {
+    const startGameweek = parseGameweek(values.startGameweek);
+    const endGameweek = parseGameweek(values.endGameweek);
+    if (!startGameweek || !endGameweek || endGameweek < startGameweek) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['endGameweek'],
+        message: 'End gameweek must be on or after the start gameweek.',
+      });
+    }
+    if (values.groupFormat === 'points' && !values.groupNum) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['groupNum'],
+        message: 'Group number is required for a points race.',
+      });
+    }
+    if (
+      values.groupFormat === 'points' &&
+      values.knockoutFormat !== 'none' &&
+      !values.qualifiersPerGroup
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['qualifiersPerGroup'],
+        message: 'Qualifiers per group are required for a knockout phase.',
+      });
+    }
+  });
 
 export type TournamentCreateInput = z.infer<typeof tournamentCreateInputSchema>;
 export type TournamentSetupStatus = 'pending' | 'processing' | 'ready' | 'failed';

--- a/src/repositories/tournament-management.ts
+++ b/src/repositories/tournament-management.ts
@@ -1,0 +1,187 @@
+import { getDbClient } from '../db/singleton';
+import { ConflictError, DatabaseError } from '../utils/errors';
+import { logError, logInfo } from '../utils/logger';
+
+export interface TournamentManagementRecord {
+  id: number;
+  name: string;
+  creator: string;
+  adminEntryId: number;
+  totalTeamNum: number;
+  state: 'active' | 'inactive' | 'finished';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type TournamentDeleteResult =
+  | { status: 'deleted'; tournament: TournamentManagementRecord }
+  | { status: 'not_found' }
+  | { status: 'forbidden' };
+
+type TournamentManagementDatabaseRow = {
+  id: number;
+  name: string;
+  creator: string;
+  admin_entry_id: number;
+  total_team_num: number;
+  state: 'active' | 'inactive' | 'finished';
+  created_at: string;
+  updated_at: string;
+};
+
+function mapRecord(row: TournamentManagementDatabaseRow): TournamentManagementRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    creator: row.creator,
+    adminEntryId: row.admin_entry_id,
+    totalTeamNum: row.total_team_num,
+    state: row.state,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === '23505');
+}
+
+export const createTournamentManagementRepository = () => ({
+  findById: async (tournamentId: number): Promise<TournamentManagementRecord | null> => {
+    try {
+      const client = await getDbClient();
+      const rows = await client<TournamentManagementDatabaseRow[]>`
+        select
+          id,
+          name,
+          creator,
+          admin_entry_id,
+          total_team_num,
+          state,
+          created_at::text,
+          updated_at::text
+        from tournament_infos
+        where id = ${tournamentId}
+        limit 1
+      `;
+      return rows[0] ? mapRecord(rows[0]) : null;
+    } catch (error) {
+      logError('Failed to retrieve tournament management record', error, { tournamentId });
+      throw new DatabaseError(
+        'Failed to retrieve tournament.',
+        'TOURNAMENT_MANAGEMENT_FIND_ERROR',
+        error as Error,
+      );
+    }
+  },
+
+  checkNameExistsExcluding: async (name: string, tournamentId: number): Promise<boolean> => {
+    try {
+      const client = await getDbClient();
+      const rows = await client<{ exists: boolean }[]>`
+        select exists(
+          select 1
+          from tournament_infos
+          where name = ${name} and id <> ${tournamentId}
+        ) as exists
+      `;
+      return rows[0]?.exists === true;
+    } catch (error) {
+      logError('Failed to check tournament management name', error, { tournamentId });
+      throw new DatabaseError(
+        'Failed to check tournament name.',
+        'TOURNAMENT_MANAGEMENT_NAME_CHECK_ERROR',
+        error as Error,
+      );
+    }
+  },
+
+  updateNameOwned: async (
+    tournamentId: number,
+    adminEntryId: number,
+    name: string,
+  ): Promise<TournamentManagementRecord | null> => {
+    try {
+      const client = await getDbClient();
+      const rows = await client<TournamentManagementDatabaseRow[]>`
+        update tournament_infos
+        set name = ${name}, updated_at = now()
+        where id = ${tournamentId} and admin_entry_id = ${adminEntryId}
+        returning
+          id,
+          name,
+          creator,
+          admin_entry_id,
+          total_team_num,
+          state,
+          created_at::text,
+          updated_at::text
+      `;
+      if (!rows[0]) return null;
+      logInfo('Updated tournament name', { tournamentId, adminEntryId });
+      return mapRecord(rows[0]);
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new ConflictError('Tournament name already exists.', 'TOURNAMENT_NAME_EXISTS');
+      }
+      logError('Failed to update tournament name', error, { tournamentId, adminEntryId });
+      throw new DatabaseError(
+        'Failed to update tournament.',
+        'TOURNAMENT_MANAGEMENT_UPDATE_ERROR',
+        error as Error,
+      );
+    }
+  },
+
+  deleteOwned: async (
+    tournamentId: number,
+    adminEntryId: number,
+  ): Promise<TournamentDeleteResult> => {
+    try {
+      const client = await getDbClient();
+      const result = await client.begin(async (tx) => {
+        const rows = await tx<TournamentManagementDatabaseRow[]>`
+          select
+            id,
+            name,
+            creator,
+            admin_entry_id,
+            total_team_num,
+            state,
+            created_at::text,
+            updated_at::text
+          from tournament_infos
+          where id = ${tournamentId}
+          for update
+        `;
+        const row = rows[0];
+        if (!row) return { status: 'not_found' } as const;
+        if (row.admin_entry_id !== adminEntryId) return { status: 'forbidden' } as const;
+
+        await tx`delete from tournament_selection_stats where tournament_id = ${tournamentId}`;
+        await tx`delete from tournament_knockout_results where tournament_id = ${tournamentId}`;
+        await tx`delete from tournament_knockouts where tournament_id = ${tournamentId}`;
+        await tx`delete from tournament_battle_group_results where tournament_id = ${tournamentId}`;
+        await tx`delete from tournament_points_group_results where tournament_id = ${tournamentId}`;
+        await tx`delete from tournament_groups where tournament_id = ${tournamentId}`;
+        await tx`delete from tournament_entries where tournament_id = ${tournamentId}`;
+        await tx`delete from tournament_infos where id = ${tournamentId}`;
+
+        return { status: 'deleted', tournament: mapRecord(row) } as const;
+      });
+      if (result.status === 'deleted') {
+        logInfo('Deleted tournament and related data', { tournamentId, adminEntryId });
+      }
+      return result;
+    } catch (error) {
+      logError('Failed to delete tournament', error, { tournamentId, adminEntryId });
+      throw new DatabaseError(
+        'Failed to delete tournament.',
+        'TOURNAMENT_MANAGEMENT_DELETE_ERROR',
+        error as Error,
+      );
+    }
+  },
+});
+
+export const tournamentManagementRepository = createTournamentManagementRepository();

--- a/src/services/tournament-management.service.ts
+++ b/src/services/tournament-management.service.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+
+import {
+  tournamentManagementRepository,
+  type TournamentManagementRecord,
+} from '../repositories/tournament-management';
+import { normalizeTournamentName } from '../domain/tournament';
+import { ConflictError, ForbiddenError, NotFoundError } from '../utils/errors';
+
+const updateTournamentSchema = z.object({
+  name: z.string().trim().min(3).max(80),
+  adminEntryId: z.number().int().positive(),
+});
+
+const deleteTournamentSchema = z.object({
+  adminEntryId: z.number().int().positive(),
+});
+
+export type TournamentManagementRepository = {
+  findById(tournamentId: number): Promise<TournamentManagementRecord | null>;
+  checkNameExistsExcluding(name: string, tournamentId: number): Promise<boolean>;
+  updateNameOwned(
+    tournamentId: number,
+    adminEntryId: number,
+    name: string,
+  ): Promise<TournamentManagementRecord | null>;
+  deleteOwned(
+    tournamentId: number,
+    adminEntryId: number,
+  ): Promise<
+    | { status: 'deleted'; tournament: TournamentManagementRecord }
+    | { status: 'not_found' }
+    | { status: 'forbidden' }
+  >;
+};
+
+export function createTournamentManagementService(repository: TournamentManagementRepository) {
+  const assertOwner = async (tournamentId: number, adminEntryId: number) => {
+    const tournament = await repository.findById(tournamentId);
+    if (!tournament) {
+      throw new NotFoundError('Tournament not found.', 'TOURNAMENT_NOT_FOUND');
+    }
+    if (tournament.adminEntryId !== adminEntryId) {
+      throw new ForbiddenError(
+        'Only the tournament administrator can manage this tournament.',
+        'TOURNAMENT_ADMIN_REQUIRED',
+      );
+    }
+    return tournament;
+  };
+
+  return {
+    updateTournament: async (tournamentId: number, input: unknown) => {
+      const payload = updateTournamentSchema.parse(input);
+      const current = await assertOwner(tournamentId, payload.adminEntryId);
+      const name = normalizeTournamentName(payload.name);
+      if (current.name === name) return current;
+      if (await repository.checkNameExistsExcluding(name, tournamentId)) {
+        throw new ConflictError('Tournament name already exists.', 'TOURNAMENT_NAME_EXISTS');
+      }
+      const updated = await repository.updateNameOwned(tournamentId, payload.adminEntryId, name);
+      if (!updated) {
+        throw new NotFoundError('Tournament not found.', 'TOURNAMENT_NOT_FOUND');
+      }
+      return updated;
+    },
+
+    deleteTournament: async (tournamentId: number, input: unknown) => {
+      const payload = deleteTournamentSchema.parse(input);
+      const result = await repository.deleteOwned(tournamentId, payload.adminEntryId);
+      if (result.status === 'not_found') {
+        throw new NotFoundError('Tournament not found.', 'TOURNAMENT_NOT_FOUND');
+      }
+      if (result.status === 'forbidden') {
+        throw new ForbiddenError(
+          'Only the tournament administrator can delete this tournament.',
+          'TOURNAMENT_ADMIN_REQUIRED',
+        );
+      }
+      return result.tournament;
+    },
+  };
+}
+
+export const tournamentManagementService = createTournamentManagementService(
+  tournamentManagementRepository,
+);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -70,6 +70,18 @@ export class ConflictError extends Error implements APIError {
   }
 }
 
+export class ForbiddenError extends Error implements APIError {
+  public readonly status = 403;
+  constructor(
+    message: string,
+    public code?: string,
+    public details?: unknown,
+  ) {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
 // Error handling utilities
 export function isAPIError(error: unknown): error is APIError {
   return error instanceof Error && 'status' in error;
@@ -79,6 +91,7 @@ export function getHttpStatusFromError(error: unknown): number {
   if (error instanceof ValidationError) return error.status;
   if (error instanceof NotFoundError) return error.status;
   if (error instanceof ConflictError) return error.status;
+  if (error instanceof ForbiddenError) return error.status;
   if (isAPIError(error) && typeof error.status === 'number') return error.status;
   return 500;
 }

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -120,11 +120,20 @@ const managedTournament = {
   createdAt: '2026-08-01T00:00:00.000Z',
   updatedAt: '2026-08-02T00:00:00.000Z',
 };
-const updateTournament = mock(async () => managedTournament);
-const deleteTournament = mock(async () => managedTournament);
-mock.module('../../src/services/tournament-management.service', () => ({
-  tournamentManagementService: { updateTournament, deleteTournament },
-}));
+// Spy on the singleton instead of replacing the whole module. Bun shares the
+// module mock registry across test files, and a partial mock here would hide
+// createTournamentManagementService from tournament-management.test.ts.
+const tournamentManagementServiceModule = await import(
+  '../../src/services/tournament-management.service'
+);
+const updateTournament = spyOn(
+  tournamentManagementServiceModule.tournamentManagementService,
+  'updateTournament',
+).mockImplementation(async () => managedTournament);
+const deleteTournament = spyOn(
+  tournamentManagementServiceModule.tournamentManagementService,
+  'deleteTournament',
+).mockImplementation(async () => managedTournament);
 
 const syncEntryInfo = mock(async (entryId: number) => ({ id: entryId, name: 'Test' }));
 mock.module('../../src/services/entry-info.service', () => ({

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -110,6 +110,22 @@ mock.module('../../src/services/tournament-create.service', () => ({
   getTournamentSetupStatus,
 }));
 
+const managedTournament = {
+  id: 55,
+  name: 'Managed Cup',
+  creator: 'Manager',
+  adminEntryId: 123,
+  totalTeamNum: 8,
+  state: 'active' as const,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-02T00:00:00.000Z',
+};
+const updateTournament = mock(async () => managedTournament);
+const deleteTournament = mock(async () => managedTournament);
+mock.module('../../src/services/tournament-management.service', () => ({
+  tournamentManagementService: { updateTournament, deleteTournament },
+}));
+
 const syncEntryInfo = mock(async (entryId: number) => ({ id: entryId, name: 'Test' }));
 mock.module('../../src/services/entry-info.service', () => ({
   syncEntryInfo,
@@ -406,6 +422,10 @@ describe('tournamentsAPI handlers', () => {
   beforeEach(() => {
     checkTournamentNameAvailability.mockClear();
     getTournamentSetupStatus.mockClear();
+    updateTournament.mockClear();
+    deleteTournament.mockClear();
+    updateTournament.mockImplementation(async () => managedTournament);
+    deleteTournament.mockImplementation(async () => managedTournament);
   });
 
   test('GET /tournaments/check-name returns availability', async () => {
@@ -445,6 +465,62 @@ describe('tournamentsAPI handlers', () => {
     expect(JSON.stringify(body)).not.toContain('internal-host');
 
     getTournamentSetupStatus.mockImplementation(async () => null);
+  });
+
+  test('PATCH /tournaments/:id forwards a validated management command', async () => {
+    const response = await tournamentsAPI.handle(
+      new Request('http://localhost/tournaments/55', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Managed Cup', adminEntryId: 123 }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, tournament: managedTournament });
+    expect(updateTournament).toHaveBeenCalledWith(55, {
+      name: 'Managed Cup',
+      adminEntryId: 123,
+    });
+  });
+
+  test('DELETE /tournaments/:id forwards ownership and returns a bounded receipt', async () => {
+    const response = await tournamentsAPI.handle(
+      new Request('http://localhost/tournaments/55', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ adminEntryId: 123 }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      tournamentId: 55,
+      deletedName: 'Managed Cup',
+    });
+    expect(deleteTournament).toHaveBeenCalledWith(55, { adminEntryId: 123 });
+  });
+
+  test('maps management ownership failures to 403', async () => {
+    deleteTournament.mockImplementationOnce(async () => {
+      throw Object.assign(
+        new Error('Only the tournament administrator can delete this tournament.'),
+        {
+          status: 403,
+        },
+      );
+    });
+    const response = await tournamentsAPI.handle(
+      new Request('http://localhost/tournaments/55', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ adminEntryId: 999 }),
+      }),
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: 'Only the tournament administrator can delete this tournament.',
+    });
   });
 });
 

--- a/tests/unit/tournament-domain.test.ts
+++ b/tests/unit/tournament-domain.test.ts
@@ -5,6 +5,7 @@ import {
   parseLeagueUrl,
   planTournamentStructure,
   seedBracketEntries,
+  tournamentCreateInputSchema,
   type TournamentConfig,
   type TournamentCreateInput,
   type TournamentParticipant,
@@ -143,5 +144,45 @@ describe('planTournamentStructure', () => {
     expect(() =>
       planTournamentStructure(basePayload, participants([1, 2, 3]), 1, 'classic'),
     ).toThrow(ValidationError);
+  });
+});
+
+describe('tournamentCreateInputSchema', () => {
+  const validPayload = {
+    tournamentName: 'Test Cup',
+    adminId: '1',
+    creator: 'admin',
+    participantSource: 'custom' as const,
+    tournamentType: 'standard' as const,
+    leagueUrl: 'https://fantasy.premierleague.com/leagues/1/standings/c',
+    groupFormat: 'points' as const,
+    startGameweek: 'GW1',
+    endGameweek: 'GW10',
+    groupNum: '2',
+    qualifiersPerGroup: '2',
+    knockoutFormat: 'single' as const,
+    selectedParticipantIds: ['1', '2', '3', '4'],
+  };
+
+  test('accepts a bounded tournament payload', () => {
+    expect(tournamentCreateInputSchema.safeParse(validPayload).success).toBe(true);
+  });
+
+  test('rejects invalid numeric fields, insecure URLs, and reversed gameweeks', () => {
+    const result = tournamentCreateInputSchema.safeParse({
+      ...validPayload,
+      leagueUrl: 'http://fantasy.premierleague.com/leagues/1/standings/c',
+      startGameweek: 'GW12',
+      endGameweek: 'GW4',
+      groupNum: 'not-a-number',
+      qualifiersPerGroup: '0',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(new Set(result.error.issues.map((issue) => issue.path[0]))).toEqual(
+        new Set(['leagueUrl', 'endGameweek', 'groupNum', 'qualifiersPerGroup']),
+      );
+    }
   });
 });

--- a/tests/unit/tournament-management.test.ts
+++ b/tests/unit/tournament-management.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { TournamentManagementRecord } from '../../src/repositories/tournament-management';
+import {
+  createTournamentManagementService,
+  type TournamentManagementRepository,
+} from '../../src/services/tournament-management.service';
+import { ConflictError, ForbiddenError, NotFoundError } from '../../src/utils/errors';
+
+const tournament: TournamentManagementRecord = {
+  id: 42,
+  name: 'Original Cup',
+  creator: 'Manager',
+  adminEntryId: 123,
+  totalTeamNum: 8,
+  state: 'active',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+};
+
+function createRepository(
+  overrides: Partial<TournamentManagementRepository> = {},
+): TournamentManagementRepository {
+  return {
+    findById: async () => tournament,
+    checkNameExistsExcluding: async () => false,
+    updateNameOwned: async (_id, _adminEntryId, name) => ({ ...tournament, name }),
+    deleteOwned: async () => ({ status: 'deleted', tournament }),
+    ...overrides,
+  };
+}
+
+describe('tournament management service', () => {
+  test('updates only an administrator-owned tournament and trims the name', async () => {
+    let updatedName = '';
+    const service = createTournamentManagementService(
+      createRepository({
+        updateNameOwned: async (_id, _adminEntryId, name) => {
+          updatedName = name;
+          return { ...tournament, name };
+        },
+      }),
+    );
+
+    const updated = await service.updateTournament(42, {
+      name: '  Renamed Cup  ',
+      adminEntryId: 123,
+    });
+
+    expect(updated.name).toBe('Renamed Cup');
+    expect(updatedName).toBe('Renamed Cup');
+  });
+
+  test('rejects updates from a different FPL entry', async () => {
+    const service = createTournamentManagementService(createRepository());
+    await expect(
+      service.updateTournament(42, { name: 'Renamed Cup', adminEntryId: 999 }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  test('rejects a duplicate tournament name', async () => {
+    const service = createTournamentManagementService(
+      createRepository({ checkNameExistsExcluding: async () => true }),
+    );
+    await expect(
+      service.updateTournament(42, { name: 'Existing Cup', adminEntryId: 123 }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  test('returns not found when the tournament does not exist', async () => {
+    const service = createTournamentManagementService(
+      createRepository({ findById: async () => null }),
+    );
+    await expect(
+      service.updateTournament(42, { name: 'Renamed Cup', adminEntryId: 123 }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test('deletes an owned tournament', async () => {
+    const service = createTournamentManagementService(createRepository());
+    const deleted = await service.deleteTournament(42, { adminEntryId: 123 });
+    expect(deleted).toEqual(tournament);
+  });
+
+  test('rejects deletion from a different FPL entry', async () => {
+    const service = createTournamentManagementService(
+      createRepository({ deleteOwned: async () => ({ status: 'forbidden' }) }),
+    );
+    await expect(service.deleteTournament(42, { adminEntryId: 999 })).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add administrator-owned tournament rename and transactional delete endpoints
- enforce bounded validation, ownership checks, and safe error mapping
- tighten tournament creation contracts and add domain/service/handler coverage

## Verification
- 470 unit tests passed
- focused tournament/API suite: 48 passed
- lint: 0 errors (7 pre-existing warnings)
- TypeScript and production build passed