### PR TITLE
Fix preseason synchronization and player price propagation

### DIFF
--- a/src/api/jobs.api.ts
+++ b/src/api/jobs.api.ts
@@ -17,11 +17,11 @@ export const jobsAPI = new Elysia({ prefix: '/jobs' })
     return { success: true, jobs, count: jobs.length };
   })
 
-  .post('/:name/trigger', async ({ params, set }) => {
+  .post('/:name/trigger', async ({ params, body, set }) => {
     const { name } = params;
 
     try {
-      const result = await triggerJob(name);
+      const result = await triggerJob(name, body);
 
       if (result.kind === 'event-current-refresh') {
         return {

--- a/src/api/player-values.api.ts
+++ b/src/api/player-values.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { syncCurrentPlayerValues } from '../services/player-values.service';
+import { enqueuePlayerValuesSyncJob } from '../jobs/data-sync-enqueue';
 
 /**
  * Player Values API Routes
@@ -12,11 +12,15 @@ import { syncCurrentPlayerValues } from '../services/player-values.service';
  * Each record is uniquely identified by (elementId, changeDate).
  */
 
-export const playerValuesAPI = new Elysia({ prefix: '/player-values' }).post('/sync', async () => {
-  const result = await syncCurrentPlayerValues();
-  return {
-    success: true,
-    message: 'Current player values sync completed',
-    data: result,
-  };
-});
+export const playerValuesAPI = new Elysia({ prefix: '/player-values' }).post(
+  '/sync',
+  async ({ set }) => {
+    const job = await enqueuePlayerValuesSyncJob('api');
+    set.status = 202;
+    return {
+      success: true,
+      message: 'Player values sync job enqueued',
+      jobId: job.id,
+    };
+  },
+);

--- a/src/api/players.api.ts
+++ b/src/api/players.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { syncPlayers } from '../services/players.service';
+import { enqueuePlayersSyncJob } from '../jobs/data-sync-enqueue';
 
 /**
  * Players API Routes
@@ -9,7 +9,8 @@ import { syncPlayers } from '../services/players.service';
  * - POST /players/sync - Trigger players sync
  */
 
-export const playersAPI = new Elysia({ prefix: '/players' }).post('/sync', async () => {
-  const result = await syncPlayers();
-  return { success: true, message: 'Players sync completed', ...result };
+export const playersAPI = new Elysia({ prefix: '/players' }).post('/sync', async ({ set }) => {
+  const job = await enqueuePlayersSyncJob('api');
+  set.status = 202;
+  return { success: true, message: 'Players sync job enqueued', jobId: job.id };
 });

--- a/src/cache/player-stats-cache.ts
+++ b/src/cache/player-stats-cache.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import { CacheError } from '../utils/errors';
 import { logDebug, logError } from '../utils/logger';
 import { getActiveCacheSeason } from './cache-season';
@@ -46,9 +48,18 @@ export const createPlayerStatsHashCache = () => {
     },
 
     setPlayerStatsByEvent: async (eventId: EventId, playerStats: PlayerStat[]): Promise<void> => {
+      if (playerStats.length === 0) {
+        throw new CacheError(
+          `Refusing to publish an empty player stats view for event: ${eventId}`,
+          'PLAYER_STATS_EMPTY_VIEW_ERROR',
+        );
+      }
+
+      let stagingKey: string | null = null;
       try {
         const redis = await redisSingleton.getClient();
         const key = await getHashKey();
+        stagingKey = `${key}:staging:${randomUUID()}`;
 
         const hashEntries: Record<string, string> = {};
         for (const playerStat of playerStats) {
@@ -57,18 +68,23 @@ export const createPlayerStatsHashCache = () => {
           }
         }
 
-        const pipeline = redis.pipeline();
-        pipeline.del(key);
-
-        if (Object.keys(hashEntries).length === 0) {
-          await pipeline.exec();
-          logDebug('Player stats cache cleared (no entries to set)', { key, eventId });
-          return;
+        const expectedFields = Object.keys(hashEntries).length;
+        if (expectedFields !== playerStats.length) {
+          throw new Error('Player stats contain duplicate element IDs');
         }
 
-        pipeline.hset(key, hashEntries);
-
-        await pipeline.exec();
+        // Build a complete staging hash, verify it, then atomically rename it
+        // over the latest view. Readers see either the old complete view or
+        // the new complete view, never a delete/rebuild gap.
+        await redis.hset(stagingKey, hashEntries);
+        const stagedFields = await redis.hlen(stagingKey);
+        if (stagedFields !== expectedFields) {
+          throw new Error(
+            `Incomplete player stats staging hash: expected ${expectedFields}, got ${stagedFields}`,
+          );
+        }
+        await redis.rename(stagingKey, key);
+        stagingKey = null;
         logDebug('Player stats cache batch set by event', {
           key,
           eventId,
@@ -76,6 +92,14 @@ export const createPlayerStatsHashCache = () => {
           elementIds: Object.keys(hashEntries).slice(0, 5),
         });
       } catch (error) {
+        if (stagingKey) {
+          try {
+            const redis = await redisSingleton.getClient();
+            await redis.del(stagingKey);
+          } catch {
+            // Preserve the original publication failure.
+          }
+        }
         logError('Player stats cache batch set by event error', error, {
           eventId,
           count: playerStats.length,

--- a/src/cache/player-values-cache.ts
+++ b/src/cache/player-values-cache.ts
@@ -1,8 +1,13 @@
 import { logDebug, logError } from '../utils/logger';
-import { parseHashValues } from './hash-read';
+import { parseHashEntries, parseHashValues } from './hash-read';
 import { redisSingleton } from './singleton';
 
 import type { PlayerValue } from '../domain/player-values';
+
+export type PlayerValueCacheSnapshot = {
+  fields: string[];
+  entries: Array<[field: string, value: PlayerValue]>;
+};
 
 export const playerValuesCache = {
   /**
@@ -54,6 +59,42 @@ export const playerValuesCache = {
     } catch (error) {
       logError('Player values cache get error', error);
       return null;
+    }
+  },
+
+  /** Read both raw field names and valid values so repair can fix the key set. */
+  async inspect(changeDate: string): Promise<PlayerValueCacheSnapshot> {
+    try {
+      const redis = await redisSingleton.getClient();
+      const key = `PlayerValue:${changeDate}`;
+      const hash = await redis.hgetall(key);
+      return {
+        fields: Object.keys(hash),
+        entries: parseHashEntries<PlayerValue>(hash, { key, changeDate }),
+      };
+    } catch (error) {
+      logError('Player values cache inspect error', error, { changeDate });
+      throw error;
+    }
+  },
+
+  /** Remove only fields that cannot be backed by persisted rows. */
+  async deleteFields(changeDate: string, fields: string[]): Promise<void> {
+    if (fields.length === 0) {
+      return;
+    }
+
+    try {
+      const redis = await redisSingleton.getClient();
+      const key = `PlayerValue:${changeDate}`;
+      await redis.hdel(key, ...fields);
+      logDebug('Player values cache stale fields deleted', {
+        changeDate,
+        count: fields.length,
+      });
+    } catch (error) {
+      logError('Player values cache field deletion error', error, { changeDate, fields });
+      throw error;
     }
   },
 

--- a/src/cache/player-values-cache.ts
+++ b/src/cache/player-values-cache.ts
@@ -5,39 +5,6 @@ import { redisSingleton } from './singleton';
 import type { PlayerValue } from '../domain/player-values';
 
 export const playerValuesCache = {
-  // Store player values by changeDate: PlayerValue:{changeDate}
-  // Replaces the whole hash (use after a full re-read of the date, or clear).
-  async set(changeDate: string, playerValues: PlayerValue[]): Promise<void> {
-    try {
-      const redis = await redisSingleton.getClient();
-      const key = `PlayerValue:${changeDate}`;
-      // PlayerValueMissing:* is written by an external consumer; delete it here
-      // defensively whenever we refresh the real PlayerValue hash for that date.
-      const missingKey = `PlayerValueMissing:${changeDate}`;
-
-      // Use pipeline for atomic operation
-      const pipeline = redis.pipeline();
-
-      // Clear existing hash
-      pipeline.del(key, missingKey);
-
-      if (playerValues.length > 0) {
-        // Store each player value as a hash field (element ID -> full player value JSON)
-        const valueFields: Record<string, string> = {};
-        for (const playerValue of playerValues) {
-          valueFields[playerValue.elementId.toString()] = JSON.stringify(playerValue);
-        }
-        pipeline.hset(key, valueFields);
-      }
-
-      await pipeline.exec();
-      logDebug('Player values cache updated (hash)', { count: playerValues.length, changeDate });
-    } catch (error) {
-      logError('Player values cache set error', error);
-      throw error;
-    }
-  },
-
   /**
    * Merge fields into PlayerValue:{date} without deleting the existing hash.
    * Used after partial ON CONFLICT DO NOTHING inserts so concurrent daily syncs
@@ -55,10 +22,11 @@ export const playerValuesCache = {
       for (const playerValue of playerValues) {
         valueFields[playerValue.elementId.toString()] = JSON.stringify(playerValue);
       }
-      const pipeline = redis.pipeline();
-      pipeline.del(missingKey);
-      pipeline.hset(key, valueFields);
-      await pipeline.exec();
+      // HSET first so a WRONGTYPE/OOM/network failure leaves the negative
+      // marker intact and rejects the job. The marker is cleared only after
+      // positive history fields were successfully written.
+      await redis.hset(key, valueFields);
+      await redis.del(missingKey);
       logDebug('Player values cache merged (hash fields)', {
         count: playerValues.length,
         changeDate,

--- a/src/cache/players-cache.ts
+++ b/src/cache/players-cache.ts
@@ -150,8 +150,15 @@ const createPlayerHashCache = () => {
       }
     },
 
-    /** Merge only the supplied player fields; every other hash field is preserved. */
-    mergePlayers: async (players: Player[], season?: string): Promise<void> => {
+    /**
+     * Merge only the supplied player fields after verifying the existing hash
+     * is the complete database-backed player view.
+     */
+    mergePlayers: async (
+      players: Player[],
+      expectedPlayerIds: number[],
+      season?: string,
+    ): Promise<void> => {
       if (players.length === 0) {
         return;
       }
@@ -159,6 +166,19 @@ const createPlayerHashCache = () => {
       try {
         const key = await getHashKey(season);
         const redis = await redisSingleton.getClient();
+        const cachedFields = await redis.hkeys(key);
+        const cachedIds = new Set(cachedFields);
+        const expectedIds = new Set(expectedPlayerIds.map(String));
+        const completeView =
+          cachedIds.size === expectedIds.size &&
+          Array.from(expectedIds).every((elementId) => cachedIds.has(elementId));
+        if (!completeView) {
+          throw new CacheError(
+            `Refusing to merge prices into incomplete players cache: ${key}`,
+            'PLAYERS_MERGE_INCOMPLETE_VIEW',
+          );
+        }
+
         const hashEntries: Record<string, string> = {};
         for (const player of players) {
           hashEntries[String(player.id)] = JSON.stringify(player);
@@ -168,6 +188,9 @@ const createPlayerHashCache = () => {
         logDebug('Players cache fields merged', { key, count: players.length });
       } catch (error) {
         logError('Players cache merge error', error, { count: players.length });
+        if (error instanceof CacheError) {
+          throw error;
+        }
         throw new CacheError(
           'Failed to merge players in cache',
           'PLAYERS_MERGE_ERROR',
@@ -267,8 +290,8 @@ export const playersCache = {
     return playerHashCacheInstance.setAllPlayers(players, season);
   },
 
-  async merge(players: Player[], season?: string): Promise<void> {
-    return playerHashCacheInstance.mergePlayers(players, season);
+  async merge(players: Player[], expectedPlayerIds: number[], season?: string): Promise<void> {
+    return playerHashCacheInstance.mergePlayers(players, expectedPlayerIds, season);
   },
 
   async clear(): Promise<void> {

--- a/src/cache/players-cache.ts
+++ b/src/cache/players-cache.ts
@@ -150,6 +150,32 @@ const createPlayerHashCache = () => {
       }
     },
 
+    /** Merge only the supplied player fields; every other hash field is preserved. */
+    mergePlayers: async (players: Player[], season?: string): Promise<void> => {
+      if (players.length === 0) {
+        return;
+      }
+
+      try {
+        const key = await getHashKey(season);
+        const redis = await redisSingleton.getClient();
+        const hashEntries: Record<string, string> = {};
+        for (const player of players) {
+          hashEntries[String(player.id)] = JSON.stringify(player);
+        }
+
+        await redis.hset(key, hashEntries);
+        logDebug('Players cache fields merged', { key, count: players.length });
+      } catch (error) {
+        logError('Players cache merge error', error, { count: players.length });
+        throw new CacheError(
+          'Failed to merge players in cache',
+          'PLAYERS_MERGE_ERROR',
+          error instanceof Error ? error : undefined,
+        );
+      }
+    },
+
     /**
      * Get players by team ID
      */
@@ -239,6 +265,10 @@ export const playersCache = {
 
   async set(players: Player[], season?: string): Promise<void> {
     return playerHashCacheInstance.setAllPlayers(players, season);
+  },
+
+  async merge(players: Player[], season?: string): Promise<void> {
+    return playerHashCacheInstance.mergePlayers(players, season);
   },
 
   async clear(): Promise<void> {

--- a/src/domain/job-priority.ts
+++ b/src/domain/job-priority.ts
@@ -27,6 +27,7 @@ export type DataSyncPriorityJobName =
   | 'fixtures-all-gameweeks'
   | 'teams'
   | 'players'
+  | 'player-prices'
   | 'player-stats'
   | 'phases'
   | 'player-values';

--- a/src/domain/job-schedules.ts
+++ b/src/domain/job-schedules.ts
@@ -1,2 +1,11 @@
 /** Poll frequently enough to overlap FPL's deadline-dependent pick publication window. */
 export const ENTRY_PICKS_CRON_PATTERN = '*/5 * * * *';
+
+/** Once daily before GW1; every minute in this range once an event is current. */
+export const PLAYER_VALUES_CRON_PATTERN = '25-35 9 * * *';
+
+/** Daily current-price reconciliation from persisted Rise/Faller history. */
+export const PLAYER_PRICES_REPLAY_CRON_PATTERN = '40 9 * * *';
+
+/** Daily transfer/popularity statistics refresh for the current or preseason next event. */
+export const PLAYER_STATS_CRON_PATTERN = '40 9 * * *';

--- a/src/domain/mutation-scope.ts
+++ b/src/domain/mutation-scope.ts
@@ -67,11 +67,13 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
 
   if (queue === 'data-sync') {
     switch (jobName) {
+      case 'players':
+      case 'player-prices':
+        return ['data-core:players'];
       case 'events':
       case 'fixtures':
       case 'fixtures-all-gameweeks':
       case 'teams':
-      case 'players':
       case 'player-stats':
       case 'phases':
       case 'player-values':

--- a/src/domain/player-stats.ts
+++ b/src/domain/player-stats.ts
@@ -210,15 +210,17 @@ export function hasGoodValue(playerStat: PlayerStat, threshold: number = 10): bo
 
 /**
  * PlayerStat:{season} is a latest-event-wins cache view consumed externally
- * (H9): every write wholesale-replaces the hash. Only a sync for the
- * current event may write it — older-event syncs persist to the DB only,
- * otherwise a backfill would clobber the current view with stale data.
+ * (H9): every write wholesale-replaces the hash. The target is the current
+ * event, or the next event only when no current event exists. Older/manual
+ * backfills persist to the DB only so they cannot clobber the latest view.
  */
 export function shouldWritePlayerStatsView(
   eventId: EventId,
   currentEventId: EventId | null,
+  nextEventId: EventId | null = null,
 ): boolean {
-  return currentEventId !== null && eventId === currentEventId;
+  const targetEventId = currentEventId ?? nextEventId;
+  return targetEventId !== null && eventId === targetEventId;
 }
 
 /**

--- a/src/domain/player-values.ts
+++ b/src/domain/player-values.ts
@@ -40,7 +40,7 @@ export type RawPlayerValues = readonly RawPlayerValue[];
 // Domain Validation Schemas
 // ================================
 
-export const PlayerValueSchema = z.object({
+const PlayerValueBaseSchema = z.object({
   elementId: z.number().int().positive('Element ID must be a positive integer'),
   webName: z.string().min(1, 'Web name is required').max(30, 'Web name too long'),
   elementType: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)], {
@@ -61,23 +61,46 @@ export const PlayerValueSchema = z.object({
     .int()
     .min(35, 'Value must be at least 3.5m')
     .max(200, 'Value cannot exceed 20.0m'),
-  changeDate: z.string().min(1, 'Change date is required'),
+  changeDate: z.string().regex(/^\d{8}$/, 'Change date must use YYYYMMDD format'),
   changeType: z.enum(['Start', 'Rise', 'Faller'], {
     errorMap: () => ({ message: 'Change type must be Start, Rise, or Faller' }),
   }),
   lastValue: z
     .number()
     .int()
-    .min(35, 'Last value must be at least 3.5m')
+    .min(0, 'Last value cannot be negative')
     .max(200, 'Last value cannot exceed 20.0m'),
 });
 
-export const RawPlayerValueSchema = PlayerValueSchema.omit({
+function validateLastValueSemantics(
+  value: { changeType: ValueChangeType; lastValue: number },
+  context: z.RefinementCtx,
+) {
+  if (value.changeType === 'Start' && value.lastValue !== 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['lastValue'],
+      message: 'Start rows must use 0 as the last value',
+    });
+  }
+
+  if (value.changeType !== 'Start' && value.lastValue < 35) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['lastValue'],
+      message: 'Changed rows must have a previous value of at least 3.5m',
+    });
+  }
+}
+
+export const PlayerValueSchema = PlayerValueBaseSchema.superRefine(validateLastValueSemantics);
+
+export const RawPlayerValueSchema = PlayerValueBaseSchema.omit({
   webName: true,
   elementTypeName: true,
   teamName: true,
   teamShortName: true,
-});
+}).superRefine(validateLastValueSemantics);
 
 // ================================
 // Domain Business Logic
@@ -229,7 +252,9 @@ export function getValueChangeStats(playerValues: PlayerValues): {
         break;
     }
     totalValue += pv.value;
-    totalValueChange += getValueChangeAmount(pv);
+    if (pv.changeType !== 'Start') {
+      totalValueChange += getValueChangeAmount(pv);
+    }
   }
 
   return {

--- a/src/domain/player-values.ts
+++ b/src/domain/player-values.ts
@@ -110,6 +110,9 @@ export const RawPlayerValueSchema = PlayerValueBaseSchema.omit({
  * Calculate value change amount
  */
 export function getValueChangeAmount(playerValue: PlayerValue): number {
+  if (playerValue.changeType === 'Start') {
+    return 0;
+  }
   return playerValue.value - playerValue.lastValue;
 }
 

--- a/src/jobs/data-sync-enqueue.ts
+++ b/src/jobs/data-sync-enqueue.ts
@@ -1,12 +1,14 @@
 import { getDataSyncJobPriority, type DataSyncPriorityJobName } from '../domain/job-priority';
 import { getDataSyncQueue, type DataSyncJobName } from '../queues/data-sync.queue';
 import { logError, logInfo } from '../utils/logger';
+import { formatCronDateKey } from '../utils/timezone';
 
-export type DataSyncJobSource = 'cron' | 'manual' | 'api' | 'event-transition';
+export type DataSyncJobSource = 'cron' | 'manual' | 'api' | 'event-transition' | 'cascade';
 
-interface DataSyncEnqueueOptions {
+export interface DataSyncEnqueueOptions {
   jobId?: string;
   eventId?: number;
+  changeDate?: string;
   /** When true (default for explicit jobId), remove job on settle so re-triggers work. */
   removeOnSettle?: boolean;
 }
@@ -21,7 +23,8 @@ function defaultDataSyncJobId(
     return undefined;
   }
   const eventPart = options.eventId !== undefined ? `-e${options.eventId}` : '';
-  return `${jobName}${eventPart}-${source}`;
+  const datePart = options.changeDate !== undefined ? `-${options.changeDate}` : '';
+  return `${jobName}${eventPart}${datePart}-${source}`;
 }
 
 async function enqueueDataSyncJob(
@@ -41,6 +44,7 @@ async function enqueueDataSyncJob(
         source,
         triggeredAt: new Date().toISOString(),
         ...(options.eventId !== undefined ? { eventId: options.eventId } : {}),
+        ...(options.changeDate !== undefined ? { changeDate: options.changeDate } : {}),
       },
       {
         attempts: 3,
@@ -87,6 +91,11 @@ export const enqueueTeamsSyncJob = (source?: DataSyncJobSource) =>
 export const enqueuePlayersSyncJob = (source?: DataSyncJobSource) =>
   enqueueDataSyncJob('players', source);
 
+export const enqueuePlayerPricesSyncJob = (
+  source: DataSyncJobSource,
+  options: DataSyncEnqueueOptions & { changeDate: string },
+) => enqueueDataSyncJob('player-prices', source, options);
+
 export const enqueuePlayerStatsSyncJob = (
   source?: DataSyncJobSource,
   options?: DataSyncEnqueueOptions,
@@ -98,4 +107,8 @@ export const enqueuePhasesSyncJob = (source?: DataSyncJobSource) =>
 export const enqueuePlayerValuesSyncJob = (
   source?: DataSyncJobSource,
   options?: DataSyncEnqueueOptions,
-) => enqueueDataSyncJob('player-values', source, options);
+) =>
+  enqueueDataSyncJob('player-values', source, {
+    ...options,
+    changeDate: options?.changeDate ?? formatCronDateKey(),
+  });

--- a/src/jobs/data-sync.jobs.ts
+++ b/src/jobs/data-sync.jobs.ts
@@ -6,19 +6,24 @@ import {
   enqueueFixturesSyncJob,
   enqueuePlayerStatsSyncJob,
   enqueuePhasesSyncJob,
+  enqueuePlayerPricesSyncJob,
   enqueuePlayersSyncJob,
   enqueueTeamsSyncJob,
 } from './data-sync-enqueue';
-import { shouldRunCurrentEventJob } from './current-event-gate';
+import {
+  PLAYER_PRICES_REPLAY_CRON_PATTERN,
+  PLAYER_STATS_CRON_PATTERN,
+} from '../domain/job-schedules';
+import { resolvePlayerSyncEvent } from '../services/player-sync-event.service';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logInfo } from '../utils/logger';
-import { CRON_TIMEZONE } from '../utils/timezone';
+import { CRON_TIMEZONE, formatCronDateKey } from '../utils/timezone';
 
 /**
  * Core entity syncs (events/teams/fixtures/players/phases) run year-round so a
  * newly published FPL season is picked up before the calendar season window
- * opens. Services short-circuit on empty pre-season payloads. Player-stats
- * remains gated by the season window and the presence of a current event.
+ * opens. Services short-circuit on empty pre-season payloads. Player-specific
+ * jobs use current ?? next so GW1 data is refreshed before the first kickoff.
  */
 export function registerDataSyncJobs(app: Elysia) {
   return app
@@ -32,6 +37,31 @@ export function registerDataSyncJobs(app: Elysia) {
             await executeTrackedCron('events-sync', async () => {
               const job = await enqueueEventsSyncJob('cron');
               logInfo('Events sync job enqueued via cron', { jobId: job.id });
+            });
+          } catch {
+            // Failure details are already emitted by runTrackedJob.
+          }
+        },
+      }),
+    )
+    .use(
+      cron({
+        name: 'player-prices-sync',
+        pattern: PLAYER_PRICES_REPLAY_CRON_PATTERN,
+        timezone: CRON_TIMEZONE,
+        async run() {
+          try {
+            await executeTrackedCron('player-prices-sync', async () => {
+              if (!(await resolvePlayerSyncEvent())) {
+                return;
+              }
+              const changeDate = formatCronDateKey();
+              const job = await enqueuePlayerPricesSyncJob('cron', {
+                changeDate,
+                jobId: `player-prices-${changeDate}-replay`,
+                removeOnSettle: true,
+              });
+              logInfo('Player prices replay job enqueued via cron', { jobId: job.id, changeDate });
             });
           } catch {
             // Failure details are already emitted by runTrackedJob.
@@ -93,12 +123,12 @@ export function registerDataSyncJobs(app: Elysia) {
     .use(
       cron({
         name: 'player-stats-sync',
-        pattern: '40 9 * * *',
+        pattern: PLAYER_STATS_CRON_PATTERN,
         timezone: CRON_TIMEZONE,
         async run() {
           try {
             await executeTrackedCron('player-stats-sync', async () => {
-              if (!(await shouldRunCurrentEventJob('player-stats-sync'))) {
+              if (!(await resolvePlayerSyncEvent())) {
                 return;
               }
               const job = await enqueuePlayerStatsSyncJob('cron');

--- a/src/jobs/player-values-window.jobs.ts
+++ b/src/jobs/player-values-window.jobs.ts
@@ -1,24 +1,24 @@
 import { cron } from '@elysiajs/cron';
 import { Elysia } from 'elysia';
 
-import { shouldRunCurrentEventJob } from './current-event-gate';
 import { enqueuePlayerValuesSyncJob } from './data-sync-enqueue';
+import { PLAYER_VALUES_CRON_PATTERN } from '../domain/job-schedules';
 import { playerValuesRepository } from '../repositories/player-values';
+import {
+  resolvePlayerSyncEvent,
+  type PlayerSyncEvent,
+} from '../services/player-sync-event.service';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logInfo } from '../utils/logger';
-import { CRON_TIMEZONE } from '../utils/timezone';
-
-function getChangeDateKey(date: Date) {
-  return date.toISOString().split('T')[0].replace(/-/g, '');
-}
+import { CRON_TIMEZONE, formatCronDateKey, getCronMinute } from '../utils/timezone';
 
 export type PlayerValuesWindowDependencies = {
-  shouldRunCurrentEventJob: (jobName: string, date: Date) => Promise<boolean>;
+  resolvePlayerSyncEvent: (date: Date) => Promise<PlayerSyncEvent | null>;
   hasChangesForDate: (changeDate: string) => Promise<boolean>;
 };
 
 const defaultDependencies: PlayerValuesWindowDependencies = {
-  shouldRunCurrentEventJob,
+  resolvePlayerSyncEvent,
   hasChangesForDate: (changeDate) => playerValuesRepository.hasChangesForDate(changeDate),
 };
 
@@ -26,11 +26,18 @@ export async function shouldRunPlayerValuesSync(
   now: Date,
   dependencies: PlayerValuesWindowDependencies = defaultDependencies,
 ) {
-  if (!(await dependencies.shouldRunCurrentEventJob('player-values-sync', now))) {
+  const syncEvent = await dependencies.resolvePlayerSyncEvent(now);
+  if (!syncEvent) {
     return false;
   }
 
-  const changeDate = getChangeDateKey(now);
+  // The cron covers the full in-season polling window. Before GW1, only its
+  // first tick is allowed through so an unchanged bootstrap is checked once.
+  if (syncEvent.phase === 'preseason' && getCronMinute(now) !== 25) {
+    return false;
+  }
+
+  const changeDate = formatCronDateKey(now);
   const alreadySynced = await dependencies.hasChangesForDate(changeDate);
   if (alreadySynced) {
     logInfo('Skipping player values sync - price changes already recorded for today', {
@@ -45,16 +52,14 @@ export async function shouldRunPlayerValuesSync(
 /**
  * Player Values Window Cron
  *
- * Polls FPL player prices every minute between 09:25 and 09:35 to
- * capture the once-per-day price update. Enqueues a BullMQ data-sync job
- * (retry/backoff) instead of running the sync inline so ticks cannot overlap.
- * The cron bails out immediately once today's price changes have been recorded.
+ * Before GW1 only the 09:25 tick runs. Once an event is current, prices are
+ * polled every minute between 09:25 and 09:35 until the daily change is stored.
  */
 export function registerPlayerValuesWindowJobs(app: Elysia) {
   return app.use(
     cron({
       name: 'player-values-sync',
-      pattern: '25-35 9 * * *',
+      pattern: PLAYER_VALUES_CRON_PATTERN,
       timezone: CRON_TIMEZONE,
       async run() {
         try {
@@ -64,10 +69,11 @@ export function registerPlayerValuesWindowJobs(app: Elysia) {
               return;
             }
 
-            const changeDate = getChangeDateKey(now);
+            const changeDate = formatCronDateKey(now);
             const job = await enqueuePlayerValuesSyncJob('cron', {
               // Stable id prevents stacking duplicate jobs during the 09:25-09:35 window.
               jobId: `player-values-${changeDate}`,
+              changeDate,
             });
             logInfo('Player values sync job enqueued via cron', { jobId: job.id });
           });

--- a/src/queues/data-sync.queue.ts
+++ b/src/queues/data-sync.queue.ts
@@ -9,15 +9,18 @@ export type DataSyncJobName =
   | 'fixtures-all-gameweeks'
   | 'teams'
   | 'players'
+  | 'player-prices'
   | 'player-stats'
   | 'phases'
   | 'player-values';
 
 export interface DataSyncJobData {
-  source?: 'cron' | 'manual' | 'api' | 'event-transition';
+  source?: 'cron' | 'manual' | 'api' | 'event-transition' | 'cascade';
   triggeredAt: string;
   /** Optional event filter (fixtures, player-stats); absent = current/all behavior */
   eventId?: number;
+  /** Price-history date in the configured cron timezone (YYYYMMDD). */
+  changeDate?: string;
 }
 
 const defaultJobOptions = {

--- a/src/repositories/player-values.ts
+++ b/src/repositories/player-values.ts
@@ -70,6 +70,31 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
       }
     },
 
+    findDistinctPlayerIds: async (
+      fromChangeDate: string,
+      throughChangeDate: string,
+    ): Promise<number[]> => {
+      try {
+        const db = await getDbInstance();
+        const rows = await db
+          .selectDistinct({ elementId: playerValues.elementId })
+          .from(playerValues).where(sql`
+            ${playerValues.changeDate} >= ${fromChangeDate}
+            AND ${playerValues.changeDate} <= ${throughChangeDate}
+          `);
+        return rows.map((row) => row.elementId);
+      } catch (error) {
+        logError('Failed to get current-season player value IDs', error, {
+          fromChangeDate,
+          throughChangeDate,
+        });
+        throw new DatabaseError(
+          'Failed to get current-season player value IDs',
+          'PLAYER_VALUE_IDS_ERROR',
+        );
+      }
+    },
+
     findByChangeDate: async (changeDate: string): Promise<StoredPlayerValue[]> => {
       try {
         const db = await getDbInstance();

--- a/src/repositories/player-values.ts
+++ b/src/repositories/player-values.ts
@@ -44,7 +44,10 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   return {
-    findLatestForAllPlayers: async (): Promise<ValueRecord[]> => {
+    findLatestForAllPlayers: async (
+      fromChangeDate: string,
+      throughChangeDate: string,
+    ): Promise<ValueRecord[]> => {
       try {
         const db = await getDbInstance();
         const rows = await db.execute(sql`
@@ -53,11 +56,16 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
           value,
           change_date as "changeDate"
         FROM player_values
+        WHERE change_date >= ${fromChangeDate}
+          AND change_date <= ${throughChangeDate}
         ORDER BY element_id, change_date DESC, created_at DESC
       `);
         return rows as unknown as ValueRecord[];
       } catch (error) {
-        logError('Failed to get latest player values', error);
+        logError('Failed to get latest player values', error, {
+          fromChangeDate,
+          throughChangeDate,
+        });
         throw new DatabaseError('Failed to get latest player values', 'LATEST_VALUES_ERROR');
       }
     },

--- a/src/repositories/player-values.ts
+++ b/src/repositories/player-values.ts
@@ -1,4 +1,4 @@
-import { asc, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, lt, sql } from 'drizzle-orm';
 
 import { playerValues, type DbPlayerValueInsert } from '../db/schemas/index.schema';
 import { getDb } from '../db/singleton';
@@ -92,7 +92,11 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
       }
     },
 
-    findLatestForPlayerIds: async (elementIds: number[]): Promise<StoredPlayerValue[]> => {
+    findLatestForPlayerIds: async (
+      elementIds: number[],
+      fromChangeDate: string,
+      beforeChangeDate: string,
+    ): Promise<StoredPlayerValue[]> => {
       if (elementIds.length === 0) {
         return [];
       }
@@ -111,7 +115,13 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
             lastValue: playerValues.lastValue,
           })
           .from(playerValues)
-          .where(inArray(playerValues.elementId, uniqueIds))
+          .where(
+            and(
+              inArray(playerValues.elementId, uniqueIds),
+              gte(playerValues.changeDate, fromChangeDate),
+              lt(playerValues.changeDate, beforeChangeDate),
+            ),
+          )
           .orderBy(
             asc(playerValues.elementId),
             desc(playerValues.changeDate),
@@ -130,6 +140,8 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
       } catch (error) {
         logError('Failed to get latest player values by player IDs', error, {
           count: elementIds.length,
+          fromChangeDate,
+          beforeChangeDate,
         });
         throw new DatabaseError(
           'Failed to get latest player values by player IDs',

--- a/src/repositories/player-values.ts
+++ b/src/repositories/player-values.ts
@@ -70,31 +70,6 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
       }
     },
 
-    findDistinctPlayerIds: async (
-      fromChangeDate: string,
-      throughChangeDate: string,
-    ): Promise<number[]> => {
-      try {
-        const db = await getDbInstance();
-        const rows = await db
-          .selectDistinct({ elementId: playerValues.elementId })
-          .from(playerValues).where(sql`
-            ${playerValues.changeDate} >= ${fromChangeDate}
-            AND ${playerValues.changeDate} <= ${throughChangeDate}
-          `);
-        return rows.map((row) => row.elementId);
-      } catch (error) {
-        logError('Failed to get current-season player value IDs', error, {
-          fromChangeDate,
-          throughChangeDate,
-        });
-        throw new DatabaseError(
-          'Failed to get current-season player value IDs',
-          'PLAYER_VALUE_IDS_ERROR',
-        );
-      }
-    },
-
     findByChangeDate: async (changeDate: string): Promise<StoredPlayerValue[]> => {
       try {
         const db = await getDbInstance();

--- a/src/repositories/player-values.ts
+++ b/src/repositories/player-values.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { asc, desc, eq, inArray, sql } from 'drizzle-orm';
 
 import { playerValues, type DbPlayerValueInsert } from '../db/schemas/index.schema';
 import { getDb } from '../db/singleton';
@@ -7,11 +7,33 @@ import { logError, logInfo } from '../utils/logger';
 
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { PlayerValue } from '../domain/player-values';
+import type { ValueChangeType } from '../types/base.type';
 
 interface ValueRecord {
   elementId: number;
   value: number;
   changeDate: string;
+}
+
+export interface StoredPlayerValue extends ValueRecord {
+  eventId: number;
+  elementType: number;
+  changeType: ValueChangeType;
+  lastValue: number;
+}
+
+function mapStoredPlayerValue(row: {
+  elementId: number;
+  value: number;
+  changeDate: string;
+  eventId: number;
+  elementType: number;
+  changeType: 'start' | 'rise' | 'fall';
+  lastValue: number;
+}): StoredPlayerValue {
+  const changeType: ValueChangeType =
+    row.changeType === 'start' ? 'Start' : row.changeType === 'rise' ? 'Rise' : 'Faller';
+  return { ...row, changeType };
 }
 
 type DatabaseInstance = PostgresJsDatabase<Record<string, never>>;
@@ -40,18 +62,71 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
       }
     },
 
-    findByChangeDate: async (changeDate: string): Promise<ValueRecord[]> => {
+    findByChangeDate: async (changeDate: string): Promise<StoredPlayerValue[]> => {
       try {
         const db = await getDbInstance();
-        const rows = await db.execute(sql`
-        SELECT element_id as "elementId", value, change_date as "changeDate"
-        FROM player_values
-        WHERE change_date = ${changeDate}
-      `);
-        return rows as unknown as ValueRecord[];
+        const rows = await db
+          .select({
+            elementId: playerValues.elementId,
+            value: playerValues.value,
+            changeDate: playerValues.changeDate,
+            eventId: playerValues.eventId,
+            elementType: playerValues.elementType,
+            changeType: playerValues.changeType,
+            lastValue: playerValues.lastValue,
+          })
+          .from(playerValues)
+          .where(eq(playerValues.changeDate, changeDate));
+        return rows.map(mapStoredPlayerValue);
       } catch (error) {
         logError('Failed to get player values by date', error, { changeDate });
         throw new DatabaseError('Failed to get player values by date', 'FIND_BY_DATE_ERROR');
+      }
+    },
+
+    findLatestForPlayerIds: async (elementIds: number[]): Promise<StoredPlayerValue[]> => {
+      if (elementIds.length === 0) {
+        return [];
+      }
+
+      try {
+        const db = await getDbInstance();
+        const uniqueIds = Array.from(new Set(elementIds));
+        const rows = await db
+          .select({
+            elementId: playerValues.elementId,
+            value: playerValues.value,
+            changeDate: playerValues.changeDate,
+            eventId: playerValues.eventId,
+            elementType: playerValues.elementType,
+            changeType: playerValues.changeType,
+            lastValue: playerValues.lastValue,
+          })
+          .from(playerValues)
+          .where(inArray(playerValues.elementId, uniqueIds))
+          .orderBy(
+            asc(playerValues.elementId),
+            desc(playerValues.changeDate),
+            desc(playerValues.createdAt),
+          );
+
+        const seen = new Set<number>();
+        const latest: StoredPlayerValue[] = [];
+        for (const row of rows) {
+          if (!seen.has(row.elementId)) {
+            seen.add(row.elementId);
+            latest.push(mapStoredPlayerValue(row));
+          }
+        }
+        return latest;
+      } catch (error) {
+        logError('Failed to get latest player values by player IDs', error, {
+          count: elementIds.length,
+        });
+        throw new DatabaseError(
+          'Failed to get latest player values by player IDs',
+          'LATEST_VALUES_BY_IDS_ERROR',
+        );
       }
     },
 
@@ -88,7 +163,9 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
           value: playerValue.value,
           changeDate: playerValue.changeDate,
           changeType:
-            playerValue.changeType.toLowerCase() as (typeof playerValues.changeType)['enumValues'][number],
+            playerValue.changeType === 'Faller'
+              ? 'fall'
+              : (playerValue.changeType.toLowerCase() as 'start' | 'rise'),
           lastValue: playerValue.lastValue,
         }));
 

--- a/src/repositories/players.ts
+++ b/src/repositories/players.ts
@@ -28,21 +28,6 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   return {
-    findAllIds: async (): Promise<number[]> => {
-      try {
-        const db = await getDbInstance();
-        const rows = await db.select({ id: players.id }).from(players);
-        return rows.map((row) => row.id);
-      } catch (error) {
-        logError('Failed to retrieve player IDs', error);
-        throw new DatabaseError(
-          'Failed to retrieve player IDs',
-          'FIND_PLAYER_IDS_ERROR',
-          error instanceof Error ? error : undefined,
-        );
-      }
-    },
-
     findByIds: async (ids: number[]): Promise<DomainPlayer[]> => {
       if (ids.length === 0) {
         return [];

--- a/src/repositories/players.ts
+++ b/src/repositories/players.ts
@@ -57,6 +57,46 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
       }
     },
 
+    updatePrices: async (
+      priceUpdates: Array<{ elementId: number; value: number }>,
+    ): Promise<DomainPlayer[]> => {
+      if (priceUpdates.length === 0) {
+        return [];
+      }
+
+      try {
+        const deduplicated = Array.from(
+          new Map(priceUpdates.map((update) => [update.elementId, update])).values(),
+        );
+        const elementIds = deduplicated.map((update) => update.elementId);
+        const priceCases = deduplicated.map(
+          (update) => sql`WHEN ${update.elementId} THEN ${update.value}`,
+        );
+        const priceExpression = sql`CASE ${players.id} ${sql.join(
+          priceCases,
+          sql.raw(' '),
+        )} ELSE ${players.price} END`;
+
+        const db = await getDbInstance();
+        const updated = await db
+          .update(players)
+          .set({ price: priceExpression, updatedAt: sql`NOW()` })
+          .where(inArray(players.id, elementIds))
+          .returning();
+
+        const mappedPlayers = updated.map(mapDbPlayerToDomain);
+        logInfo('Batch updated player prices', { count: mappedPlayers.length });
+        return mappedPlayers;
+      } catch (error) {
+        logError('Failed to batch update player prices', error, { count: priceUpdates.length });
+        throw new DatabaseError(
+          'Failed to batch update player prices',
+          'BATCH_PRICE_UPDATE_ERROR',
+          error instanceof Error ? error : undefined,
+        );
+      }
+    },
+
     upsertBatch: async (domainPlayers: DomainPlayer[]): Promise<DomainPlayer[]> => {
       try {
         if (domainPlayers.length === 0) {

--- a/src/repositories/players.ts
+++ b/src/repositories/players.ts
@@ -28,6 +28,21 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   return {
+    findAllIds: async (): Promise<number[]> => {
+      try {
+        const db = await getDbInstance();
+        const rows = await db.select({ id: players.id }).from(players);
+        return rows.map((row) => row.id);
+      } catch (error) {
+        logError('Failed to retrieve player IDs', error);
+        throw new DatabaseError(
+          'Failed to retrieve player IDs',
+          'FIND_PLAYER_IDS_ERROR',
+          error instanceof Error ? error : undefined,
+        );
+      }
+    },
+
     findByIds: async (ids: number[]): Promise<DomainPlayer[]> => {
       if (ids.length === 0) {
         return [];

--- a/src/services/job-trigger.service.ts
+++ b/src/services/job-trigger.service.ts
@@ -2,6 +2,7 @@ import {
   enqueueEventsSyncJob,
   enqueueFixturesSyncJob,
   enqueuePhasesSyncJob,
+  enqueuePlayerPricesSyncJob,
   enqueuePlayersSyncJob,
   enqueuePlayerStatsSyncJob,
   enqueuePlayerValuesSyncJob,
@@ -40,6 +41,7 @@ import { getCurrentEvent } from './events.service';
 import { refreshTournamentMaterializedViews } from './tournament-materialized-views.service';
 import { syncTournamentSelectionStats } from './tournament-selection-stats.service';
 import { logInfo } from '../utils/logger';
+import { ValidationError } from '../utils/errors';
 
 export type TriggerableJobInfo = {
   name: string;
@@ -99,9 +101,14 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
     schedule: 'Daily at 6:43 AM',
   },
   {
+    name: 'player-prices',
+    description: 'Replay persisted price changes into current player prices',
+    schedule: 'Daily at 09:40 UTC+8 plus immediate player-values cascade',
+  },
+  {
     name: 'player-stats-sync',
     description: 'Sync player stats from FPL API',
-    schedule: 'Daily at 9:40 AM',
+    schedule: 'Daily at 09:40 UTC+8 (current event or preseason next event)',
   },
   {
     name: 'phases-sync',
@@ -111,7 +118,7 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'player-values-sync',
     description: 'Sync player values from FPL API',
-    schedule: '09:25-09:35 AM window (stops after success)',
+    schedule: 'Preseason 09:25; in-season 09:25-09:35 until changes are stored',
   },
   {
     name: 'entry-info-daily',
@@ -241,13 +248,31 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   },
 ];
 
-function buildJobMap(): Record<string, () => Promise<unknown>> {
+function requirePlayerPricesChangeDate(input: unknown): string {
+  const changeDate =
+    input && typeof input === 'object' && !Array.isArray(input)
+      ? (input as Record<string, unknown>).changeDate
+      : undefined;
+  if (typeof changeDate !== 'string' || !/^\d{8}$/.test(changeDate)) {
+    throw new ValidationError(
+      'Job player-prices requires a changeDate in YYYYMMDD format',
+      'PLAYER_PRICES_CHANGE_DATE_REQUIRED',
+    );
+  }
+  return changeDate;
+}
+
+function buildJobMap(input?: unknown): Record<string, () => Promise<unknown>> {
   return {
     'event-current-refresh': () => runManualEventCurrentRefresh(),
     'events-sync': () => enqueueEventsSyncJob('manual'),
     'fixtures-sync': () => enqueueFixturesSyncJob('manual'),
     'teams-sync': () => enqueueTeamsSyncJob('manual'),
     'players-sync': () => enqueuePlayersSyncJob('manual'),
+    'player-prices': () =>
+      enqueuePlayerPricesSyncJob('manual', {
+        changeDate: requirePlayerPricesChangeDate(input),
+      }),
     'player-stats-sync': () => enqueuePlayerStatsSyncJob('manual'),
     'phases-sync': () => enqueuePhasesSyncJob('manual'),
     'player-values-sync': () => enqueuePlayerValuesSyncJob('manual'),
@@ -359,8 +384,8 @@ export function listTriggerableJobs(): TriggerableJobInfo[] {
   return TRIGGERABLE_JOBS;
 }
 
-export async function triggerJob(name: string): Promise<JobTriggerResult> {
-  const jobMap = buildJobMap();
+export async function triggerJob(name: string, input?: unknown): Promise<JobTriggerResult> {
+  const jobMap = buildJobMap(input);
   const job = jobMap[name];
   if (!job) {
     throw new JobNotFoundError(name);

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -1,13 +1,13 @@
 import { playersCache } from '../cache/operations';
+import { fplClient } from '../clients/fpl';
 import { playerValuesRepository } from '../repositories/player-values';
 import { playerRepository } from '../repositories/players';
 import { logInfo } from '../utils/logger';
-import { getPlayerValueSeasonFloorForDate } from '../utils/player-value-season';
 
 export type PlayerPricesSyncDependencies = {
   findByChangeDate: typeof playerValuesRepository.findByChangeDate;
   findLatestForPlayerIds: typeof playerValuesRepository.findLatestForPlayerIds;
-  findDistinctPlayerIds: typeof playerValuesRepository.findDistinctPlayerIds;
+  getBootstrap: typeof fplClient.getBootstrap;
   updatePrices: typeof playerRepository.updatePrices;
   mergePlayersCache: typeof playersCache.merge;
 };
@@ -15,7 +15,7 @@ export type PlayerPricesSyncDependencies = {
 const defaultDependencies: PlayerPricesSyncDependencies = {
   findByChangeDate: playerValuesRepository.findByChangeDate,
   findLatestForPlayerIds: playerValuesRepository.findLatestForPlayerIds,
-  findDistinctPlayerIds: playerValuesRepository.findDistinctPlayerIds,
+  getBootstrap: () => fplClient.getBootstrap(),
   updatePrices: playerRepository.updatePrices,
   mergePlayersCache: playersCache.merge,
 };
@@ -42,32 +42,39 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
       return { count: 0, changeDate };
     }
 
+    const bootstrap = await dependencies.getBootstrap();
+    if (!Array.isArray(bootstrap.elements) || bootstrap.elements.length === 0) {
+      throw new Error('No published player roster returned from FPL API');
+    }
+    const publishedPlayerIds = bootstrap.elements.map((player) => player.id);
+    const publishedIdSet = new Set(publishedPlayerIds);
+    const currentChangedIds = changedIds.filter((elementId) => publishedIdSet.has(elementId));
+    if (currentChangedIds.length === 0) {
+      logInfo('Affected price rows no longer belong to the published roster', { changeDate });
+      return { count: 0, changeDate };
+    }
+
     // The date selects the affected players, while the latest row selects the
     // value. A delayed replay of an older date therefore cannot regress a
     // player who has changed again since that date.
-    const latestRows = await dependencies.findLatestForPlayerIds(changedIds);
+    const latestRows = await dependencies.findLatestForPlayerIds(currentChangedIds);
     const latestById = new Map(latestRows.map((row) => [row.elementId, row]));
-    const missingLatest = changedIds.filter((elementId) => !latestById.has(elementId));
+    const missingLatest = currentChangedIds.filter((elementId) => !latestById.has(elementId));
     if (missingLatest.length > 0) {
       throw new Error(`Latest player values missing for IDs: ${missingLatest.join(', ')}`);
     }
 
-    const priceUpdates = changedIds.map((elementId) => ({
+    const priceUpdates = currentChangedIds.map((elementId) => ({
       elementId,
       value: latestById.get(elementId)!.value,
     }));
     const updatedPlayers = await dependencies.updatePrices(priceUpdates);
     const updatedIds = new Set(updatedPlayers.map((player) => player.id));
-    const missingPlayers = changedIds.filter((elementId) => !updatedIds.has(elementId));
+    const missingPlayers = currentChangedIds.filter((elementId) => !updatedIds.has(elementId));
     if (missingPlayers.length > 0) {
       throw new Error(`Player rows missing for price update: ${missingPlayers.join(', ')}`);
     }
 
-    // The season's player-value seed is captured from the complete published
-    // bootstrap roster. Do not use the single-season players table here: its
-    // retained prior-roster IDs are valid history owners but not cache fields.
-    const seasonFloor = getPlayerValueSeasonFloorForDate(changeDate);
-    const publishedPlayerIds = await dependencies.findDistinctPlayerIds(seasonFloor, changeDate);
     await dependencies.mergePlayersCache(updatedPlayers, publishedPlayerIds);
     logInfo('Player prices updated in database and cache', {
       changeDate,

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -2,6 +2,7 @@ import { playersCache } from '../cache/operations';
 import { fplClient } from '../clients/fpl';
 import { playerValuesRepository } from '../repositories/player-values';
 import { playerRepository } from '../repositories/players';
+import { transformPlayers } from '../transformers/players';
 import { logInfo } from '../utils/logger';
 import { getPlayerValueSeasonBounds } from '../utils/player-value-season';
 
@@ -47,7 +48,15 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
     if (!Array.isArray(bootstrap.elements) || bootstrap.elements.length === 0) {
       throw new Error('No published player roster returned from FPL API');
     }
-    const publishedPlayerIds = bootstrap.elements.map((player) => player.id);
+    // The full players sync publishes only elements that pass the player
+    // transformer. Use the same roster here so the partial-merge guard checks
+    // the exact field set that syncPlayers writes, not unpublishable raw rows.
+    const publishedPlayerIds = Array.from(
+      new Set(transformPlayers(bootstrap.elements).map((player) => player.id)),
+    );
+    if (publishedPlayerIds.length === 0) {
+      throw new Error('No valid published player roster returned from FPL API');
+    }
     const publishedIdSet = new Set(publishedPlayerIds);
     const currentChangedIds = changedIds.filter((elementId) => publishedIdSet.has(elementId));
     if (currentChangedIds.length === 0) {

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -6,6 +6,7 @@ import { logInfo } from '../utils/logger';
 export type PlayerPricesSyncDependencies = {
   findByChangeDate: typeof playerValuesRepository.findByChangeDate;
   findLatestForPlayerIds: typeof playerValuesRepository.findLatestForPlayerIds;
+  findAllPlayerIds: typeof playerRepository.findAllIds;
   updatePrices: typeof playerRepository.updatePrices;
   mergePlayersCache: typeof playersCache.merge;
 };
@@ -13,6 +14,7 @@ export type PlayerPricesSyncDependencies = {
 const defaultDependencies: PlayerPricesSyncDependencies = {
   findByChangeDate: playerValuesRepository.findByChangeDate,
   findLatestForPlayerIds: playerValuesRepository.findLatestForPlayerIds,
+  findAllPlayerIds: playerRepository.findAllIds,
   updatePrices: playerRepository.updatePrices,
   mergePlayersCache: playersCache.merge,
 };
@@ -60,7 +62,8 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
       throw new Error(`Player rows missing for price update: ${missingPlayers.join(', ')}`);
     }
 
-    await dependencies.mergePlayersCache(updatedPlayers);
+    const allPlayerIds = await dependencies.findAllPlayerIds();
+    await dependencies.mergePlayersCache(updatedPlayers, allPlayerIds);
     logInfo('Player prices updated in database and cache', {
       changeDate,
       count: updatedPlayers.length,

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -3,6 +3,7 @@ import { fplClient } from '../clients/fpl';
 import { playerValuesRepository } from '../repositories/player-values';
 import { playerRepository } from '../repositories/players';
 import { logInfo } from '../utils/logger';
+import { getPlayerValueSeasonBounds } from '../utils/player-value-season';
 
 export type PlayerPricesSyncDependencies = {
   findByChangeDate: typeof playerValuesRepository.findByChangeDate;
@@ -53,11 +54,18 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
       logInfo('Affected price rows no longer belong to the published roster', { changeDate });
       return { count: 0, changeDate };
     }
+    const gw1Deadline = bootstrap.events.find((event) => event.id === 1)?.deadline_time ?? null;
+    const { fromChangeDate, beforeChangeDate } = getPlayerValueSeasonBounds(gw1Deadline);
 
     // The date selects the affected players, while the latest row selects the
     // value. A delayed replay of an older date therefore cannot regress a
-    // player who has changed again since that date.
-    const latestRows = await dependencies.findLatestForPlayerIds(currentChangedIds);
+    // player who has changed again since that date. The published-season
+    // bounds prevent a reused FPL element ID from reading prior-season history.
+    const latestRows = await dependencies.findLatestForPlayerIds(
+      currentChangedIds,
+      fromChangeDate,
+      beforeChangeDate,
+    );
     const latestById = new Map(latestRows.map((row) => [row.elementId, row]));
     const missingLatest = currentChangedIds.filter((elementId) => !latestById.has(elementId));
     if (missingLatest.length > 0) {

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -2,11 +2,12 @@ import { playersCache } from '../cache/operations';
 import { playerValuesRepository } from '../repositories/player-values';
 import { playerRepository } from '../repositories/players';
 import { logInfo } from '../utils/logger';
+import { getPlayerValueSeasonFloorForDate } from '../utils/player-value-season';
 
 export type PlayerPricesSyncDependencies = {
   findByChangeDate: typeof playerValuesRepository.findByChangeDate;
   findLatestForPlayerIds: typeof playerValuesRepository.findLatestForPlayerIds;
-  findAllPlayerIds: typeof playerRepository.findAllIds;
+  findDistinctPlayerIds: typeof playerValuesRepository.findDistinctPlayerIds;
   updatePrices: typeof playerRepository.updatePrices;
   mergePlayersCache: typeof playersCache.merge;
 };
@@ -14,7 +15,7 @@ export type PlayerPricesSyncDependencies = {
 const defaultDependencies: PlayerPricesSyncDependencies = {
   findByChangeDate: playerValuesRepository.findByChangeDate,
   findLatestForPlayerIds: playerValuesRepository.findLatestForPlayerIds,
-  findAllPlayerIds: playerRepository.findAllIds,
+  findDistinctPlayerIds: playerValuesRepository.findDistinctPlayerIds,
   updatePrices: playerRepository.updatePrices,
   mergePlayersCache: playersCache.merge,
 };
@@ -62,8 +63,12 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
       throw new Error(`Player rows missing for price update: ${missingPlayers.join(', ')}`);
     }
 
-    const allPlayerIds = await dependencies.findAllPlayerIds();
-    await dependencies.mergePlayersCache(updatedPlayers, allPlayerIds);
+    // The season's player-value seed is captured from the complete published
+    // bootstrap roster. Do not use the single-season players table here: its
+    // retained prior-roster IDs are valid history owners but not cache fields.
+    const seasonFloor = getPlayerValueSeasonFloorForDate(changeDate);
+    const publishedPlayerIds = await dependencies.findDistinctPlayerIds(seasonFloor, changeDate);
+    await dependencies.mergePlayersCache(updatedPlayers, publishedPlayerIds);
     logInfo('Player prices updated in database and cache', {
       changeDate,
       count: updatedPlayers.length,

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -1,0 +1,73 @@
+import { playersCache } from '../cache/operations';
+import { playerValuesRepository } from '../repositories/player-values';
+import { playerRepository } from '../repositories/players';
+import { logInfo } from '../utils/logger';
+
+export type PlayerPricesSyncDependencies = {
+  findByChangeDate: typeof playerValuesRepository.findByChangeDate;
+  findLatestForPlayerIds: typeof playerValuesRepository.findLatestForPlayerIds;
+  updatePrices: typeof playerRepository.updatePrices;
+  mergePlayersCache: typeof playersCache.merge;
+};
+
+const defaultDependencies: PlayerPricesSyncDependencies = {
+  findByChangeDate: playerValuesRepository.findByChangeDate,
+  findLatestForPlayerIds: playerValuesRepository.findLatestForPlayerIds,
+  updatePrices: playerRepository.updatePrices,
+  mergePlayersCache: playersCache.merge,
+};
+
+export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencies) {
+  return async function syncForDate(
+    changeDate: string,
+  ): Promise<{ count: number; changeDate: string }> {
+    if (!/^\d{8}$/.test(changeDate)) {
+      throw new Error(`Invalid player price change date: ${changeDate}`);
+    }
+
+    const rowsForDate = await dependencies.findByChangeDate(changeDate);
+    const changedIds = Array.from(
+      new Set(
+        rowsForDate
+          .filter((row) => row.changeType === 'Rise' || row.changeType === 'Faller')
+          .map((row) => row.elementId),
+      ),
+    );
+
+    if (changedIds.length === 0) {
+      logInfo('No player price changes to apply', { changeDate });
+      return { count: 0, changeDate };
+    }
+
+    // The date selects the affected players, while the latest row selects the
+    // value. A delayed replay of an older date therefore cannot regress a
+    // player who has changed again since that date.
+    const latestRows = await dependencies.findLatestForPlayerIds(changedIds);
+    const latestById = new Map(latestRows.map((row) => [row.elementId, row]));
+    const missingLatest = changedIds.filter((elementId) => !latestById.has(elementId));
+    if (missingLatest.length > 0) {
+      throw new Error(`Latest player values missing for IDs: ${missingLatest.join(', ')}`);
+    }
+
+    const priceUpdates = changedIds.map((elementId) => ({
+      elementId,
+      value: latestById.get(elementId)!.value,
+    }));
+    const updatedPlayers = await dependencies.updatePrices(priceUpdates);
+    const updatedIds = new Set(updatedPlayers.map((player) => player.id));
+    const missingPlayers = changedIds.filter((elementId) => !updatedIds.has(elementId));
+    if (missingPlayers.length > 0) {
+      throw new Error(`Player rows missing for price update: ${missingPlayers.join(', ')}`);
+    }
+
+    await dependencies.mergePlayersCache(updatedPlayers);
+    logInfo('Player prices updated in database and cache', {
+      changeDate,
+      count: updatedPlayers.length,
+    });
+
+    return { count: updatedPlayers.length, changeDate };
+  };
+}
+
+export const syncPlayerPricesForDate = createPlayerPricesSync(defaultDependencies);

--- a/src/services/player-stats.service.ts
+++ b/src/services/player-stats.service.ts
@@ -5,12 +5,13 @@ import { playerStatsRepository } from '../repositories/player-stats';
 import {
   createTeamsMap,
   transformCurrentGameweekPlayerStats,
-  transformPlayerStats,
+  transformPlayerStatsStrict,
 } from '../transformers/player-stats';
 import type { EventId } from '../types/base.type';
 import { logInfo } from '../utils/logger';
 import { loadTeamsBasicInfo } from '../utils/teams';
-import { getCurrentEvent } from './events.service';
+import { getCurrentEvent, getNextEvent } from './events.service';
+import { resolvePlayerSyncEvent } from './player-sync-event.service';
 
 export async function syncCurrentPlayerStats(): Promise<{
   count: number;
@@ -25,9 +26,9 @@ export async function syncCurrentPlayerStats(): Promise<{
     throw new Error('Invalid player elements data from FPL API');
   }
 
-  const currentEvent = await getCurrentEvent();
-  if (!currentEvent) {
-    throw new Error('No current event found');
+  const syncEvent = await resolvePlayerSyncEvent();
+  if (!syncEvent) {
+    throw new Error('No current or next event found for player stats');
   }
 
   if (fplData.elements.length === 0) {
@@ -36,33 +37,33 @@ export async function syncCurrentPlayerStats(): Promise<{
 
   logInfo('Raw player stats data fetched', {
     playersCount: fplData.elements.length,
-    eventId: currentEvent.id,
+    eventId: syncEvent.event.id,
   });
 
-  const transformedPlayerStats = transformCurrentGameweekPlayerStats(fplData, currentEvent.id);
+  const transformedPlayerStats = transformCurrentGameweekPlayerStats(fplData, syncEvent.event.id);
   const errors = fplData.elements.length - transformedPlayerStats.length;
 
   logInfo('Player stats transformed', {
     total: fplData.elements.length,
     successful: transformedPlayerStats.length,
     errors,
-    eventId: currentEvent.id,
+    eventId: syncEvent.event.id,
   });
 
   const upsertResult = await playerStatsRepository.upsertBatch(transformedPlayerStats);
   logInfo('Player stats upserted to database', { count: upsertResult.count });
 
   if (upsertResult.count > 0) {
-    await playerStatsCache.setByEvent(currentEvent.id, transformedPlayerStats);
+    await playerStatsCache.setByEvent(syncEvent.event.id, transformedPlayerStats);
     logInfo('Player stats cache updated', {
-      eventId: currentEvent.id,
+      eventId: syncEvent.event.id,
       count: transformedPlayerStats.length,
     });
   }
 
   const result = {
     count: upsertResult.count,
-    eventId: currentEvent.id,
+    eventId: syncEvent.event.id,
     errors,
   };
 
@@ -88,7 +89,7 @@ export async function syncPlayerStatsForEvent(
   const teams = await loadTeamsBasicInfo();
   const teamsMap = createTeamsMap(teams);
 
-  const transformedPlayerStats = transformPlayerStats(fplData.elements, eventId, teamsMap);
+  const transformedPlayerStats = transformPlayerStatsStrict(fplData.elements, eventId, teamsMap);
   const errors = fplData.elements.length - transformedPlayerStats.length;
 
   logInfo('Player stats transformed for event', {
@@ -106,20 +107,21 @@ export async function syncPlayerStatsForEvent(
 
   if (upsertResult.count > 0) {
     // H9: PlayerStat:{season} is a latest-event-wins view consumed
-    // externally — every setByEvent wholesale-replaces it. Only the current
-    // event may write it; older-event syncs persist to the DB only so a
-    // backfill can never clobber the current view.
-    const currentEvent = await getCurrentEvent();
-    if (shouldWritePlayerStatsView(eventId, currentEvent?.id ?? null)) {
+    // externally — every setByEvent wholesale-replaces it. The current event,
+    // or preseason next event when no current exists, may write it. Historical
+    // backfills persist to the DB only so they cannot clobber the latest view.
+    const [currentEvent, nextEvent] = await Promise.all([getCurrentEvent(), getNextEvent()]);
+    if (shouldWritePlayerStatsView(eventId, currentEvent?.id ?? null, nextEvent?.id ?? null)) {
       await playerStatsCache.setByEvent(eventId, transformedPlayerStats);
       logInfo('Player stats cache updated for event', {
         eventId,
         count: transformedPlayerStats.length,
       });
     } else {
-      logInfo('Skipping player stats cache write for non-current event', {
+      logInfo('Skipping player stats cache write for non-latest event', {
         eventId,
         currentEventId: currentEvent?.id ?? null,
+        nextEventId: nextEvent?.id ?? null,
       });
     }
   }

--- a/src/services/player-sync-event.service.ts
+++ b/src/services/player-sync-event.service.ts
@@ -1,0 +1,52 @@
+import { getCurrentEvent, getNextEvent } from './events.service';
+import type { Event } from '../types';
+import { isFPLSeason } from '../utils/conditions';
+
+export type PlayerSyncEvent = {
+  event: Event;
+  phase: 'preseason' | 'current';
+};
+
+export type PlayerSyncEventDependencies = {
+  getCurrentEvent: () => Promise<Event | null>;
+  getNextEvent: () => Promise<Event | null>;
+  isFPLSeason: (date: Date) => Promise<boolean>;
+};
+
+const defaultDependencies: PlayerSyncEventDependencies = {
+  getCurrentEvent,
+  getNextEvent,
+  isFPLSeason,
+};
+
+/**
+ * Player values and stats need GW1 before the ordinary current-event gate opens.
+ * Other current-event jobs intentionally continue using shouldRunCurrentEventJob.
+ */
+export async function resolvePlayerSyncEvent(
+  date: Date = new Date(),
+  dependencies: PlayerSyncEventDependencies = defaultDependencies,
+): Promise<PlayerSyncEvent | null> {
+  const [currentEvent, nextEvent, seasonActive] = await Promise.all([
+    dependencies.getCurrentEvent(),
+    dependencies.getNextEvent(),
+    dependencies.isFPLSeason(date),
+  ]);
+
+  if (currentEvent && seasonActive) {
+    return { event: currentEvent, phase: 'current' };
+  }
+
+  if (!currentEvent && nextEvent) {
+    return { event: nextEvent, phase: 'preseason' };
+  }
+
+  // The GW1 deadline can pass shortly before the first fixture opens the
+  // fixture-derived season window. Keep targeting GW1, but retain the
+  // once-daily preseason schedule until the season window opens.
+  if (currentEvent?.id === 1 && !currentEvent.finished) {
+    return { event: currentEvent, phase: 'preseason' };
+  }
+
+  return null;
+}

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -136,6 +136,28 @@ function enrichStoredRows(
   });
 }
 
+/**
+ * player_values is intentionally date-keyed and has no season column. Scope
+ * comparisons to the published season inferred from the target event's
+ * deadline so reused element IDs cannot inherit prior-season price history.
+ */
+export function getPlayerValueSeasonFloor(deadlineTime: string | null): string {
+  if (!deadlineTime) {
+    throw new Error('Player value season cannot be resolved without an event deadline');
+  }
+
+  const deadline = new Date(deadlineTime);
+  if (Number.isNaN(deadline.getTime())) {
+    throw new Error(`Invalid event deadline for player value season: ${deadlineTime}`);
+  }
+
+  // The previous FPL season finishes in May. June 1 is therefore a stable
+  // boundary that also permits unusually early preseason bootstrap releases.
+  const deadlineYear = deadline.getUTCFullYear();
+  const seasonStartYear = deadline.getUTCMonth() >= 6 ? deadlineYear : deadlineYear - 1;
+  return `${seasonStartYear}0601`;
+}
+
 export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencies) {
   return async function syncForDate(
     changeDate: string = formatCronDateKey(),
@@ -158,8 +180,10 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
       throw new Error('No player values returned from FPL API');
     }
 
-    // Get last stored value for each player
-    const lastStoredValues = await dependencies.findLatestForAllPlayers();
+    // Get the last value inside this published season only. Element IDs are
+    // reused by FPL and must not be compared with prior-season players.
+    const seasonFloor = getPlayerValueSeasonFloor(syncEvent.event.deadlineTime);
+    const lastStoredValues = await dependencies.findLatestForAllPlayers(seasonFloor, changeDate);
     const lastValueMap = new Map<number, number>();
     lastStoredValues.forEach((pv) => lastValueMap.set(pv.elementId, pv.value));
 

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -1,4 +1,5 @@
 import { playerValuesCache } from '../cache/operations';
+import type { PlayerValueCacheSnapshot } from '../cache/player-values-cache';
 import { fplClient } from '../clients/fpl';
 import type { PlayerValue } from '../domain/player-values';
 import { enqueuePlayerPricesSyncJob } from '../jobs/data-sync-enqueue';
@@ -21,8 +22,9 @@ export type PlayerValuesSyncDependencies = {
   findByChangeDate: typeof playerValuesRepository.findByChangeDate;
   insertBatch: typeof playerValuesRepository.insertBatch;
   loadTeamsBasicInfo: typeof loadTeamsBasicInfo;
-  getCachedValues: typeof playerValuesCache.get;
+  inspectCachedValues: typeof playerValuesCache.inspect;
   mergeCachedValues: typeof playerValuesCache.merge;
+  deleteCachedFields: typeof playerValuesCache.deleteFields;
   enqueuePlayerPrices: typeof enqueuePlayerPricesSyncJob;
   notify: typeof notifyTwoBots;
   getCurrentChangeDate: () => string;
@@ -35,8 +37,9 @@ const defaultDependencies: PlayerValuesSyncDependencies = {
   findByChangeDate: playerValuesRepository.findByChangeDate,
   insertBatch: playerValuesRepository.insertBatch,
   loadTeamsBasicInfo,
-  getCachedValues: playerValuesCache.get,
+  inspectCachedValues: playerValuesCache.inspect,
   mergeCachedValues: playerValuesCache.merge,
+  deleteCachedFields: playerValuesCache.deleteFields,
   enqueuePlayerPrices: enqueuePlayerPricesSyncJob,
   notify: notifyTwoBots,
   getCurrentChangeDate: () => formatCronDateKey(),
@@ -101,15 +104,18 @@ function playerValueMatches(left: PlayerValue, right: PlayerValue): boolean {
   );
 }
 
-export function findPlayerValueCacheRepairs(
+export function planPlayerValueCacheRepairs(
   expected: PlayerValue[],
-  cached: PlayerValue[] | null,
-): PlayerValue[] {
-  const cachedById = new Map((cached ?? []).map((row) => [row.elementId, row]));
-  return expected.filter((row) => {
-    const cachedRow = cachedById.get(row.elementId);
+  snapshot: PlayerValueCacheSnapshot,
+): { writes: PlayerValue[]; staleFields: string[] } {
+  const expectedFields = new Set(expected.map((row) => String(row.elementId)));
+  const cachedByField = new Map(snapshot.entries);
+  const writes = expected.filter((row) => {
+    const cachedRow = cachedByField.get(String(row.elementId));
     return !cachedRow || !playerValueMatches(row, cachedRow);
   });
+  const staleFields = snapshot.fields.filter((field) => !expectedFields.has(field));
+  return { writes, staleFields };
 }
 
 function enrichStoredRows(
@@ -227,19 +233,24 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
 
     const elementsById = new Map(bootstrapData.elements.map((element) => [element.id, element]));
     const expectedCacheRows = enrichStoredRows(persistedRows, elementsById, teamsMap);
-    const cachedRows = await dependencies.getCachedValues(changeDate);
-    const cacheRepairs = findPlayerValueCacheRepairs(expectedCacheRows, cachedRows);
+    const cacheSnapshot = await dependencies.inspectCachedValues(changeDate);
+    const cacheRepairs = planPlayerValueCacheRepairs(expectedCacheRows, cacheSnapshot);
     // Even when every history field already matches, rewrite one verified
     // positive field before deleting the negative marker. This makes a retry
     // recover when a prior HSET succeeded but its subsequent DEL failed.
-    const cacheWrites = cacheRepairs.length > 0 ? cacheRepairs : expectedCacheRows.slice(0, 1);
+    const cacheWrites =
+      cacheRepairs.writes.length > 0 ? cacheRepairs.writes : expectedCacheRows.slice(0, 1);
     if (cacheWrites.length > 0) {
       await dependencies.mergeCachedValues(changeDate, cacheWrites);
     }
-    if (cacheRepairs.length > 0) {
+    if (cacheRepairs.staleFields.length > 0) {
+      await dependencies.deleteCachedFields(changeDate, cacheRepairs.staleFields);
+    }
+    if (cacheRepairs.writes.length > 0 || cacheRepairs.staleFields.length > 0) {
       logInfo('Player values cache fields repaired', {
         changeDate,
-        count: cacheRepairs.length,
+        writes: cacheRepairs.writes.length,
+        deletes: cacheRepairs.staleFields.length,
       });
     }
 

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -1,12 +1,43 @@
 import { playerValuesCache } from '../cache/operations';
 import { fplClient } from '../clients/fpl';
 import type { PlayerValue } from '../domain/player-values';
+import { enqueuePlayerPricesSyncJob } from '../jobs/data-sync-enqueue';
+import type { StoredPlayerValue } from '../repositories/player-values';
 import { playerValuesRepository } from '../repositories/player-values';
-import { createTeamsMap } from '../transformers/player-values';
+import { createTeamsMap, transformPlayerValuesWithChanges } from '../transformers/player-values';
+import type { RawFPLElement } from '../types';
+import { ELEMENT_TYPE_MAP } from '../types/base.type';
 import { notifyTwoBots } from '../utils/notify';
-import { logInfo } from '../utils/logger';
+import { logError, logInfo } from '../utils/logger';
 import { loadTeamsBasicInfo } from '../utils/teams';
-import { getCurrentEvent } from './events.service';
+import { formatCronDateKey } from '../utils/timezone';
+import { resolvePlayerSyncEvent } from './player-sync-event.service';
+
+export type PlayerValuesSyncDependencies = {
+  getBootstrap: typeof fplClient.getBootstrap;
+  resolvePlayerSyncEvent: typeof resolvePlayerSyncEvent;
+  findLatestForAllPlayers: typeof playerValuesRepository.findLatestForAllPlayers;
+  findByChangeDate: typeof playerValuesRepository.findByChangeDate;
+  insertBatch: typeof playerValuesRepository.insertBatch;
+  loadTeamsBasicInfo: typeof loadTeamsBasicInfo;
+  getCachedValues: typeof playerValuesCache.get;
+  mergeCachedValues: typeof playerValuesCache.merge;
+  enqueuePlayerPrices: typeof enqueuePlayerPricesSyncJob;
+  notify: typeof notifyTwoBots;
+};
+
+const defaultDependencies: PlayerValuesSyncDependencies = {
+  getBootstrap: () => fplClient.getBootstrap(),
+  resolvePlayerSyncEvent,
+  findLatestForAllPlayers: playerValuesRepository.findLatestForAllPlayers,
+  findByChangeDate: playerValuesRepository.findByChangeDate,
+  insertBatch: playerValuesRepository.insertBatch,
+  loadTeamsBasicInfo,
+  getCachedValues: playerValuesCache.get,
+  mergeCachedValues: playerValuesCache.merge,
+  enqueuePlayerPrices: enqueuePlayerPricesSyncJob,
+  notify: notifyTwoBots,
+};
 
 function formatPlayerValuesNotification(
   changeDate: string,
@@ -50,86 +81,176 @@ function formatPlayerValuesNotification(
  *
  * Player values are date-based (changeDate in YYYYMMDD format)
  */
-export async function syncCurrentPlayerValues(): Promise<{ count: number }> {
-  logInfo('Starting daily player values sync');
-
-  const bootstrapData = await fplClient.getBootstrap();
-  const currentEvent = await getCurrentEvent();
-  if (!currentEvent) {
-    throw new Error('No current event found');
-  }
-
-  if (!Array.isArray(bootstrapData.elements) || bootstrapData.elements.length === 0) {
-    throw new Error('No player values returned from FPL API');
-  }
-
-  // Generate today's date in YYYYMMDD format (e.g., "20260118")
-  const today = new Date().toISOString().split('T')[0].replace(/-/g, '');
-
-  // Get last stored value for each player
-  const lastStoredValues = await playerValuesRepository.findLatestForAllPlayers();
-  const lastValueMap = new Map<number, number>();
-  lastStoredValues.forEach((pv) => lastValueMap.set(pv.elementId, pv.value));
-
-  // Check if we've already recorded changes for today
-  const todaysRecords = await playerValuesRepository.findByChangeDate(today);
-  const todaysPlayerIds = new Set(todaysRecords.map((pv) => pv.elementId));
-
-  const teams = await loadTeamsBasicInfo();
-  const teamsMap = createTeamsMap(teams);
-
-  // Find players with price changes that haven't been recorded today
-  const playersWithChanges = bootstrapData.elements.filter((player) => {
-    if (todaysPlayerIds.has(player.id)) return false;
-    const lastValue = lastValueMap.get(player.id) || 0;
-    return player.now_cost !== lastValue;
-  });
-
-  if (playersWithChanges.length === 0) {
-    logInfo('No player price changes detected today');
-    // Clear cache for today if no changes (in case there was old data)
-    await playerValuesCache.clear(today);
-    return { count: 0 };
-  }
-
-  const { transformPlayerValuesWithChanges } = await import('../transformers/player-values');
-  const playerValues = transformPlayerValuesWithChanges(
-    playersWithChanges,
-    currentEvent.id,
-    teamsMap,
-    lastValueMap,
-    today,
+function playerValueMatches(left: PlayerValue, right: PlayerValue): boolean {
+  return (
+    left.elementId === right.elementId &&
+    left.eventId === right.eventId &&
+    left.elementType === right.elementType &&
+    left.value === right.value &&
+    left.lastValue === right.lastValue &&
+    left.changeDate === right.changeDate &&
+    left.changeType === right.changeType
   );
+}
 
-  const result = await playerValuesRepository.insertBatch(playerValues);
+export function findPlayerValueCacheRepairs(
+  expected: PlayerValue[],
+  cached: PlayerValue[] | null,
+): PlayerValue[] {
+  const cachedById = new Map((cached ?? []).map((row) => [row.elementId, row]));
+  return expected.filter((row) => {
+    const cachedRow = cachedById.get(row.elementId);
+    return !cachedRow || !playerValueMatches(row, cachedRow);
+  });
+}
 
-  // Cache/notify only rows that were actually inserted — partial ON CONFLICT
-  // DO NOTHING must not publish skipped values to Telegram (FP-10).
-  // Merge into Redis (do not replace the whole hash) so concurrent daily syncs
-  // that each insert different elements do not erase each other's winners.
-  if (result.count > 0) {
-    await playerValuesCache.merge(today, result.inserted);
-    logInfo('Player values cache merged', {
-      changeDate: today,
-      count: result.inserted.length,
+function enrichStoredRows(
+  rows: StoredPlayerValue[],
+  elementsById: Map<number, RawFPLElement>,
+  teamsMap: Map<number, { name: string; shortName: string }>,
+): PlayerValue[] {
+  return rows.map((row) => {
+    const player = elementsById.get(row.elementId);
+    if (!player) {
+      throw new Error(`Bootstrap player missing for stored value: ${row.elementId}`);
+    }
+    const team = teamsMap.get(player.team);
+    if (!team) {
+      throw new Error(`Team missing for stored player value: ${player.team}`);
+    }
+
+    return {
+      ...row,
+      elementType: row.elementType as 1 | 2 | 3 | 4,
+      elementTypeName: ELEMENT_TYPE_MAP[row.elementType as 1 | 2 | 3 | 4],
+      webName: player.web_name,
+      teamId: player.team,
+      teamName: team.name,
+      teamShortName: team.shortName,
+    };
+  });
+}
+
+export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencies) {
+  return async function syncForDate(
+    changeDate: string = formatCronDateKey(),
+  ): Promise<{ count: number }> {
+    logInfo('Starting daily player values sync');
+
+    if (!/^\d{8}$/.test(changeDate)) {
+      throw new Error(`Invalid player value change date: ${changeDate}`);
+    }
+
+    const [bootstrapData, syncEvent] = await Promise.all([
+      dependencies.getBootstrap(),
+      dependencies.resolvePlayerSyncEvent(),
+    ]);
+    if (!syncEvent) {
+      throw new Error('No current or next event found for player values');
+    }
+
+    if (!Array.isArray(bootstrapData.elements) || bootstrapData.elements.length === 0) {
+      throw new Error('No player values returned from FPL API');
+    }
+
+    // Get last stored value for each player
+    const lastStoredValues = await dependencies.findLatestForAllPlayers();
+    const lastValueMap = new Map<number, number>();
+    lastStoredValues.forEach((pv) => lastValueMap.set(pv.elementId, pv.value));
+
+    // Check if we've already recorded changes for today
+    const todaysRecords = await dependencies.findByChangeDate(changeDate);
+    const todaysPlayerIds = new Set(todaysRecords.map((pv) => pv.elementId));
+
+    // Find players with price changes that haven't been recorded today
+    const playersWithChanges = bootstrapData.elements.filter((player) => {
+      if (todaysPlayerIds.has(player.id)) return false;
+      const lastValue = lastValueMap.get(player.id);
+      return lastValue === undefined || player.now_cost !== lastValue;
     });
 
-    const hasRiseOrFall = result.inserted.some(
-      (pv) => pv.changeType === 'Rise' || pv.changeType === 'Faller',
-    );
-    if (hasRiseOrFall) {
-      const message = formatPlayerValuesNotification(today, result.inserted);
-      await notifyTwoBots(message);
+    if (playersWithChanges.length === 0 && todaysRecords.length === 0) {
+      logInfo('No player price changes detected; preserving database and cache', { changeDate });
+      return { count: 0 };
     }
-  }
 
-  logInfo('Daily player values sync completed', {
-    eventId: currentEvent.id,
-    changeDate: today,
-    totalChecked: bootstrapData.elements.length,
-    changesDetected: playersWithChanges.length,
-    recordsInserted: result.count,
-  });
+    const teams = await dependencies.loadTeamsBasicInfo();
+    const teamsMap = createTeamsMap(teams);
 
-  return { count: result.count };
+    const playerValues = transformPlayerValuesWithChanges(
+      playersWithChanges,
+      syncEvent.event.id,
+      teamsMap,
+      lastValueMap,
+      changeDate,
+    );
+
+    const result = await dependencies.insertBatch(playerValues);
+
+    const persistedRows =
+      playersWithChanges.length > 0
+        ? await dependencies.findByChangeDate(changeDate)
+        : todaysRecords;
+    const persistedById = new Map(persistedRows.map((row) => [row.elementId, row]));
+    for (const expected of playerValues) {
+      const persisted = persistedById.get(expected.elementId);
+      if (
+        !persisted ||
+        persisted.value !== expected.value ||
+        persisted.lastValue !== expected.lastValue ||
+        persisted.changeType !== expected.changeType
+      ) {
+        throw new Error(
+          `Player value persistence verification failed for player ${expected.elementId}`,
+        );
+      }
+    }
+
+    const elementsById = new Map(bootstrapData.elements.map((element) => [element.id, element]));
+    const expectedCacheRows = enrichStoredRows(persistedRows, elementsById, teamsMap);
+    const cachedRows = await dependencies.getCachedValues(changeDate);
+    const cacheRepairs = findPlayerValueCacheRepairs(expectedCacheRows, cachedRows);
+    if (cacheRepairs.length > 0) {
+      await dependencies.mergeCachedValues(changeDate, cacheRepairs);
+      logInfo('Player values cache fields repaired', {
+        changeDate,
+        count: cacheRepairs.length,
+      });
+    }
+
+    const hasPersistedPriceChanges = persistedRows.some(
+      (row) => row.changeType === 'Rise' || row.changeType === 'Faller',
+    );
+    if (hasPersistedPriceChanges) {
+      await dependencies.enqueuePlayerPrices('cascade', {
+        changeDate,
+        jobId: `player-prices-${changeDate}-immediate`,
+        removeOnSettle: true,
+      });
+    }
+
+    const insertedPriceChanges = result.inserted.filter(
+      (row) => row.changeType === 'Rise' || row.changeType === 'Faller',
+    );
+    if (insertedPriceChanges.length > 0) {
+      try {
+        const message = formatPlayerValuesNotification(changeDate, result.inserted);
+        await dependencies.notify(message);
+      } catch (error) {
+        logError('Failed to send player values notification', error, { changeDate });
+      }
+    }
+
+    logInfo('Daily player values sync completed', {
+      eventId: syncEvent.event.id,
+      changeDate,
+      totalChecked: bootstrapData.elements.length,
+      changesDetected: playersWithChanges.length,
+      recordsInserted: result.count,
+    });
+
+    return { count: result.count };
+  };
 }
+
+export const syncCurrentPlayerValues = createPlayerValuesSync(defaultDependencies);

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -9,6 +9,7 @@ import type { RawFPLElement } from '../types';
 import { ELEMENT_TYPE_MAP } from '../types/base.type';
 import { notifyTwoBots } from '../utils/notify';
 import { logError, logInfo } from '../utils/logger';
+import { getPlayerValueSeasonFloor } from '../utils/player-value-season';
 import { loadTeamsBasicInfo } from '../utils/teams';
 import { formatCronDateKey } from '../utils/timezone';
 import { resolvePlayerSyncEvent } from './player-sync-event.service';
@@ -24,6 +25,7 @@ export type PlayerValuesSyncDependencies = {
   mergeCachedValues: typeof playerValuesCache.merge;
   enqueuePlayerPrices: typeof enqueuePlayerPricesSyncJob;
   notify: typeof notifyTwoBots;
+  getCurrentChangeDate: () => string;
 };
 
 const defaultDependencies: PlayerValuesSyncDependencies = {
@@ -37,6 +39,7 @@ const defaultDependencies: PlayerValuesSyncDependencies = {
   mergeCachedValues: playerValuesCache.merge,
   enqueuePlayerPrices: enqueuePlayerPricesSyncJob,
   notify: notifyTwoBots,
+  getCurrentChangeDate: () => formatCronDateKey(),
 };
 
 function formatPlayerValuesNotification(
@@ -136,28 +139,6 @@ function enrichStoredRows(
   });
 }
 
-/**
- * player_values is intentionally date-keyed and has no season column. Scope
- * comparisons to the published season inferred from the target event's
- * deadline so reused element IDs cannot inherit prior-season price history.
- */
-export function getPlayerValueSeasonFloor(deadlineTime: string | null): string {
-  if (!deadlineTime) {
-    throw new Error('Player value season cannot be resolved without an event deadline');
-  }
-
-  const deadline = new Date(deadlineTime);
-  if (Number.isNaN(deadline.getTime())) {
-    throw new Error(`Invalid event deadline for player value season: ${deadlineTime}`);
-  }
-
-  // The previous FPL season finishes in May. June 1 is therefore a stable
-  // boundary that also permits unusually early preseason bootstrap releases.
-  const deadlineYear = deadline.getUTCFullYear();
-  const seasonStartYear = deadline.getUTCMonth() >= 6 ? deadlineYear : deadlineYear - 1;
-  return `${seasonStartYear}0601`;
-}
-
 export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencies) {
   return async function syncForDate(
     changeDate: string = formatCronDateKey(),
@@ -166,6 +147,15 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
 
     if (!/^\d{8}$/.test(changeDate)) {
       throw new Error(`Invalid player value change date: ${changeDate}`);
+    }
+
+    const currentChangeDate = dependencies.getCurrentChangeDate();
+    if (changeDate !== currentChangeDate) {
+      logInfo('Skipping player values capture outside its scheduled date', {
+        changeDate,
+        currentChangeDate,
+      });
+      return { count: 0 };
     }
 
     const [bootstrapData, syncEvent] = await Promise.all([

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -5,8 +5,9 @@ import type { PlayerValue } from '../domain/player-values';
 import { enqueuePlayerPricesSyncJob } from '../jobs/data-sync-enqueue';
 import type { StoredPlayerValue } from '../repositories/player-values';
 import { playerValuesRepository } from '../repositories/player-values';
+import { playerRepository } from '../repositories/players';
 import { createTeamsMap, transformPlayerValuesWithChanges } from '../transformers/player-values';
-import type { RawFPLElement } from '../types';
+import type { Player, RawFPLElement } from '../types';
 import { ELEMENT_TYPE_MAP } from '../types/base.type';
 import { notifyTwoBots } from '../utils/notify';
 import { logError, logInfo } from '../utils/logger';
@@ -20,6 +21,7 @@ export type PlayerValuesSyncDependencies = {
   resolvePlayerSyncEvent: typeof resolvePlayerSyncEvent;
   findLatestForAllPlayers: typeof playerValuesRepository.findLatestForAllPlayers;
   findByChangeDate: typeof playerValuesRepository.findByChangeDate;
+  findPlayersByIds: typeof playerRepository.findByIds;
   insertBatch: typeof playerValuesRepository.insertBatch;
   loadTeamsBasicInfo: typeof loadTeamsBasicInfo;
   inspectCachedValues: typeof playerValuesCache.inspect;
@@ -35,6 +37,7 @@ const defaultDependencies: PlayerValuesSyncDependencies = {
   resolvePlayerSyncEvent,
   findLatestForAllPlayers: playerValuesRepository.findLatestForAllPlayers,
   findByChangeDate: playerValuesRepository.findByChangeDate,
+  findPlayersByIds: playerRepository.findByIds,
   insertBatch: playerValuesRepository.insertBatch,
   loadTeamsBasicInfo,
   inspectCachedValues: playerValuesCache.inspect,
@@ -121,24 +124,31 @@ export function planPlayerValueCacheRepairs(
 function enrichStoredRows(
   rows: StoredPlayerValue[],
   elementsById: Map<number, RawFPLElement>,
+  retainedPlayersById: Map<number, Player>,
   teamsMap: Map<number, { name: string; shortName: string }>,
 ): PlayerValue[] {
   return rows.map((row) => {
-    const player = elementsById.get(row.elementId);
-    if (!player) {
-      throw new Error(`Bootstrap player missing for stored value: ${row.elementId}`);
+    const livePlayer = elementsById.get(row.elementId);
+    const retainedPlayer = retainedPlayersById.get(row.elementId);
+    const identity = livePlayer
+      ? { teamId: livePlayer.team, webName: livePlayer.web_name }
+      : retainedPlayer
+        ? { teamId: retainedPlayer.teamId, webName: retainedPlayer.webName }
+        : null;
+    if (!identity) {
+      throw new Error(`Player identity missing for stored value: ${row.elementId}`);
     }
-    const team = teamsMap.get(player.team);
+    const team = teamsMap.get(identity.teamId);
     if (!team) {
-      throw new Error(`Team missing for stored player value: ${player.team}`);
+      throw new Error(`Team missing for stored player value: ${identity.teamId}`);
     }
 
     return {
       ...row,
       elementType: row.elementType as 1 | 2 | 3 | 4,
       elementTypeName: ELEMENT_TYPE_MAP[row.elementType as 1 | 2 | 3 | 4],
-      webName: player.web_name,
-      teamId: player.team,
+      webName: identity.webName,
+      teamId: identity.teamId,
       teamName: team.name,
       teamShortName: team.shortName,
     };
@@ -232,7 +242,24 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
     }
 
     const elementsById = new Map(bootstrapData.elements.map((element) => [element.id, element]));
-    const expectedCacheRows = enrichStoredRows(persistedRows, elementsById, teamsMap);
+    const missingLivePlayerIds = Array.from(
+      new Set(
+        persistedRows
+          .map((row) => row.elementId)
+          .filter((elementId) => !elementsById.has(elementId)),
+      ),
+    );
+    const retainedPlayers =
+      missingLivePlayerIds.length > 0
+        ? await dependencies.findPlayersByIds(missingLivePlayerIds)
+        : [];
+    const retainedPlayersById = new Map(retainedPlayers.map((player) => [player.id, player]));
+    const expectedCacheRows = enrichStoredRows(
+      persistedRows,
+      elementsById,
+      retainedPlayersById,
+      teamsMap,
+    );
     const cacheSnapshot = await dependencies.inspectCachedValues(changeDate);
     const cacheRepairs = planPlayerValueCacheRepairs(expectedCacheRows, cacheSnapshot);
     // Even when every history field already matches, rewrite one verified

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -84,8 +84,13 @@ function formatPlayerValuesNotification(
 function playerValueMatches(left: PlayerValue, right: PlayerValue): boolean {
   return (
     left.elementId === right.elementId &&
+    left.webName === right.webName &&
     left.eventId === right.eventId &&
     left.elementType === right.elementType &&
+    left.elementTypeName === right.elementTypeName &&
+    left.teamId === right.teamId &&
+    left.teamName === right.teamName &&
+    left.teamShortName === right.teamShortName &&
     left.value === right.value &&
     left.lastValue === right.lastValue &&
     left.changeDate === right.changeDate &&
@@ -210,8 +215,14 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
     const expectedCacheRows = enrichStoredRows(persistedRows, elementsById, teamsMap);
     const cachedRows = await dependencies.getCachedValues(changeDate);
     const cacheRepairs = findPlayerValueCacheRepairs(expectedCacheRows, cachedRows);
+    // Even when every history field already matches, rewrite one verified
+    // positive field before deleting the negative marker. This makes a retry
+    // recover when a prior HSET succeeded but its subsequent DEL failed.
+    const cacheWrites = cacheRepairs.length > 0 ? cacheRepairs : expectedCacheRows.slice(0, 1);
+    if (cacheWrites.length > 0) {
+      await dependencies.mergeCachedValues(changeDate, cacheWrites);
+    }
     if (cacheRepairs.length > 0) {
-      await dependencies.mergeCachedValues(changeDate, cacheRepairs);
       logInfo('Player values cache fields repaired', {
         changeDate,
         count: cacheRepairs.length,

--- a/src/transformers/player-stats.ts
+++ b/src/transformers/player-stats.ts
@@ -271,7 +271,7 @@ export function transformCurrentGameweekPlayerStats(
     })),
   );
 
-  return transformPlayerStats(fplBootstrapResponse.elements, currentEventId, teamsMap);
+  return transformPlayerStatsStrict(fplBootstrapResponse.elements, currentEventId, teamsMap);
 }
 
 /**

--- a/src/transformers/player-values.ts
+++ b/src/transformers/player-values.ts
@@ -8,6 +8,7 @@ import type { RawFPLElement } from '../types';
 import type { EventId, ValueChangeType } from '../types/base.type';
 import { ELEMENT_TYPE_MAP } from '../types/base.type';
 import { logError, logInfo } from '../utils/logger';
+import { formatCronDateKey } from '../utils/timezone';
 
 // ================================
 // Data Transformation Functions
@@ -32,14 +33,14 @@ export function transformPlayerValue(
     }
 
     // Get previous value for comparison
-    const lastValue = previousValuesMap?.get(rawElement.id) || rawElement.now_cost;
+    const lastValue = previousValuesMap?.get(rawElement.id) ?? 0;
     const currentValue = rawElement.now_cost;
 
     // Determine change type
     const changeType = determineValueChangeType(currentValue, lastValue);
 
     // Use current date if no change date provided
-    const effectiveChangeDate = changeDate || new Date().toISOString();
+    const effectiveChangeDate = changeDate ?? formatCronDateKey();
 
     // Transform to domain model
     const playerValue: PlayerValue = {
@@ -78,9 +79,9 @@ export function transformRawPlayerValue(
 ): RawPlayerValue {
   try {
     const currentValue = rawElement.now_cost;
-    const effectiveLastValue = lastValue || currentValue;
+    const effectiveLastValue = lastValue ?? 0;
     const changeType = determineValueChangeType(currentValue, effectiveLastValue);
-    const effectiveChangeDate = changeDate || new Date().toISOString();
+    const effectiveChangeDate = changeDate ?? formatCronDateKey();
 
     const rawPlayerValue: RawPlayerValue = {
       elementId: rawElement.id,
@@ -319,28 +320,18 @@ export function transformPlayerValuesWithChanges(
   lastValueMap: Map<number, number>,
   changeDate: string,
 ): PlayerValue[] {
-  const results: PlayerValue[] = [];
-  let successCount = 0;
-  let errorCount = 0;
-
-  for (const player of changedPlayers) {
+  return changedPlayers.map((player, index) => {
     try {
-      // Get team information
       const team = teamsMap.get(player.team);
       if (!team) {
-        logError('Team not found for player', { playerId: player.id, teamId: player.team });
-        errorCount++;
-        continue;
+        throw new Error(`Team not found for ID: ${player.team}`);
       }
 
-      // Get last known value for this player
-      const lastValue = lastValueMap.get(player.id) || 0;
+      const lastValue = lastValueMap.get(player.id) ?? 0;
       const currentValue = player.now_cost;
-
-      // Determine change type based on price comparison
       const changeType = determineValueChangeType(currentValue, lastValue);
 
-      const playerValue: PlayerValue = {
+      return validatePlayerValue({
         eventId,
         elementId: player.id,
         webName: player.web_name,
@@ -353,26 +344,15 @@ export function transformPlayerValuesWithChanges(
         lastValue,
         changeDate,
         changeType,
-      };
-
-      results.push(playerValue);
-      successCount++;
-    } catch (error) {
-      logError('Failed to transform player value', error, {
-        playerId: player.id,
-        playerName: player.web_name,
       });
-      errorCount++;
+    } catch (error) {
+      throw new Error(
+        `Failed to transform changed player at index ${index}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
     }
-  }
-
-  logInfo('Player values transformation completed', {
-    totalInput: changedPlayers.length,
-    successfulOutput: successCount,
-    skippedCount: errorCount,
   });
-
-  return results;
 }
 
 /**

--- a/src/utils/player-value-season.ts
+++ b/src/utils/player-value-season.ts
@@ -1,0 +1,34 @@
+function seasonStartYear(year: number, month: number, boundaryMonth: number): number {
+  return month >= boundaryMonth ? year : year - 1;
+}
+
+/**
+ * player_values is date-keyed and has no season column. June 1 is the stable
+ * post-season boundary before a new FPL bootstrap can publish its roster.
+ */
+export function getPlayerValueSeasonFloor(deadlineTime: string | null): string {
+  if (!deadlineTime) {
+    throw new Error('Player value season cannot be resolved without an event deadline');
+  }
+
+  const deadline = new Date(deadlineTime);
+  if (Number.isNaN(deadline.getTime())) {
+    throw new Error(`Invalid event deadline for player value season: ${deadlineTime}`);
+  }
+
+  return `${seasonStartYear(deadline.getUTCFullYear(), deadline.getUTCMonth() + 1, 7)}0601`;
+}
+
+export function getPlayerValueSeasonFloorForDate(changeDate: string): string {
+  if (!/^\d{8}$/.test(changeDate)) {
+    throw new Error(`Invalid player value change date: ${changeDate}`);
+  }
+
+  const year = Number.parseInt(changeDate.slice(0, 4), 10);
+  const month = Number.parseInt(changeDate.slice(4, 6), 10);
+  if (month < 1 || month > 12) {
+    throw new Error(`Invalid player value change date: ${changeDate}`);
+  }
+
+  return `${seasonStartYear(year, month, 6)}0601`;
+}

--- a/src/utils/player-value-season.ts
+++ b/src/utils/player-value-season.ts
@@ -18,17 +18,3 @@ export function getPlayerValueSeasonFloor(deadlineTime: string | null): string {
 
   return `${seasonStartYear(deadline.getUTCFullYear(), deadline.getUTCMonth() + 1, 7)}0601`;
 }
-
-export function getPlayerValueSeasonFloorForDate(changeDate: string): string {
-  if (!/^\d{8}$/.test(changeDate)) {
-    throw new Error(`Invalid player value change date: ${changeDate}`);
-  }
-
-  const year = Number.parseInt(changeDate.slice(0, 4), 10);
-  const month = Number.parseInt(changeDate.slice(4, 6), 10);
-  if (month < 1 || month > 12) {
-    throw new Error(`Invalid player value change date: ${changeDate}`);
-  }
-
-  return `${seasonStartYear(year, month, 6)}0601`;
-}

--- a/src/utils/player-value-season.ts
+++ b/src/utils/player-value-season.ts
@@ -18,3 +18,15 @@ export function getPlayerValueSeasonFloor(deadlineTime: string | null): string {
 
   return `${seasonStartYear(deadline.getUTCFullYear(), deadline.getUTCMonth() + 1, 7)}0601`;
 }
+
+export function getPlayerValueSeasonBounds(deadlineTime: string | null): {
+  fromChangeDate: string;
+  beforeChangeDate: string;
+} {
+  const fromChangeDate = getPlayerValueSeasonFloor(deadlineTime);
+  const startYear = Number.parseInt(fromChangeDate.slice(0, 4), 10);
+  return {
+    fromChangeDate,
+    beforeChangeDate: `${startYear + 1}0601`,
+  };
+}

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -15,6 +15,16 @@ function getPart(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPart
   return parts.find((part) => part.type === type)?.value ?? '00';
 }
 
+export function formatCronDateKey(date: Date = new Date()): string {
+  const parts = utc8Formatter.formatToParts(date);
+  return `${getPart(parts, 'year')}${getPart(parts, 'month')}${getPart(parts, 'day')}`;
+}
+
+export function getCronMinute(date: Date = new Date()): number {
+  const minute = Number.parseInt(getPart(utc8Formatter.formatToParts(date), 'minute'), 10);
+  return Number.isFinite(minute) ? minute : 0;
+}
+
 /**
  * Format timestamp as ISO-like UTC+8 string.
  * Example: 2026-04-19T23:05:01.123+08:00

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -11,6 +11,7 @@ import { syncEvents } from '../services/events.service';
 import { syncAllGameweeks, syncFixtures } from '../services/fixtures.service';
 import { syncPhases } from '../services/phases.service';
 import { syncPlayers } from '../services/players.service';
+import { syncPlayerPricesForDate } from '../services/player-prices.service';
 import { syncCurrentPlayerStats, syncPlayerStatsForEvent } from '../services/player-stats.service';
 import { syncCurrentPlayerValues } from '../services/player-values.service';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
@@ -19,6 +20,7 @@ import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
 import { alertOnFinalFailure } from '../utils/notify';
 import { withMutationConflictGuard } from '../utils/mutation-lock';
+import { formatCronDateKey } from '../utils/timezone';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
 
@@ -54,6 +56,11 @@ const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
             return syncTeams();
           case 'players':
             return syncPlayers();
+          case 'player-prices':
+            if (!job.data.changeDate) {
+              throw new Error('player-prices job requires changeDate');
+            }
+            return syncPlayerPricesForDate(job.data.changeDate);
           case 'player-stats':
             return job.data.eventId !== undefined
               ? syncPlayerStatsForEvent(job.data.eventId)
@@ -61,7 +68,9 @@ const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
           case 'phases':
             return syncPhases();
           case 'player-values':
-            return syncCurrentPlayerValues();
+            return syncCurrentPlayerValues(
+              job.data.changeDate ?? formatCronDateKey(new Date(job.data.triggeredAt)),
+            );
           default:
             throw new Error(`Unknown data-sync job: ${job.name}`);
         }

--- a/tests/fixtures/player-values.fixtures.ts
+++ b/tests/fixtures/player-values.fixtures.ts
@@ -13,7 +13,7 @@ export const singlePlayerValueFixture: PlayerValue = {
   teamName: 'Manchester City',
   teamShortName: 'MCI',
   value: 142,
-  changeDate: '2023-12-15T10:00:00.000Z',
+  changeDate: '20231215',
   changeType: 'Rise' as ValueChangeType,
   lastValue: 138,
 };
@@ -25,7 +25,7 @@ export const singleRawPlayerValueFixture: RawPlayerValue = {
   eventId: 15 as EventId,
   teamId: 11 as TeamId,
   value: 142,
-  changeDate: '2023-12-15T10:00:00.000Z',
+  changeDate: '20231215',
   changeType: 'Rise' as ValueChangeType,
   lastValue: 138,
 };
@@ -41,9 +41,9 @@ export const gkpPlayerValueFixture: PlayerValue = {
   teamName: 'Liverpool',
   teamShortName: 'LIV',
   value: 55,
-  changeDate: '2023-12-15T10:00:00.000Z',
+  changeDate: '20231215',
   changeType: 'Start' as ValueChangeType,
-  lastValue: 55,
+  lastValue: 0,
 };
 
 export const defPlayerValueFixture: PlayerValue = {
@@ -56,7 +56,7 @@ export const defPlayerValueFixture: PlayerValue = {
   teamName: 'Liverpool',
   teamShortName: 'LIV',
   value: 72,
-  changeDate: '2023-12-15T10:00:00.000Z',
+  changeDate: '20231215',
   changeType: 'Faller' as ValueChangeType,
   lastValue: 74,
 };
@@ -71,7 +71,7 @@ export const midPlayerValueFixture: PlayerValue = {
   teamName: 'Manchester City',
   teamShortName: 'MCI',
   value: 102,
-  changeDate: '2023-12-15T10:00:00.000Z',
+  changeDate: '20231215',
   changeType: 'Rise' as ValueChangeType,
   lastValue: 100,
 };
@@ -86,9 +86,9 @@ export const fwdPlayerValueFixture: PlayerValue = {
   teamName: 'Liverpool',
   teamShortName: 'LIV',
   value: 125,
-  changeDate: '2023-12-15T10:00:00.000Z',
+  changeDate: '20231215',
   changeType: 'Start' as ValueChangeType,
-  lastValue: 125,
+  lastValue: 0,
 };
 
 // Array of player values for different teams and positions
@@ -201,9 +201,9 @@ export function generatePlayerValue(overrides: Partial<PlayerValue> = {}): Playe
     teamName: 'Test Team',
     teamShortName: 'TST',
     value: 80,
-    changeDate: '2023-12-15T10:00:00.000Z',
+    changeDate: '20231215',
     changeType: 'Start' as ValueChangeType,
-    lastValue: 80,
+    lastValue: 0,
     ...overrides,
   };
 }
@@ -211,15 +211,16 @@ export function generatePlayerValue(overrides: Partial<PlayerValue> = {}): Playe
 // Generate array of player values
 export function generatePlayerValues(count: number = 3): PlayerValue[] {
   const cycle: ValueChangeType[] = ['Rise', 'Faller', 'Start'];
-  return Array.from({ length: count }, (_, index) =>
-    generatePlayerValue({
+  return Array.from({ length: count }, (_, index) => {
+    const changeType = cycle[index % cycle.length];
+    return generatePlayerValue({
       elementId: (index + 1) as PlayerId,
       webName: `Player ${index + 1}`,
       value: 60 + index * 10,
-      lastValue: 58 + index * 10,
-      changeType: cycle[index % cycle.length],
-    }),
-  );
+      lastValue: changeType === 'Start' ? 0 : 58 + index * 10,
+      changeType,
+    });
+  });
 }
 
 // Generate player values with different change types
@@ -243,7 +244,7 @@ export function generatePlayerValuesWithChanges(): PlayerValue[] {
       elementId: 3 as PlayerId,
       webName: 'Stable Player',
       value: 80,
-      lastValue: 80,
+      lastValue: 0,
       changeType: 'Start',
     }),
   ];

--- a/tests/integration/upsert-correctness.test.ts
+++ b/tests/integration/upsert-correctness.test.ts
@@ -8,6 +8,7 @@ import type { PlayerValue } from '../../src/domain/player-values';
 import { getDbClient } from '../../src/db/singleton';
 import { createEntryEventTransfersRepository } from '../../src/repositories/entry-event-transfers';
 import { createPlayerValuesRepository } from '../../src/repositories/player-values';
+import { createPlayerRepository } from '../../src/repositories/players';
 import type { RawFPLEntryTransfer } from '../../src/types';
 
 /**
@@ -32,6 +33,7 @@ async function db() {
 }
 const transfersRepository = createEntryEventTransfersRepository();
 const playerValuesRepository = createPlayerValuesRepository();
+const playerRepository = createPlayerRepository();
 
 function buildPlayerValue(elementId: number, value: number): PlayerValue {
   return {
@@ -84,6 +86,8 @@ beforeAll(async () => {
           code: id,
           type: 1,
           team_id: TEAM_ID,
+          price: 50,
+          start_price: 50,
           web_name: `Player ${id}`,
         })),
       )}
@@ -218,5 +222,42 @@ describe('player-values concurrent insert race (H6)', () => {
     // Idempotent re-run of the same day inserts nothing
     const rerun = await playerValuesRepository.insertBatch(batchA);
     expect(rerun.count).toBe(0);
+  });
+});
+
+describe('affected-player current price update', () => {
+  test('updates and returns only requested complete player rows idempotently', async () => {
+    const client = await db();
+    await client`
+      UPDATE players
+      SET price = CASE
+        WHEN id = ${VALUE_PLAYER_A} THEN 50
+        WHEN id = ${VALUE_PLAYER_B} THEN 100
+        WHEN id = ${PLAYER_OUT} THEN 77
+        ELSE price
+      END
+      WHERE id IN (${VALUE_PLAYER_A}, ${VALUE_PLAYER_B}, ${PLAYER_OUT})
+    `;
+
+    const updates = [
+      { elementId: VALUE_PLAYER_A, value: 51 },
+      { elementId: VALUE_PLAYER_B, value: 99 },
+    ];
+    const first = await playerRepository.updatePrices(updates);
+    const second = await playerRepository.updatePrices(updates);
+
+    expect(first.map((row) => row.id).sort()).toEqual([VALUE_PLAYER_A, VALUE_PLAYER_B]);
+    expect(first.every((row) => row.webName.length > 0 && row.teamId === TEAM_ID)).toBe(true);
+    expect(second.map((row) => row.price).sort((a, b) => a - b)).toEqual([51, 99]);
+
+    const stored = await client<{ id: number; price: number }[]>`
+      SELECT id, price
+      FROM players
+      WHERE id IN (${VALUE_PLAYER_A}, ${VALUE_PLAYER_B}, ${PLAYER_OUT})
+      ORDER BY id
+    `;
+    expect(stored.find((row) => row.id === VALUE_PLAYER_A)?.price).toBe(51);
+    expect(stored.find((row) => row.id === VALUE_PLAYER_B)?.price).toBe(99);
+    expect(stored.find((row) => row.id === PLAYER_OUT)?.price).toBe(77);
   });
 });

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -17,10 +17,18 @@ class JobNotFoundError extends Error {
 
 const listTriggerableJobs = mock(() => [
   { name: 'events-sync', description: 'Sync events from FPL API', schedule: 'Daily at 6:35 AM' },
+  {
+    name: 'player-prices',
+    description: 'Replay persisted price changes',
+    schedule: 'Daily at 9:40 AM',
+  },
 ]);
-const triggerJob = mock(async (name: string) => {
+const triggerJob = mock(async (name: string, _input?: unknown) => {
   if (name === 'events-sync') {
     return { kind: 'enqueued' as const, jobId: 'job-events-1', message: 'Job triggered' };
+  }
+  if (name === 'player-prices') {
+    return { kind: 'enqueued' as const, jobId: 'job-player-prices-1', message: 'Job triggered' };
   }
   throw new JobNotFoundError(name);
 });
@@ -209,7 +217,20 @@ describe('jobsAPI handlers', () => {
     };
     expect(body.success).toBe(true);
     expect(body.jobId).toBe('job-events-1');
-    expect(triggerJob).toHaveBeenCalledWith('events-sync');
+    expect(triggerJob).toHaveBeenCalledWith('events-sync', undefined);
+  });
+
+  test('POST /jobs/player-prices/trigger forwards the required change date', async () => {
+    const response = await jobsAPI.handle(
+      new Request('http://localhost/jobs/player-prices/trigger', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ changeDate: '20260803' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(triggerJob).toHaveBeenCalledWith('player-prices', { changeDate: '20260803' });
   });
 
   test('POST /jobs/unknown/trigger returns 404', async () => {

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -42,12 +42,14 @@ const enqueueEventsSyncJob = mock(async () => ({ id: 'events-job-1' }));
 const enqueueFixturesSyncJob = mock(async () => ({ id: 'fixtures-job-1' }));
 const enqueueFixturesAllGameweeksSyncJob = mock(async () => ({ id: 'fixtures-all-gw-job-1' }));
 const enqueuePlayersSyncJob = mock(async () => ({ id: 'players-job-1' }));
+const enqueuePlayerValuesSyncJob = mock(async () => ({ id: 'player-values-job-1' }));
 const enqueuePlayerStatsSyncJob = mock(async () => ({ id: 'player-stats-job-1' }));
 mock.module('../../src/jobs/data-sync-enqueue', () => ({
   enqueueEventsSyncJob,
   enqueueFixturesSyncJob,
   enqueueFixturesAllGameweeksSyncJob,
   enqueuePlayersSyncJob,
+  enqueuePlayerValuesSyncJob,
   enqueuePlayerStatsSyncJob,
 }));
 
@@ -155,6 +157,7 @@ const { jobsAPI } = await import('../../src/api/jobs.api');
 const { entrySyncAPI } = await import('../../src/api/entry-sync.api');
 const { fixturesAPI } = await import('../../src/api/fixtures.api');
 const { playersAPI } = await import('../../src/api/players.api');
+const { playerValuesAPI } = await import('../../src/api/player-values.api');
 const { playerStatsAPI } = await import('../../src/api/player-stats.api');
 const { eventLivesAPI } = await import('../../src/api/event-lives.api');
 const { tournamentsAPI } = await import('../../src/api/tournaments.api');
@@ -198,6 +201,17 @@ describe('playersAPI handlers', () => {
     expect(response.status).toBe(202);
     expect(await response.json()).toMatchObject({ success: true, jobId: 'players-job-1' });
     expect(enqueuePlayersSyncJob).toHaveBeenCalledWith('api');
+  });
+});
+
+describe('playerValuesAPI handlers', () => {
+  test('POST /player-values/sync enqueues the mutation-scoped job', async () => {
+    const response = await playerValuesAPI.handle(
+      new Request('http://localhost/player-values/sync', { method: 'POST' }),
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({ success: true, jobId: 'player-values-job-1' });
+    expect(enqueuePlayerValuesSyncJob).toHaveBeenCalledWith('api');
   });
 });
 

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -41,11 +41,13 @@ mock.module('../../src/services/job-trigger.service', () => ({
 const enqueueEventsSyncJob = mock(async () => ({ id: 'events-job-1' }));
 const enqueueFixturesSyncJob = mock(async () => ({ id: 'fixtures-job-1' }));
 const enqueueFixturesAllGameweeksSyncJob = mock(async () => ({ id: 'fixtures-all-gw-job-1' }));
+const enqueuePlayersSyncJob = mock(async () => ({ id: 'players-job-1' }));
 const enqueuePlayerStatsSyncJob = mock(async () => ({ id: 'player-stats-job-1' }));
 mock.module('../../src/jobs/data-sync-enqueue', () => ({
   enqueueEventsSyncJob,
   enqueueFixturesSyncJob,
   enqueueFixturesAllGameweeksSyncJob,
+  enqueuePlayersSyncJob,
   enqueuePlayerStatsSyncJob,
 }));
 
@@ -152,6 +154,7 @@ const { eventsAPI } = await import('../../src/api/events.api');
 const { jobsAPI } = await import('../../src/api/jobs.api');
 const { entrySyncAPI } = await import('../../src/api/entry-sync.api');
 const { fixturesAPI } = await import('../../src/api/fixtures.api');
+const { playersAPI } = await import('../../src/api/players.api');
 const { playerStatsAPI } = await import('../../src/api/player-stats.api');
 const { eventLivesAPI } = await import('../../src/api/event-lives.api');
 const { tournamentsAPI } = await import('../../src/api/tournaments.api');
@@ -184,6 +187,17 @@ describe('eventsAPI handlers', () => {
     expect(body.success).toBe(true);
     expect(body.jobId).toBe('events-job-1');
     expect(enqueueEventsSyncJob).toHaveBeenCalledWith('api');
+  });
+});
+
+describe('playersAPI handlers', () => {
+  test('POST /players/sync enqueues the shared-lock players job', async () => {
+    const response = await playersAPI.handle(
+      new Request('http://localhost/players/sync', { method: 'POST' }),
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({ success: true, jobId: 'players-job-1' });
+    expect(enqueuePlayersSyncJob).toHaveBeenCalledWith('api');
   });
 });
 

--- a/tests/unit/job-priority.test.ts
+++ b/tests/unit/job-priority.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+  getDataSyncJobPriority,
   getEntrySyncJobPriority,
   getLeagueSyncJobPriority,
   getLiveDataJobPriority,
@@ -22,6 +23,10 @@ describe('job priority mapping', () => {
     expect(getEntrySyncJobPriority('entry-picks')).toBe('p2');
     expect(getEntrySyncJobPriority('entry-transfers')).toBe('p2');
     expect(getEntrySyncJobPriority('entry-results')).toBe('p2');
+  });
+
+  it('keeps player price reconciliation in the primary data tier', () => {
+    expect(getDataSyncJobPriority('player-prices')).toBe('p1');
   });
 
   it('maps tournament and league jobs to expected tiers', () => {

--- a/tests/unit/job-trigger.service.test.ts
+++ b/tests/unit/job-trigger.service.test.ts
@@ -5,12 +5,14 @@ import {
   listTriggerableJobs,
   triggerJob,
 } from '../../src/services/job-trigger.service';
+import { ValidationError } from '../../src/utils/errors';
 
 describe('job-trigger service', () => {
   test('lists known triggerable jobs', () => {
     const jobs = listTriggerableJobs();
     expect(jobs.length).toBeGreaterThan(0);
     expect(jobs.some((job) => job.name === 'events-sync')).toBe(true);
+    expect(jobs.some((job) => job.name === 'player-prices')).toBe(true);
     expect(jobs.every((job) => job.name && job.description && job.schedule)).toBe(true);
   });
 
@@ -22,5 +24,12 @@ describe('job-trigger service', () => {
     const error = new JobNotFoundError('foo');
     expect(error.message).toContain('foo');
     expect(error.name).toBe('JobNotFoundError');
+  });
+
+  test('player-prices requires an explicit YYYYMMDD payload', async () => {
+    await expect(triggerJob('player-prices')).rejects.toBeInstanceOf(ValidationError);
+    await expect(triggerJob('player-prices', { changeDate: '2026-08-02' })).rejects.toThrow(
+      'requires a changeDate in YYYYMMDD format',
+    );
   });
 });

--- a/tests/unit/mutation-scope.test.ts
+++ b/tests/unit/mutation-scope.test.ts
@@ -17,6 +17,17 @@ describe('resolveMutationScopes', () => {
     expect(scopes).toEqual(['event-live:event:33']);
   });
 
+  it('serializes partial price updates with the full players sync', () => {
+    const fullSync = resolveMutationScopes({ queueName: 'data-sync-p1', jobName: 'players' });
+    const priceSync = resolveMutationScopes({
+      queueName: 'data-sync-p1',
+      jobName: 'player-prices',
+    });
+
+    expect(fullSync).toEqual(['data-core:players']);
+    expect(priceSync).toEqual(fullSync);
+  });
+
   it('adds event-scoped conflict groups for league event results', () => {
     const scopes = resolveMutationScopes({
       queueName: 'league-sync-p3',

--- a/tests/unit/player-cache-merge.test.ts
+++ b/tests/unit/player-cache-merge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+
+import { playersCache } from '../../src/cache/operations';
+import { redisSingleton } from '../../src/cache/singleton';
+import type { Player } from '../../src/types';
+
+describe('players cache merge', () => {
+  test('updates supplied fields without deleting unrelated players', async () => {
+    const originalGetClient = redisSingleton.getClient;
+    const fields = new Map<string, string>([
+      ['1', JSON.stringify({ id: 1, webName: 'Untouched', price: 50 })],
+      ['2', JSON.stringify({ id: 2, webName: 'Changed', price: 60 })],
+    ]);
+    let deleteCalls = 0;
+    redisSingleton.getClient = async () =>
+      ({
+        hset: async (_key: string, entries: Record<string, string>) => {
+          for (const [field, value] of Object.entries(entries)) fields.set(field, value);
+          return Object.keys(entries).length;
+        },
+        del: async () => {
+          deleteCalls += 1;
+          return 1;
+        },
+      }) as never;
+
+    const changed: Player = {
+      id: 2,
+      code: 1002,
+      type: 3,
+      teamId: 1,
+      price: 61,
+      startPrice: 60,
+      firstName: 'Price',
+      secondName: 'Change',
+      webName: 'Changed',
+    };
+    try {
+      await playersCache.merge([changed], '2627');
+    } finally {
+      redisSingleton.getClient = originalGetClient;
+    }
+
+    expect(JSON.parse(fields.get('1') ?? '{}')).toEqual({
+      id: 1,
+      webName: 'Untouched',
+      price: 50,
+    });
+    expect(JSON.parse(fields.get('2') ?? '{}')).toEqual(changed);
+    expect(deleteCalls).toBe(0);
+  });
+});

--- a/tests/unit/player-cache-merge.test.ts
+++ b/tests/unit/player-cache-merge.test.ts
@@ -14,6 +14,7 @@ describe('players cache merge', () => {
     let deleteCalls = 0;
     redisSingleton.getClient = async () =>
       ({
+        hkeys: async () => Array.from(fields.keys()),
         hset: async (_key: string, entries: Record<string, string>) => {
           for (const [field, value] of Object.entries(entries)) fields.set(field, value);
           return Object.keys(entries).length;
@@ -36,7 +37,7 @@ describe('players cache merge', () => {
       webName: 'Changed',
     };
     try {
-      await playersCache.merge([changed], '2627');
+      await playersCache.merge([changed], [1, 2], '2627');
     } finally {
       redisSingleton.getClient = originalGetClient;
     }
@@ -48,5 +49,44 @@ describe('players cache merge', () => {
     });
     expect(JSON.parse(fields.get('2') ?? '{}')).toEqual(changed);
     expect(deleteCalls).toBe(0);
+  });
+
+  test('refuses to create or extend an incomplete player view', async () => {
+    const originalGetClient = redisSingleton.getClient;
+    let hsetCalls = 0;
+    redisSingleton.getClient = async () =>
+      ({
+        hkeys: async () => ['2'],
+        hset: async () => {
+          hsetCalls += 1;
+          return 1;
+        },
+      }) as never;
+
+    try {
+      await expect(
+        playersCache.merge(
+          [
+            {
+              id: 2,
+              code: 1002,
+              type: 3,
+              teamId: 1,
+              price: 61,
+              startPrice: 60,
+              firstName: 'Price',
+              secondName: 'Change',
+              webName: 'Changed',
+            },
+          ],
+          [1, 2],
+          '2627',
+        ),
+      ).rejects.toThrow('Refusing to merge prices into incomplete players cache');
+    } finally {
+      redisSingleton.getClient = originalGetClient;
+    }
+
+    expect(hsetCalls).toBe(0);
   });
 });

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from 'bun:test';
 
 import { createPlayerPricesSync } from '../../src/services/player-prices.service';
 import type { Player } from '../../src/types';
+import { singleRawFPLElementFixture } from '../fixtures/player-values.fixtures';
 
 const stored = (
   elementId: number,
@@ -32,7 +33,14 @@ const player = (id: number, price: number): Player => ({
 
 const bootstrap = (ids: number[]) =>
   ({
-    elements: ids.map((id) => ({ id })),
+    elements: ids.map((id) => ({
+      ...singleRawFPLElementFixture,
+      id,
+      code: singleRawFPLElementFixture.code + id,
+      first_name: `First ${id}`,
+      second_name: `Last ${id}`,
+      web_name: `Player ${id}`,
+    })),
     events: [{ id: 1, deadline_time: '2026-08-15T17:30:00Z' }],
   }) as never;
 
@@ -119,5 +127,28 @@ describe('player-prices sync', () => {
     expect(findLatestForPlayerIds).not.toHaveBeenCalled();
     expect(updatePrices).not.toHaveBeenCalled();
     expect(mergePlayersCache).not.toHaveBeenCalled();
+  });
+
+  test('checks cache completeness against only transformable bootstrap players', async () => {
+    const mergePlayersCache = mock(async () => undefined);
+    const validBootstrap = bootstrap([1, 2]) as {
+      elements: Array<Record<string, unknown>>;
+      events: Array<Record<string, unknown>>;
+    };
+    validBootstrap.elements.push({
+      ...singleRawFPLElementFixture,
+      id: 3,
+      first_name: '',
+    });
+    const sync = createPlayerPricesSync({
+      findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
+      findLatestForPlayerIds: async () => [stored(2, 61, '20260803', 'Rise')],
+      getBootstrap: async () => validBootstrap as never,
+      updatePrices: async () => [player(2, 61)],
+      mergePlayersCache,
+    });
+
+    expect(await sync('20260803')).toEqual({ count: 1, changeDate: '20260803' });
+    expect(mergePlayersCache).toHaveBeenCalledWith([player(2, 61)], [1, 2]);
   });
 });

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { createPlayerPricesSync } from '../../src/services/player-prices.service';
+import type { Player } from '../../src/types';
+
+const stored = (
+  elementId: number,
+  value: number,
+  changeDate: string,
+  changeType: 'Start' | 'Rise' | 'Faller',
+) => ({
+  elementId,
+  value,
+  changeDate,
+  changeType,
+  eventId: 1,
+  elementType: 3,
+  lastValue: changeType === 'Start' ? 0 : value - 1,
+});
+
+const player = (id: number, price: number): Player => ({
+  id,
+  code: id + 1000,
+  type: 3,
+  teamId: 1,
+  price,
+  startPrice: 50,
+  firstName: `First ${id}`,
+  secondName: `Last ${id}`,
+  webName: `Player ${id}`,
+});
+
+describe('player-prices sync', () => {
+  test('updates only risers and fallers and merges their complete cache fields', async () => {
+    const updatePrices = mock(async (updates: Array<{ elementId: number; value: number }>) =>
+      updates.map((update) => player(update.elementId, update.value)),
+    );
+    const mergePlayersCache = mock(async () => undefined);
+    const sync = createPlayerPricesSync({
+      findByChangeDate: async () => [
+        stored(1, 50, '20260803', 'Start'),
+        stored(2, 61, '20260803', 'Rise'),
+        stored(3, 49, '20260803', 'Faller'),
+      ],
+      findLatestForPlayerIds: async () => [
+        stored(2, 61, '20260803', 'Rise'),
+        stored(3, 49, '20260803', 'Faller'),
+      ],
+      updatePrices,
+      mergePlayersCache,
+    });
+
+    expect(await sync('20260803')).toEqual({ count: 2, changeDate: '20260803' });
+    expect(updatePrices).toHaveBeenCalledWith([
+      { elementId: 2, value: 61 },
+      { elementId: 3, value: 49 },
+    ]);
+    expect(mergePlayersCache).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses each affected player latest value during an old-date replay', async () => {
+    const updatePrices = mock(async (updates: Array<{ elementId: number; value: number }>) =>
+      updates.map((update) => player(update.elementId, update.value)),
+    );
+    const sync = createPlayerPricesSync({
+      findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
+      findLatestForPlayerIds: async () => [stored(2, 63, '20260805', 'Rise')],
+      updatePrices,
+      mergePlayersCache: async () => undefined,
+    });
+
+    await sync('20260803');
+    expect(updatePrices).toHaveBeenCalledWith([{ elementId: 2, value: 63 }]);
+  });
+
+  test('skips cleanly when a date contains only Start rows', async () => {
+    const updatePrices = mock(async () => []);
+    const mergePlayersCache = mock(async () => undefined);
+    const sync = createPlayerPricesSync({
+      findByChangeDate: async () => [stored(1, 50, '20260802', 'Start')],
+      findLatestForPlayerIds: async () => [],
+      updatePrices,
+      mergePlayersCache,
+    });
+
+    expect(await sync('20260802')).toEqual({ count: 0, changeDate: '20260802' });
+    expect(updatePrices).not.toHaveBeenCalled();
+    expect(mergePlayersCache).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -36,6 +36,7 @@ describe('player-prices sync', () => {
       updates.map((update) => player(update.elementId, update.value)),
     );
     const mergePlayersCache = mock(async () => undefined);
+    const findDistinctPlayerIds = mock(async () => [1, 2, 3]);
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [
         stored(1, 50, '20260803', 'Start'),
@@ -46,7 +47,7 @@ describe('player-prices sync', () => {
         stored(2, 61, '20260803', 'Rise'),
         stored(3, 49, '20260803', 'Faller'),
       ],
-      findAllPlayerIds: async () => [1, 2, 3],
+      findDistinctPlayerIds,
       updatePrices,
       mergePlayersCache,
     });
@@ -56,6 +57,7 @@ describe('player-prices sync', () => {
       { elementId: 2, value: 61 },
       { elementId: 3, value: 49 },
     ]);
+    expect(findDistinctPlayerIds).toHaveBeenCalledWith('20260601', '20260803');
     expect(mergePlayersCache).toHaveBeenCalledWith([player(2, 61), player(3, 49)], [1, 2, 3]);
   });
 
@@ -66,7 +68,7 @@ describe('player-prices sync', () => {
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
       findLatestForPlayerIds: async () => [stored(2, 63, '20260805', 'Rise')],
-      findAllPlayerIds: async () => [1, 2],
+      findDistinctPlayerIds: async () => [1, 2],
       updatePrices,
       mergePlayersCache: async () => undefined,
     });
@@ -81,7 +83,7 @@ describe('player-prices sync', () => {
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(1, 50, '20260802', 'Start')],
       findLatestForPlayerIds: async () => [],
-      findAllPlayerIds: async () => [1],
+      findDistinctPlayerIds: async () => [1],
       updatePrices,
       mergePlayersCache,
     });

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -30,25 +30,30 @@ const player = (id: number, price: number): Player => ({
   webName: `Player ${id}`,
 });
 
+const bootstrap = (ids: number[]) =>
+  ({
+    elements: ids.map((id) => ({ id })),
+    events: [{ id: 1, deadline_time: '2026-08-15T17:30:00Z' }],
+  }) as never;
+
 describe('player-prices sync', () => {
   test('updates only risers and fallers and merges their complete cache fields', async () => {
     const updatePrices = mock(async (updates: Array<{ elementId: number; value: number }>) =>
       updates.map((update) => player(update.elementId, update.value)),
     );
     const mergePlayersCache = mock(async () => undefined);
-    const getBootstrap = mock(
-      async () => ({ elements: [{ id: 1 }, { id: 2 }, { id: 3 }] }) as never,
-    );
+    const getBootstrap = mock(async () => bootstrap([1, 2, 3]));
+    const findLatestForPlayerIds = mock(async () => [
+      stored(2, 61, '20260803', 'Rise'),
+      stored(3, 49, '20260803', 'Faller'),
+    ]);
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [
         stored(1, 50, '20260803', 'Start'),
         stored(2, 61, '20260803', 'Rise'),
         stored(3, 49, '20260803', 'Faller'),
       ],
-      findLatestForPlayerIds: async () => [
-        stored(2, 61, '20260803', 'Rise'),
-        stored(3, 49, '20260803', 'Faller'),
-      ],
+      findLatestForPlayerIds,
       getBootstrap,
       updatePrices,
       mergePlayersCache,
@@ -60,6 +65,7 @@ describe('player-prices sync', () => {
       { elementId: 3, value: 49 },
     ]);
     expect(getBootstrap).toHaveBeenCalledTimes(1);
+    expect(findLatestForPlayerIds).toHaveBeenCalledWith([2, 3], '20260601', '20270601');
     expect(mergePlayersCache).toHaveBeenCalledWith([player(2, 61), player(3, 49)], [1, 2, 3]);
   });
 
@@ -70,7 +76,7 @@ describe('player-prices sync', () => {
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
       findLatestForPlayerIds: async () => [stored(2, 63, '20260805', 'Rise')],
-      getBootstrap: async () => ({ elements: [{ id: 1 }, { id: 2 }] }) as never,
+      getBootstrap: async () => bootstrap([1, 2]),
       updatePrices,
       mergePlayersCache: async () => undefined,
     });
@@ -82,7 +88,7 @@ describe('player-prices sync', () => {
   test('skips cleanly when a date contains only Start rows', async () => {
     const updatePrices = mock(async () => []);
     const mergePlayersCache = mock(async () => undefined);
-    const getBootstrap = mock(async () => ({ elements: [{ id: 1 }] }) as never);
+    const getBootstrap = mock(async () => bootstrap([1]));
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(1, 50, '20260802', 'Start')],
       findLatestForPlayerIds: async () => [],
@@ -104,7 +110,7 @@ describe('player-prices sync', () => {
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
       findLatestForPlayerIds,
-      getBootstrap: async () => ({ elements: [{ id: 1 }, { id: 3 }] }) as never,
+      getBootstrap: async () => bootstrap([1, 3]),
       updatePrices,
       mergePlayersCache,
     });

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -36,7 +36,9 @@ describe('player-prices sync', () => {
       updates.map((update) => player(update.elementId, update.value)),
     );
     const mergePlayersCache = mock(async () => undefined);
-    const findDistinctPlayerIds = mock(async () => [1, 2, 3]);
+    const getBootstrap = mock(
+      async () => ({ elements: [{ id: 1 }, { id: 2 }, { id: 3 }] }) as never,
+    );
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [
         stored(1, 50, '20260803', 'Start'),
@@ -47,7 +49,7 @@ describe('player-prices sync', () => {
         stored(2, 61, '20260803', 'Rise'),
         stored(3, 49, '20260803', 'Faller'),
       ],
-      findDistinctPlayerIds,
+      getBootstrap,
       updatePrices,
       mergePlayersCache,
     });
@@ -57,7 +59,7 @@ describe('player-prices sync', () => {
       { elementId: 2, value: 61 },
       { elementId: 3, value: 49 },
     ]);
-    expect(findDistinctPlayerIds).toHaveBeenCalledWith('20260601', '20260803');
+    expect(getBootstrap).toHaveBeenCalledTimes(1);
     expect(mergePlayersCache).toHaveBeenCalledWith([player(2, 61), player(3, 49)], [1, 2, 3]);
   });
 
@@ -68,7 +70,7 @@ describe('player-prices sync', () => {
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
       findLatestForPlayerIds: async () => [stored(2, 63, '20260805', 'Rise')],
-      findDistinctPlayerIds: async () => [1, 2],
+      getBootstrap: async () => ({ elements: [{ id: 1 }, { id: 2 }] }) as never,
       updatePrices,
       mergePlayersCache: async () => undefined,
     });
@@ -80,15 +82,35 @@ describe('player-prices sync', () => {
   test('skips cleanly when a date contains only Start rows', async () => {
     const updatePrices = mock(async () => []);
     const mergePlayersCache = mock(async () => undefined);
+    const getBootstrap = mock(async () => ({ elements: [{ id: 1 }] }) as never);
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(1, 50, '20260802', 'Start')],
       findLatestForPlayerIds: async () => [],
-      findDistinctPlayerIds: async () => [1],
+      getBootstrap,
       updatePrices,
       mergePlayersCache,
     });
 
     expect(await sync('20260802')).toEqual({ count: 0, changeDate: '20260802' });
+    expect(getBootstrap).not.toHaveBeenCalled();
+    expect(updatePrices).not.toHaveBeenCalled();
+    expect(mergePlayersCache).not.toHaveBeenCalled();
+  });
+
+  test('does not replay a historical change for a player outside the live roster', async () => {
+    const findLatestForPlayerIds = mock(async () => []);
+    const updatePrices = mock(async () => []);
+    const mergePlayersCache = mock(async () => undefined);
+    const sync = createPlayerPricesSync({
+      findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
+      findLatestForPlayerIds,
+      getBootstrap: async () => ({ elements: [{ id: 1 }, { id: 3 }] }) as never,
+      updatePrices,
+      mergePlayersCache,
+    });
+
+    expect(await sync('20260803')).toEqual({ count: 0, changeDate: '20260803' });
+    expect(findLatestForPlayerIds).not.toHaveBeenCalled();
     expect(updatePrices).not.toHaveBeenCalled();
     expect(mergePlayersCache).not.toHaveBeenCalled();
   });

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -46,6 +46,7 @@ describe('player-prices sync', () => {
         stored(2, 61, '20260803', 'Rise'),
         stored(3, 49, '20260803', 'Faller'),
       ],
+      findAllPlayerIds: async () => [1, 2, 3],
       updatePrices,
       mergePlayersCache,
     });
@@ -55,7 +56,7 @@ describe('player-prices sync', () => {
       { elementId: 2, value: 61 },
       { elementId: 3, value: 49 },
     ]);
-    expect(mergePlayersCache).toHaveBeenCalledTimes(1);
+    expect(mergePlayersCache).toHaveBeenCalledWith([player(2, 61), player(3, 49)], [1, 2, 3]);
   });
 
   test('uses each affected player latest value during an old-date replay', async () => {
@@ -65,6 +66,7 @@ describe('player-prices sync', () => {
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(2, 61, '20260803', 'Rise')],
       findLatestForPlayerIds: async () => [stored(2, 63, '20260805', 'Rise')],
+      findAllPlayerIds: async () => [1, 2],
       updatePrices,
       mergePlayersCache: async () => undefined,
     });
@@ -79,6 +81,7 @@ describe('player-prices sync', () => {
     const sync = createPlayerPricesSync({
       findByChangeDate: async () => [stored(1, 50, '20260802', 'Start')],
       findLatestForPlayerIds: async () => [],
+      findAllPlayerIds: async () => [1],
       updatePrices,
       mergePlayersCache,
     });

--- a/tests/unit/player-schedules.test.ts
+++ b/tests/unit/player-schedules.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  PLAYER_PRICES_REPLAY_CRON_PATTERN,
+  PLAYER_STATS_CRON_PATTERN,
+  PLAYER_VALUES_CRON_PATTERN,
+} from '../../src/domain/job-schedules';
+
+describe('player synchronization schedules', () => {
+  test('polls values from 09:25 through 09:35', () => {
+    expect(PLAYER_VALUES_CRON_PATTERN).toBe('25-35 9 * * *');
+  });
+
+  test('runs current-price replay and player stats daily at 09:40', () => {
+    expect(PLAYER_PRICES_REPLAY_CRON_PATTERN).toBe('40 9 * * *');
+    expect(PLAYER_STATS_CRON_PATTERN).toBe('40 9 * * *');
+  });
+});

--- a/tests/unit/player-stats-cache-publish.test.ts
+++ b/tests/unit/player-stats-cache-publish.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resetActiveSeasonMemo } from '../../src/cache/cache-season';
+import { createPlayerStatsHashCache } from '../../src/cache/player-stats-cache';
+import { redisSingleton } from '../../src/cache/singleton';
+import { CacheError } from '../../src/utils/errors';
+import { generatePlayerStat } from '../fixtures/player-stats.fixtures';
+
+describe('player-stats latest-view publication', () => {
+  test('stages and atomically renames a complete hash over the previous view', async () => {
+    const originalGetClient = redisSingleton.getClient;
+    const hashes = new Map<string, Map<string, string>>([
+      ['PlayerStat:2627', new Map([['99', JSON.stringify({ eventId: 0, elementId: 99 })]])],
+    ]);
+    const operations: string[] = [];
+    const fakeRedis = {
+      get: async (key: string) => (key === 'Season:active' ? '2627' : null),
+      hset: async (key: string, entries: Record<string, string>) => {
+        operations.push(`hset:${key}`);
+        hashes.set(key, new Map(Object.entries(entries)));
+        return Object.keys(entries).length;
+      },
+      hlen: async (key: string) => hashes.get(key)?.size ?? 0,
+      rename: async (source: string, destination: string) => {
+        operations.push(`rename:${source}:${destination}`);
+        const staged = hashes.get(source);
+        if (!staged) throw new Error('missing staging hash');
+        hashes.set(destination, staged);
+        hashes.delete(source);
+        return 'OK';
+      },
+      del: async (key: string) => {
+        operations.push(`del:${key}`);
+        return Number(hashes.delete(key));
+      },
+    };
+    redisSingleton.getClient = async () => fakeRedis as never;
+    resetActiveSeasonMemo();
+
+    try {
+      const stats = [
+        generatePlayerStat({ eventId: 1, elementId: 1 }),
+        generatePlayerStat({ eventId: 1, elementId: 2 }),
+      ];
+      await createPlayerStatsHashCache().setPlayerStatsByEvent(1, stats);
+    } finally {
+      redisSingleton.getClient = originalGetClient;
+      resetActiveSeasonMemo();
+    }
+
+    expect(Array.from(hashes.get('PlayerStat:2627')?.keys() ?? [])).toEqual(['1', '2']);
+    expect(operations[0]).toStartWith('hset:PlayerStat:2627:staging:');
+    expect(operations[1]).toStartWith('rename:PlayerStat:2627:staging:');
+    expect(operations[1]).toEndWith(':PlayerStat:2627');
+    expect(operations.some((operation) => operation.startsWith('del:'))).toBe(false);
+  });
+
+  test('keeps the previous complete view when staging fails', async () => {
+    const originalGetClient = redisSingleton.getClient;
+    const oldValue = JSON.stringify({ eventId: 1, elementId: 99 });
+    const hashes = new Map<string, Map<string, string>>([
+      ['PlayerStat:2627', new Map([['99', oldValue]])],
+    ]);
+    const fakeRedis = {
+      get: async (key: string) => (key === 'Season:active' ? '2627' : null),
+      hset: async () => {
+        throw new Error('OOM');
+      },
+      del: async (key: string) => Number(hashes.delete(key)),
+    };
+    redisSingleton.getClient = async () => fakeRedis as never;
+    resetActiveSeasonMemo();
+
+    try {
+      await expect(
+        createPlayerStatsHashCache().setPlayerStatsByEvent(1, [
+          generatePlayerStat({ eventId: 1, elementId: 1 }),
+        ]),
+      ).rejects.toBeInstanceOf(CacheError);
+    } finally {
+      redisSingleton.getClient = originalGetClient;
+      resetActiveSeasonMemo();
+    }
+
+    expect(hashes.get('PlayerStat:2627')?.get('99')).toBe(oldValue);
+  });
+
+  test('refuses an empty latest view', async () => {
+    await expect(createPlayerStatsHashCache().setPlayerStatsByEvent(1, [])).rejects.toBeInstanceOf(
+      CacheError,
+    );
+  });
+});

--- a/tests/unit/player-stats.test.ts
+++ b/tests/unit/player-stats.test.ts
@@ -724,10 +724,16 @@ describe('Player Stats Unit Tests', () => {
 });
 
 describe('shouldWritePlayerStatsView (FP-12 / H9)', () => {
-  test('only the current event may write the latest-event-wins view', () => {
+  test('prefers the current event for the latest-event-wins view', () => {
     expect(shouldWritePlayerStatsView(10, 10)).toBe(true);
     expect(shouldWritePlayerStatsView(9, 10)).toBe(false);
     expect(shouldWritePlayerStatsView(11, 10)).toBe(false);
-    expect(shouldWritePlayerStatsView(10, null)).toBe(false);
+    expect(shouldWritePlayerStatsView(11, 10, 11)).toBe(false);
+  });
+
+  test('allows the next event only when no current event exists', () => {
+    expect(shouldWritePlayerStatsView(1, null, 1)).toBe(true);
+    expect(shouldWritePlayerStatsView(2, null, 1)).toBe(false);
+    expect(shouldWritePlayerStatsView(1, null, null)).toBe(false);
   });
 });

--- a/tests/unit/player-sync-event.test.ts
+++ b/tests/unit/player-sync-event.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolvePlayerSyncEvent } from '../../src/services/player-sync-event.service';
+import type { Event } from '../../src/types';
+
+const event = (id: number, finished = false) => ({ id, finished }) as Event;
+
+describe('resolvePlayerSyncEvent', () => {
+  test('uses the current event inside the season window', async () => {
+    const resolved = await resolvePlayerSyncEvent(new Date(), {
+      getCurrentEvent: async () => event(4),
+      getNextEvent: async () => event(5),
+      isFPLSeason: async () => true,
+    });
+
+    expect(resolved).toEqual({ event: event(4), phase: 'current' });
+  });
+
+  test('uses the next event before GW1', async () => {
+    const resolved = await resolvePlayerSyncEvent(new Date(), {
+      getCurrentEvent: async () => null,
+      getNextEvent: async () => event(1),
+      isFPLSeason: async () => false,
+    });
+
+    expect(resolved).toEqual({ event: event(1), phase: 'preseason' });
+  });
+
+  test('keeps GW1 during the deadline-to-kickoff gap', async () => {
+    const resolved = await resolvePlayerSyncEvent(new Date(), {
+      getCurrentEvent: async () => event(1),
+      getNextEvent: async () => event(2),
+      isFPLSeason: async () => false,
+    });
+
+    expect(resolved).toEqual({ event: event(1), phase: 'preseason' });
+  });
+
+  test('does not keep syncing after the season', async () => {
+    const resolved = await resolvePlayerSyncEvent(new Date(), {
+      getCurrentEvent: async () => event(38, true),
+      getNextEvent: async () => null,
+      isFPLSeason: async () => false,
+    });
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/tests/unit/player-values-cache-merge.test.ts
+++ b/tests/unit/player-values-cache-merge.test.ts
@@ -66,4 +66,26 @@ describe('player-values cache merge', () => {
 
     expect(deleteCalls).toBe(0);
   });
+
+  test('deletes only named stale fields without replacing the hash', async () => {
+    const originalGetClient = redisSingleton.getClient;
+    const calls: Array<{ command: string; args: string[] }> = [];
+    redisSingleton.getClient = async () =>
+      ({
+        hdel: async (...fields: string[]) => {
+          calls.push({ command: 'hdel', args: fields });
+          return fields.length;
+        },
+      }) as never;
+
+    try {
+      await playerValuesCache.deleteFields('20260802', ['wrong-field', '999']);
+    } finally {
+      redisSingleton.getClient = originalGetClient;
+    }
+
+    expect(calls).toEqual([
+      { command: 'hdel', args: ['PlayerValue:20260802', 'wrong-field', '999'] },
+    ]);
+  });
 });

--- a/tests/unit/player-values-cache-merge.test.ts
+++ b/tests/unit/player-values-cache-merge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+
+import { playerValuesCache } from '../../src/cache/operations';
+import { redisSingleton } from '../../src/cache/singleton';
+import type { PlayerValue } from '../../src/domain/player-values';
+
+const value: PlayerValue = {
+  elementId: 1,
+  webName: 'Player',
+  elementType: 3,
+  elementTypeName: 'MID',
+  eventId: 1,
+  teamId: 1,
+  teamName: 'Team',
+  teamShortName: 'TEA',
+  value: 50,
+  changeDate: '20260802',
+  changeType: 'Start',
+  lastValue: 0,
+};
+
+describe('player-values cache merge', () => {
+  test('clears the negative marker only after positive HSET succeeds', async () => {
+    const originalGetClient = redisSingleton.getClient;
+    const operations: string[] = [];
+    redisSingleton.getClient = async () =>
+      ({
+        hset: async () => {
+          operations.push('hset');
+          return 1;
+        },
+        del: async () => {
+          operations.push('del');
+          return 1;
+        },
+      }) as never;
+
+    try {
+      await playerValuesCache.merge('20260802', [value]);
+    } finally {
+      redisSingleton.getClient = originalGetClient;
+    }
+
+    expect(operations).toEqual(['hset', 'del']);
+  });
+
+  test('fails without clearing the negative marker when HSET fails', async () => {
+    const originalGetClient = redisSingleton.getClient;
+    let deleteCalls = 0;
+    redisSingleton.getClient = async () =>
+      ({
+        hset: async () => {
+          throw new Error('WRONGTYPE');
+        },
+        del: async () => {
+          deleteCalls += 1;
+          return 1;
+        },
+      }) as never;
+
+    try {
+      await expect(playerValuesCache.merge('20260802', [value])).rejects.toThrow('WRONGTYPE');
+    } finally {
+      redisSingleton.getClient = originalGetClient;
+    }
+
+    expect(deleteCalls).toBe(0);
+  });
+});

--- a/tests/unit/player-values-cache-repair.test.ts
+++ b/tests/unit/player-values-cache-repair.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { PlayerValue } from '../../src/domain/player-values';
+import { findPlayerValueCacheRepairs } from '../../src/services/player-values.service';
+
+const value: PlayerValue = {
+  elementId: 1,
+  webName: 'Player',
+  elementType: 3,
+  elementTypeName: 'MID',
+  eventId: 1,
+  teamId: 1,
+  teamName: 'Team',
+  teamShortName: 'TEA',
+  value: 50,
+  changeDate: '20260802',
+  changeType: 'Start',
+  lastValue: 0,
+};
+
+describe('player-values cache repair selection', () => {
+  test('does not rewrite a complete no-change cache', () => {
+    expect(findPlayerValueCacheRepairs([value], [{ ...value }])).toEqual([]);
+  });
+
+  test('repairs missing or stale persisted fields with HSET candidates', () => {
+    expect(findPlayerValueCacheRepairs([value], null)).toEqual([value]);
+    expect(findPlayerValueCacheRepairs([value], [{ ...value, lastValue: 50 }])).toEqual([value]);
+  });
+});

--- a/tests/unit/player-values-cache-repair.test.ts
+++ b/tests/unit/player-values-cache-repair.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { PlayerValue } from '../../src/domain/player-values';
-import { findPlayerValueCacheRepairs } from '../../src/services/player-values.service';
+import { planPlayerValueCacheRepairs } from '../../src/services/player-values.service';
 
 const value: PlayerValue = {
   elementId: 1,
@@ -20,12 +20,25 @@ const value: PlayerValue = {
 
 describe('player-values cache repair selection', () => {
   test('does not rewrite a complete no-change cache', () => {
-    expect(findPlayerValueCacheRepairs([value], [{ ...value }])).toEqual([]);
+    expect(
+      planPlayerValueCacheRepairs([value], {
+        fields: ['1'],
+        entries: [['1', { ...value }]],
+      }),
+    ).toEqual({ writes: [], staleFields: [] });
   });
 
   test('repairs missing or stale persisted fields with HSET candidates', () => {
-    expect(findPlayerValueCacheRepairs([value], null)).toEqual([value]);
-    expect(findPlayerValueCacheRepairs([value], [{ ...value, lastValue: 50 }])).toEqual([value]);
+    expect(planPlayerValueCacheRepairs([value], { fields: [], entries: [] })).toEqual({
+      writes: [value],
+      staleFields: [],
+    });
+    expect(
+      planPlayerValueCacheRepairs([value], {
+        fields: ['1'],
+        entries: [['1', { ...value, lastValue: 50 }]],
+      }),
+    ).toEqual({ writes: [value], staleFields: [] });
   });
 
   test('repairs stale enrichment fields as part of the complete cached shape', () => {
@@ -38,7 +51,33 @@ describe('player-values cache repair selection', () => {
     ];
 
     for (const staleValue of staleValues) {
-      expect(findPlayerValueCacheRepairs([value], [staleValue])).toEqual([value]);
+      expect(
+        planPlayerValueCacheRepairs([value], {
+          fields: ['1'],
+          entries: [['1', staleValue]],
+        }),
+      ).toEqual({ writes: [value], staleFields: [] });
     }
+  });
+
+  test('repairs the canonical field and removes extra or mis-keyed fields', () => {
+    expect(
+      planPlayerValueCacheRepairs([value], {
+        fields: ['wrong-field', '999'],
+        entries: [
+          ['wrong-field', value],
+          ['999', { ...value, elementId: 999 }],
+        ],
+      }),
+    ).toEqual({ writes: [value], staleFields: ['wrong-field', '999'] });
+  });
+
+  test('overwrites a corrupt expected field without deleting its hash field', () => {
+    expect(
+      planPlayerValueCacheRepairs([value], {
+        fields: ['1'],
+        entries: [],
+      }),
+    ).toEqual({ writes: [value], staleFields: [] });
   });
 });

--- a/tests/unit/player-values-cache-repair.test.ts
+++ b/tests/unit/player-values-cache-repair.test.ts
@@ -27,4 +27,18 @@ describe('player-values cache repair selection', () => {
     expect(findPlayerValueCacheRepairs([value], null)).toEqual([value]);
     expect(findPlayerValueCacheRepairs([value], [{ ...value, lastValue: 50 }])).toEqual([value]);
   });
+
+  test('repairs stale enrichment fields as part of the complete cached shape', () => {
+    const staleValues: PlayerValue[] = [
+      { ...value, webName: 'Old Player' },
+      { ...value, elementTypeName: 'FWD' },
+      { ...value, teamId: 2 },
+      { ...value, teamName: 'Old Team' },
+      { ...value, teamShortName: 'OLD' },
+    ];
+
+    for (const staleValue of staleValues) {
+      expect(findPlayerValueCacheRepairs([value], [staleValue])).toEqual([value]);
+    }
+  });
 });

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -6,7 +6,10 @@ import {
   createPlayerValuesSync,
   type PlayerValuesSyncDependencies,
 } from '../../src/services/player-values.service';
-import { getPlayerValueSeasonFloor } from '../../src/utils/player-value-season';
+import {
+  getPlayerValueSeasonBounds,
+  getPlayerValueSeasonFloor,
+} from '../../src/utils/player-value-season';
 import {
   mockTeamsForPlayerValues,
   singleRawFPLElementFixture,
@@ -58,6 +61,10 @@ describe('player-values synchronization orchestration', () => {
   test('keeps the same season floor after the calendar year changes', () => {
     expect(getPlayerValueSeasonFloor('2026-08-15T17:30:00Z')).toBe('20260601');
     expect(getPlayerValueSeasonFloor('2027-01-02T11:00:00Z')).toBe('20260601');
+    expect(getPlayerValueSeasonBounds('2027-01-02T11:00:00Z')).toEqual({
+      fromChangeDate: '20260601',
+      beforeChangeDate: '20270601',
+    });
   });
 
   test('discards a delayed capture after its configured date without reading upstream', async () => {

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -45,6 +45,7 @@ function buildDependencies(
       }) as never,
     findLatestForAllPlayers: async () => [],
     findByChangeDate: async () => [],
+    findPlayersByIds: async () => [],
     insertBatch: async (rows) => ({ count: rows.length, inserted: rows }),
     loadTeamsBasicInfo: async () => mockTeamsForPlayerValues as never,
     inspectCachedValues: async () => ({ fields: [], entries: [] }),
@@ -272,6 +273,58 @@ describe('player-values synchronization orchestration', () => {
 
     expect(await sync(changeDate)).toEqual({ count: 0 });
     expect(operations).toEqual(['hset', 'hdel']);
+  });
+
+  test('repairs persisted history from retained player data after a roster omission', async () => {
+    const currentElement = { ...singleRawFPLElementFixture, id: 2, code: 223095 };
+    const persisted = storedValue(143, 'Rise', 142);
+    const mergeCachedValues = mock(async (_date: string, rows: PlayerValue[]) => {
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        elementId: singleRawFPLElementFixture.id,
+        webName: 'Retained Player',
+        teamId: singleRawFPLElementFixture.team,
+        value: 143,
+      });
+    });
+    const findPlayersByIds = mock(async (ids: number[]) => {
+      expect(ids).toEqual([singleRawFPLElementFixture.id]);
+      return [
+        {
+          id: singleRawFPLElementFixture.id,
+          code: singleRawFPLElementFixture.code,
+          type: singleRawFPLElementFixture.element_type,
+          teamId: singleRawFPLElementFixture.team,
+          price: 143,
+          startPrice: 142,
+          firstName: 'Retained',
+          secondName: 'Player',
+          webName: 'Retained Player',
+        },
+      ];
+    });
+    const enqueuePlayerPrices = mock(async () => ({ id: 'player-prices-immediate' }) as never);
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        getBootstrap: async () => ({ elements: [currentElement], teams: [] }) as never,
+        findLatestForAllPlayers: async () => [
+          {
+            elementId: currentElement.id,
+            value: currentElement.now_cost,
+            changeDate: '20260802',
+          },
+        ],
+        findByChangeDate: async () => [persisted],
+        findPlayersByIds,
+        mergeCachedValues,
+        enqueuePlayerPrices,
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(findPlayersByIds).toHaveBeenCalledTimes(1);
+    expect(mergeCachedValues).toHaveBeenCalledTimes(1);
+    expect(enqueuePlayerPrices).toHaveBeenCalledTimes(1);
   });
 
   test('notification failure does not invalidate a successful capture', async () => {

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -4,6 +4,7 @@ import type { PlayerValue } from '../../src/domain/player-values';
 import type { StoredPlayerValue } from '../../src/repositories/player-values';
 import {
   createPlayerValuesSync,
+  getPlayerValueSeasonFloor,
   type PlayerValuesSyncDependencies,
 } from '../../src/services/player-values.service';
 import {
@@ -34,7 +35,11 @@ function buildDependencies(
 ): PlayerValuesSyncDependencies {
   return {
     getBootstrap: async () => ({ elements: [singleRawFPLElementFixture], teams: [] }) as never,
-    resolvePlayerSyncEvent: async () => ({ event: { id: 1 }, phase: 'current' }) as never,
+    resolvePlayerSyncEvent: async () =>
+      ({
+        event: { id: 1, deadlineTime: '2026-08-15T17:30:00Z' },
+        phase: 'current',
+      }) as never,
     findLatestForAllPlayers: async () => [],
     findByChangeDate: async () => [],
     insertBatch: async (rows) => ({ count: rows.length, inserted: rows }),
@@ -48,6 +53,55 @@ function buildDependencies(
 }
 
 describe('player-values synchronization orchestration', () => {
+  test('keeps the same season floor after the calendar year changes', () => {
+    expect(getPlayerValueSeasonFloor('2026-08-15T17:30:00Z')).toBe('20260601');
+    expect(getPlayerValueSeasonFloor('2027-01-02T11:00:00Z')).toBe('20260601');
+  });
+
+  test('scopes preseason history to the published season before seeding Start rows', async () => {
+    let persisted: StoredPlayerValue[] = [];
+    const findLatestForAllPlayers = mock(
+      async (fromChangeDate: string, throughChangeDate: string) => {
+        expect(fromChangeDate).toBe('20260601');
+        expect(throughChangeDate).toBe(changeDate);
+        // Prior-season rows are excluded by the bounded repository query.
+        return [];
+      },
+    );
+    const enqueuePlayerPrices = mock(async () => ({ id: 'unexpected' }) as never);
+    const notify = mock(async () => undefined);
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        resolvePlayerSyncEvent: async () =>
+          ({
+            event: { id: 1, deadlineTime: '2026-08-15T17:30:00Z' },
+            phase: 'preseason',
+          }) as never,
+        findLatestForAllPlayers,
+        findByChangeDate: async () => persisted,
+        insertBatch: async (rows) => {
+          persisted = rows.map((row) => ({
+            elementId: row.elementId,
+            elementType: row.elementType,
+            eventId: row.eventId,
+            value: row.value,
+            changeDate: row.changeDate,
+            changeType: row.changeType,
+            lastValue: row.lastValue,
+          }));
+          return { count: rows.length, inserted: rows };
+        },
+        enqueuePlayerPrices,
+        notify,
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 1 });
+    expect(persisted[0]).toMatchObject({ changeType: 'Start', lastValue: 0 });
+    expect(enqueuePlayerPrices).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
   test('performs no database or Redis mutation on a true no-change run', async () => {
     const insertBatch = mock(async () => ({ count: 0, inserted: [] }));
     const loadTeamsBasicInfo = mock(async () => mockTeamsForPlayerValues as never);

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import type { StoredPlayerValue } from '../../src/repositories/player-values';
+import {
+  createPlayerValuesSync,
+  type PlayerValuesSyncDependencies,
+} from '../../src/services/player-values.service';
+import {
+  mockTeamsForPlayerValues,
+  singleRawFPLElementFixture,
+} from '../fixtures/player-values.fixtures';
+
+const changeDate = '20260803';
+
+function storedValue(
+  value: number,
+  changeType: StoredPlayerValue['changeType'],
+  lastValue: number,
+): StoredPlayerValue {
+  return {
+    elementId: singleRawFPLElementFixture.id,
+    elementType: singleRawFPLElementFixture.element_type,
+    eventId: 1,
+    value,
+    changeDate,
+    changeType,
+    lastValue,
+  };
+}
+
+function buildDependencies(
+  overrides: Partial<PlayerValuesSyncDependencies> = {},
+): PlayerValuesSyncDependencies {
+  return {
+    getBootstrap: async () => ({ elements: [singleRawFPLElementFixture], teams: [] }) as never,
+    resolvePlayerSyncEvent: async () => ({ event: { id: 1 }, phase: 'current' }) as never,
+    findLatestForAllPlayers: async () => [],
+    findByChangeDate: async () => [],
+    insertBatch: async (rows) => ({ count: rows.length, inserted: rows }),
+    loadTeamsBasicInfo: async () => mockTeamsForPlayerValues as never,
+    getCachedValues: async () => null,
+    mergeCachedValues: async () => undefined,
+    enqueuePlayerPrices: async () => ({ id: 'player-prices-immediate' }) as never,
+    notify: async () => undefined,
+    ...overrides,
+  };
+}
+
+describe('player-values synchronization orchestration', () => {
+  test('performs no database or Redis mutation on a true no-change run', async () => {
+    const insertBatch = mock(async () => ({ count: 0, inserted: [] }));
+    const loadTeamsBasicInfo = mock(async () => mockTeamsForPlayerValues as never);
+    const getCachedValues = mock(async () => null);
+    const mergeCachedValues = mock(async () => undefined);
+    const enqueuePlayerPrices = mock(async () => ({ id: 'unexpected' }) as never);
+
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        findLatestForAllPlayers: async () => [
+          {
+            elementId: singleRawFPLElementFixture.id,
+            value: singleRawFPLElementFixture.now_cost,
+            changeDate: '20260802',
+          },
+        ],
+        insertBatch,
+        loadTeamsBasicInfo,
+        getCachedValues,
+        mergeCachedValues,
+        enqueuePlayerPrices,
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(insertBatch).not.toHaveBeenCalled();
+    expect(loadTeamsBasicInfo).not.toHaveBeenCalled();
+    expect(getCachedValues).not.toHaveBeenCalled();
+    expect(mergeCachedValues).not.toHaveBeenCalled();
+    expect(enqueuePlayerPrices).not.toHaveBeenCalled();
+  });
+
+  test('persists and repairs history before enqueueing prices and notifying', async () => {
+    const operations: string[] = [];
+    const changedElement = { ...singleRawFPLElementFixture, now_cost: 143 };
+    const persisted = storedValue(143, 'Rise', 142);
+    let dateReadCount = 0;
+
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        getBootstrap: async () => ({ elements: [changedElement], teams: [] }) as never,
+        findLatestForAllPlayers: async () => [
+          { elementId: changedElement.id, value: 142, changeDate: '20260802' },
+        ],
+        findByChangeDate: async () => (dateReadCount++ === 0 ? [] : [persisted]),
+        insertBatch: async (rows) => {
+          operations.push('persist');
+          return { count: rows.length, inserted: rows };
+        },
+        mergeCachedValues: async (_date, rows) => {
+          operations.push('cache');
+          expect(rows).toHaveLength(1);
+        },
+        enqueuePlayerPrices: async (_source, options) => {
+          operations.push('enqueue');
+          expect(options).toMatchObject({
+            changeDate,
+            jobId: `player-prices-${changeDate}-immediate`,
+          });
+          return { id: 'player-prices-immediate' } as never;
+        },
+        notify: async () => {
+          operations.push('notify');
+        },
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 1 });
+    expect(operations).toEqual(['persist', 'cache', 'enqueue', 'notify']);
+  });
+
+  test('notification failure does not invalidate a successful capture', async () => {
+    const changedElement = { ...singleRawFPLElementFixture, now_cost: 143 };
+    const persisted = storedValue(143, 'Rise', 142);
+    let dateReadCount = 0;
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        getBootstrap: async () => ({ elements: [changedElement], teams: [] }) as never,
+        findLatestForAllPlayers: async () => [
+          { elementId: changedElement.id, value: 142, changeDate: '20260802' },
+        ],
+        findByChangeDate: async () => (dateReadCount++ === 0 ? [] : [persisted]),
+        notify: async () => {
+          throw new Error('bot unavailable');
+        },
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 1 });
+  });
+});

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 
+import type { PlayerValue } from '../../src/domain/player-values';
 import type { StoredPlayerValue } from '../../src/repositories/player-values';
 import {
   createPlayerValuesSync,
@@ -116,6 +117,38 @@ describe('player-values synchronization orchestration', () => {
 
     expect(await sync(changeDate)).toEqual({ count: 1 });
     expect(operations).toEqual(['persist', 'cache', 'enqueue', 'notify']);
+  });
+
+  test('retries negative-marker deletion after a complete positive hash write', async () => {
+    const persisted = storedValue(singleRawFPLElementFixture.now_cost, 'Start', 0);
+    const cachedValue: PlayerValue = {
+      ...persisted,
+      elementType: 4,
+      elementTypeName: 'FWD',
+      webName: singleRawFPLElementFixture.web_name,
+      teamId: singleRawFPLElementFixture.team,
+      teamName: 'Manchester City',
+      teamShortName: 'MCI',
+    };
+    const mergeCachedValues = mock(async () => undefined);
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        findLatestForAllPlayers: async () => [
+          {
+            elementId: singleRawFPLElementFixture.id,
+            value: singleRawFPLElementFixture.now_cost,
+            changeDate: '20260802',
+          },
+        ],
+        findByChangeDate: async () => [persisted],
+        getCachedValues: async () => [cachedValue],
+        mergeCachedValues,
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(mergeCachedValues).toHaveBeenCalledTimes(1);
+    expect(mergeCachedValues).toHaveBeenCalledWith(changeDate, [cachedValue]);
   });
 
   test('notification failure does not invalidate a successful capture', async () => {

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -6,10 +6,7 @@ import {
   createPlayerValuesSync,
   type PlayerValuesSyncDependencies,
 } from '../../src/services/player-values.service';
-import {
-  getPlayerValueSeasonFloor,
-  getPlayerValueSeasonFloorForDate,
-} from '../../src/utils/player-value-season';
+import { getPlayerValueSeasonFloor } from '../../src/utils/player-value-season';
 import {
   mockTeamsForPlayerValues,
   singleRawFPLElementFixture,
@@ -47,8 +44,9 @@ function buildDependencies(
     findByChangeDate: async () => [],
     insertBatch: async (rows) => ({ count: rows.length, inserted: rows }),
     loadTeamsBasicInfo: async () => mockTeamsForPlayerValues as never,
-    getCachedValues: async () => null,
+    inspectCachedValues: async () => ({ fields: [], entries: [] }),
     mergeCachedValues: async () => undefined,
+    deleteCachedFields: async () => undefined,
     enqueuePlayerPrices: async () => ({ id: 'player-prices-immediate' }) as never,
     notify: async () => undefined,
     getCurrentChangeDate: () => changeDate,
@@ -60,7 +58,6 @@ describe('player-values synchronization orchestration', () => {
   test('keeps the same season floor after the calendar year changes', () => {
     expect(getPlayerValueSeasonFloor('2026-08-15T17:30:00Z')).toBe('20260601');
     expect(getPlayerValueSeasonFloor('2027-01-02T11:00:00Z')).toBe('20260601');
-    expect(getPlayerValueSeasonFloorForDate('20270102')).toBe('20260601');
   });
 
   test('discards a delayed capture after its configured date without reading upstream', async () => {
@@ -123,8 +120,9 @@ describe('player-values synchronization orchestration', () => {
   test('performs no database or Redis mutation on a true no-change run', async () => {
     const insertBatch = mock(async () => ({ count: 0, inserted: [] }));
     const loadTeamsBasicInfo = mock(async () => mockTeamsForPlayerValues as never);
-    const getCachedValues = mock(async () => null);
+    const inspectCachedValues = mock(async () => ({ fields: [], entries: [] }));
     const mergeCachedValues = mock(async () => undefined);
+    const deleteCachedFields = mock(async () => undefined);
     const enqueuePlayerPrices = mock(async () => ({ id: 'unexpected' }) as never);
 
     const sync = createPlayerValuesSync(
@@ -138,8 +136,9 @@ describe('player-values synchronization orchestration', () => {
         ],
         insertBatch,
         loadTeamsBasicInfo,
-        getCachedValues,
+        inspectCachedValues,
         mergeCachedValues,
+        deleteCachedFields,
         enqueuePlayerPrices,
       }),
     );
@@ -147,8 +146,9 @@ describe('player-values synchronization orchestration', () => {
     expect(await sync(changeDate)).toEqual({ count: 0 });
     expect(insertBatch).not.toHaveBeenCalled();
     expect(loadTeamsBasicInfo).not.toHaveBeenCalled();
-    expect(getCachedValues).not.toHaveBeenCalled();
+    expect(inspectCachedValues).not.toHaveBeenCalled();
     expect(mergeCachedValues).not.toHaveBeenCalled();
+    expect(deleteCachedFields).not.toHaveBeenCalled();
     expect(enqueuePlayerPrices).not.toHaveBeenCalled();
   });
 
@@ -213,7 +213,10 @@ describe('player-values synchronization orchestration', () => {
           },
         ],
         findByChangeDate: async () => [persisted],
-        getCachedValues: async () => [cachedValue],
+        inspectCachedValues: async () => ({
+          fields: [String(cachedValue.elementId)],
+          entries: [[String(cachedValue.elementId), cachedValue]],
+        }),
         mergeCachedValues,
       }),
     );
@@ -221,6 +224,47 @@ describe('player-values synchronization orchestration', () => {
     expect(await sync(changeDate)).toEqual({ count: 0 });
     expect(mergeCachedValues).toHaveBeenCalledTimes(1);
     expect(mergeCachedValues).toHaveBeenCalledWith(changeDate, [cachedValue]);
+  });
+
+  test('writes verified fields before deleting stale or mis-keyed fields', async () => {
+    const persisted = storedValue(singleRawFPLElementFixture.now_cost, 'Start', 0);
+    const cachedValue: PlayerValue = {
+      ...persisted,
+      elementType: 4,
+      elementTypeName: 'FWD',
+      webName: singleRawFPLElementFixture.web_name,
+      teamId: singleRawFPLElementFixture.team,
+      teamName: 'Manchester City',
+      teamShortName: 'MCI',
+    };
+    const operations: string[] = [];
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        findLatestForAllPlayers: async () => [
+          {
+            elementId: singleRawFPLElementFixture.id,
+            value: singleRawFPLElementFixture.now_cost,
+            changeDate: '20260802',
+          },
+        ],
+        findByChangeDate: async () => [persisted],
+        inspectCachedValues: async () => ({
+          fields: ['wrong-field'],
+          entries: [['wrong-field', cachedValue]],
+        }),
+        mergeCachedValues: async (_date, rows) => {
+          operations.push('hset');
+          expect(rows).toEqual([cachedValue]);
+        },
+        deleteCachedFields: async (_date, fields) => {
+          operations.push('hdel');
+          expect(fields).toEqual(['wrong-field']);
+        },
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(operations).toEqual(['hset', 'hdel']);
   });
 
   test('notification failure does not invalidate a successful capture', async () => {

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -4,9 +4,12 @@ import type { PlayerValue } from '../../src/domain/player-values';
 import type { StoredPlayerValue } from '../../src/repositories/player-values';
 import {
   createPlayerValuesSync,
-  getPlayerValueSeasonFloor,
   type PlayerValuesSyncDependencies,
 } from '../../src/services/player-values.service';
+import {
+  getPlayerValueSeasonFloor,
+  getPlayerValueSeasonFloorForDate,
+} from '../../src/utils/player-value-season';
 import {
   mockTeamsForPlayerValues,
   singleRawFPLElementFixture,
@@ -48,6 +51,7 @@ function buildDependencies(
     mergeCachedValues: async () => undefined,
     enqueuePlayerPrices: async () => ({ id: 'player-prices-immediate' }) as never,
     notify: async () => undefined,
+    getCurrentChangeDate: () => changeDate,
     ...overrides,
   };
 }
@@ -56,6 +60,20 @@ describe('player-values synchronization orchestration', () => {
   test('keeps the same season floor after the calendar year changes', () => {
     expect(getPlayerValueSeasonFloor('2026-08-15T17:30:00Z')).toBe('20260601');
     expect(getPlayerValueSeasonFloor('2027-01-02T11:00:00Z')).toBe('20260601');
+    expect(getPlayerValueSeasonFloorForDate('20270102')).toBe('20260601');
+  });
+
+  test('discards a delayed capture after its configured date without reading upstream', async () => {
+    const getBootstrap = mock(async () => ({ elements: [singleRawFPLElementFixture] }) as never);
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        getBootstrap,
+        getCurrentChangeDate: () => '20260804',
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(getBootstrap).not.toHaveBeenCalled();
   });
 
   test('scopes preseason history to the published season before seeding Start rows', async () => {

--- a/tests/unit/player-values.test.ts
+++ b/tests/unit/player-values.test.ts
@@ -277,7 +277,6 @@ describe('Player Values Unit Tests', () => {
     test('should create repository instance', () => {
       expect(repository).toBeDefined();
       expect(typeof repository.findLatestForAllPlayers).toBe('function');
-      expect(typeof repository.findDistinctPlayerIds).toBe('function');
       expect(typeof repository.findByChangeDate).toBe('function');
       expect(typeof repository.hasChangesForDate).toBe('function');
       expect(typeof repository.insertBatch).toBe('function');

--- a/tests/unit/player-values.test.ts
+++ b/tests/unit/player-values.test.ts
@@ -98,13 +98,31 @@ describe('Player Values Unit Tests', () => {
 
     describe('Business Logic Functions', () => {
       test('should calculate value change amount', () => {
-        const risingPlayer = generatePlayerValue({ value: 90, lastValue: 80 });
-        const fallingPlayer = generatePlayerValue({ value: 70, lastValue: 80 });
-        const stablePlayer = generatePlayerValue({ value: 80, lastValue: 80 });
+        const risingPlayer = generatePlayerValue({
+          value: 90,
+          lastValue: 80,
+          changeType: 'Rise',
+        });
+        const fallingPlayer = generatePlayerValue({
+          value: 70,
+          lastValue: 80,
+          changeType: 'Faller',
+        });
+        const stablePlayer = generatePlayerValue({
+          value: 80,
+          lastValue: 0,
+          changeType: 'Start',
+        });
+        const startPlayer = generatePlayerValue({
+          value: 80,
+          lastValue: 0,
+          changeType: 'Start',
+        });
 
         expect(getValueChangeAmount(risingPlayer)).toBe(10);
         expect(getValueChangeAmount(fallingPlayer)).toBe(-10);
         expect(getValueChangeAmount(stablePlayer)).toBe(0);
+        expect(getValueChangeAmount(startPlayer)).toBe(0);
       });
 
       test('should calculate value change percentage', () => {
@@ -126,11 +144,25 @@ describe('Player Values Unit Tests', () => {
       });
 
       test('should check for significant value change', () => {
-        const significantRise = generatePlayerValue({ value: 90, lastValue: 75 }); // 15 = 1.5m
-        const minorRise = generatePlayerValue({ value: 85, lastValue: 80 }); // 5 = 0.5m
+        const significantRise = generatePlayerValue({
+          value: 90,
+          lastValue: 75,
+          changeType: 'Rise',
+        }); // 15 = 1.5m
+        const minorRise = generatePlayerValue({
+          value: 85,
+          lastValue: 80,
+          changeType: 'Rise',
+        }); // 5 = 0.5m
+        const startPlayer = generatePlayerValue({
+          value: 80,
+          lastValue: 0,
+          changeType: 'Start',
+        });
 
         expect(hasSignificantValueChange(significantRise)).toBe(true);
         expect(hasSignificantValueChange(minorRise)).toBe(false);
+        expect(hasSignificantValueChange(startPlayer)).toBe(false);
       });
 
       test('should convert value to millions', () => {
@@ -254,15 +286,36 @@ describe('Player Values Unit Tests', () => {
 
       test('should sort player values by change amount', () => {
         const playerValues = [
-          generatePlayerValue({ elementId: 1, value: 90, lastValue: 80 }), // +10
-          generatePlayerValue({ elementId: 2, value: 75, lastValue: 85 }), // -10
-          generatePlayerValue({ elementId: 3, value: 105, lastValue: 80 }), // +25
+          generatePlayerValue({
+            elementId: 1,
+            value: 90,
+            lastValue: 80,
+            changeType: 'Rise',
+          }), // +10
+          generatePlayerValue({
+            elementId: 2,
+            value: 75,
+            lastValue: 85,
+            changeType: 'Faller',
+          }), // -10
+          generatePlayerValue({
+            elementId: 3,
+            value: 105,
+            lastValue: 80,
+            changeType: 'Rise',
+          }), // +25
+          generatePlayerValue({
+            elementId: 4,
+            value: 80,
+            lastValue: 0,
+            changeType: 'Start',
+          }),
         ];
 
         const sorted = sortPlayerValuesByChangeAmount(playerValues);
         const changeAmounts = sorted.map((p) => getValueChangeAmount(p));
-        expect(changeAmounts).toEqual([25, 10, -10]); // Descending order
-        expect(sorted.map((p) => p.elementId)).toEqual([3, 1, 2]);
+        expect(changeAmounts).toEqual([25, 10, 0, -10]); // Descending order
+        expect(sorted.map((p) => p.elementId)).toEqual([3, 1, 4, 2]);
       });
     });
   });

--- a/tests/unit/player-values.test.ts
+++ b/tests/unit/player-values.test.ts
@@ -277,6 +277,7 @@ describe('Player Values Unit Tests', () => {
     test('should create repository instance', () => {
       expect(repository).toBeDefined();
       expect(typeof repository.findLatestForAllPlayers).toBe('function');
+      expect(typeof repository.findDistinctPlayerIds).toBe('function');
       expect(typeof repository.findByChangeDate).toBe('function');
       expect(typeof repository.hasChangesForDate).toBe('function');
       expect(typeof repository.insertBatch).toBe('function');

--- a/tests/unit/player-values.test.ts
+++ b/tests/unit/player-values.test.ts
@@ -79,6 +79,13 @@ describe('Player Values Unit Tests', () => {
         expect(validatedValues).toEqual(playerValues);
       });
 
+      test('requires Start rows to keep lastValue at zero', () => {
+        expect(() => validatePlayerValue({ ...gkpPlayerValueFixture, lastValue: 0 })).not.toThrow();
+        expect(() => validatePlayerValue({ ...gkpPlayerValueFixture, lastValue: 55 })).toThrow(
+          'Start rows must use 0',
+        );
+      });
+
       test('should throw on invalid player value', () => {
         expect(() => validatePlayerValue(invalidPlayerValueFixture)).toThrow();
       });
@@ -287,7 +294,7 @@ describe('Player Values Unit Tests', () => {
           15,
           teamsMap,
           previousValuesMap,
-          '2023-12-15T10:00:00.000Z',
+          '20231215',
         );
 
         expect(transformed.elementId).toBe(1);
@@ -300,14 +307,14 @@ describe('Player Values Unit Tests', () => {
         expect(transformed.value).toBe(142);
         expect(transformed.lastValue).toBe(138);
         expect(transformed.changeType).toBe('Rise');
-        expect(transformed.changeDate).toBe('2023-12-15T10:00:00.000Z');
+        expect(transformed.changeDate).toBe('20231215');
       });
 
       test('should handle transformation without previous values', () => {
         const transformed = transformPlayerValue(singleRawFPLElementFixture, 15, teamsMap);
 
         expect(transformed.value).toBe(142);
-        expect(transformed.lastValue).toBe(142); // Same as current when no previous
+        expect(transformed.lastValue).toBe(0);
         expect(transformed.changeType).toBe('Start');
       });
 
@@ -342,10 +349,10 @@ describe('Player Values Unit Tests', () => {
           previousValuesMap,
         );
 
-        expect(transformed).toHaveLength(3);
+        // Alisson is unchanged from the previous-value map, so no history row is emitted.
+        expect(transformed).toHaveLength(2);
         expect(transformed[0].webName).toBe('Haaland');
-        expect(transformed[1].webName).toBe('Alisson');
-        expect(transformed[2].webName).toBe('Alexander-Arnold');
+        expect(transformed[1].webName).toBe('Alexander-Arnold');
       });
 
       test('should handle partial transformation errors gracefully', () => {
@@ -417,6 +424,15 @@ describe('Player Values Unit Tests', () => {
 
         expect(transformed[0].changeType).toBe('Faller');
         expect(transformed[0].lastValue).toBe(65);
+      });
+
+      test('fails the complete changed batch when any player cannot be transformed', () => {
+        const valid = { ...singleRawFPLElementFixture, id: 901, now_cost: 60 };
+        const invalid = { ...valid, id: 902, team: 999 };
+
+        expect(() =>
+          transformPlayerValuesWithChanges([valid, invalid], 22, teamsMap, new Map(), changeDate),
+        ).toThrow('index 1');
       });
     });
 

--- a/tests/unit/post-match-readiness.test.ts
+++ b/tests/unit/post-match-readiness.test.ts
@@ -158,11 +158,11 @@ describe('current-event job gate', () => {
   });
 });
 
-describe('player-values current-event guard', () => {
-  test('does not query daily values when there is no current event', async () => {
+describe('player-values player-event guard', () => {
+  test('does not query daily values when there is no current or next event', async () => {
     const hasChangesForDate = mock(async () => false);
     const shouldRun = await shouldRunPlayerValuesSync(new Date('2026-08-21T01:25:00.000Z'), {
-      shouldRunCurrentEventJob: async () => false,
+      resolvePlayerSyncEvent: async () => null,
       hasChangesForDate,
     });
 
@@ -170,22 +170,42 @@ describe('player-values current-event guard', () => {
     expect(hasChangesForDate).not.toHaveBeenCalled();
   });
 
-  test('runs only when a current event exists and today has not been recorded', async () => {
+  test('polls a current event until today has been recorded', async () => {
     const date = new Date('2026-08-22T01:25:00.000Z');
-    const shouldRunCurrentEvent = async () => true;
+    const resolvePlayerEvent = async () => ({
+      event: { id: 1 } as Event,
+      phase: 'current' as const,
+    });
 
     expect(
       await shouldRunPlayerValuesSync(date, {
-        shouldRunCurrentEventJob: shouldRunCurrentEvent,
+        resolvePlayerSyncEvent: resolvePlayerEvent,
         hasChangesForDate: async () => true,
       }),
     ).toBe(false);
     expect(
       await shouldRunPlayerValuesSync(date, {
-        shouldRunCurrentEventJob: shouldRunCurrentEvent,
+        resolvePlayerSyncEvent: resolvePlayerEvent,
         hasChangesForDate: async () => false,
       }),
     ).toBe(true);
+  });
+
+  test('allows only the 09:25 tick before GW1', async () => {
+    const dependencies = {
+      resolvePlayerSyncEvent: async () => ({
+        event: { id: 1 } as Event,
+        phase: 'preseason' as const,
+      }),
+      hasChangesForDate: async () => false,
+    };
+
+    expect(
+      await shouldRunPlayerValuesSync(new Date('2026-08-22T01:25:00.000Z'), dependencies),
+    ).toBe(true);
+    expect(
+      await shouldRunPlayerValuesSync(new Date('2026-08-22T01:26:00.000Z'), dependencies),
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/upsert-correctness.test.ts
+++ b/tests/unit/upsert-correctness.test.ts
@@ -16,14 +16,14 @@ import type { RawFPLEntryTransfer } from '../../src/types';
  * blow up the batch.
  */
 
-type CapturedQuery = { sql: string; method: string };
+type CapturedQuery = { sql: string; method: string; params: unknown[] };
 
 type ProxyDb = Parameters<typeof createPlayerValuesRepository>[0];
 
 function createCapturingDb(rowsForAll: unknown[] = []) {
   const queries: CapturedQuery[] = [];
-  const db = drizzle(async (query, _params, method) => {
-    queries.push({ sql: query, method });
+  const db = drizzle(async (query, params, method) => {
+    queries.push({ sql: query, method, params });
     return { rows: method === 'execute' ? [] : rowsForAll };
   }) as unknown as NonNullable<ProxyDb>;
   return { db, queries };
@@ -137,6 +137,16 @@ describe('player-values insertBatch (H6)', () => {
 
     expect(queries).toHaveLength(1);
     expect(queries[0].sql).toContain('on conflict ("element_id","change_date") do nothing');
+  });
+
+  it('maps the domain Faller label to the database fall enum', async () => {
+    const { db, queries } = createCapturingDb();
+    const repo = createPlayerValuesRepository(db);
+
+    await repo.insertBatch([{ ...buildPlayerValue(1), changeType: 'Faller' }]);
+
+    expect(queries[0].params).toContain('fall');
+    expect(queries[0].params).not.toContain('faller');
   });
 
   it('reports the actually inserted count and only those domain rows', async () => {


### PR DESCRIPTION
## Summary

- keep player-value history, current player prices, and event statistics as independently retryable jobs
- initialize values and stats before GW1 using the player-specific current-or-next event resolver
- add immediate and daily current-price reconciliation for affected risers/fallers only
- make player-value and player-stat Redis publication idempotent and repairable
- expose the required `player-prices` manual trigger with an explicit `changeDate`

## Verification

- `bun run test` — 499 unit tests passed
- guarded `tests/integration/upsert-correctness.test.ts` — 4 tests passed against isolated PostgreSQL/Redis
- `bun run typecheck`
- `bun run lint` — 0 errors (7 pre-existing warnings)
- `bun run build`
- `git diff --check`

## Database

No schema migration is required. The production baseline correction remains a separately approved, bounded post-deployment operation and is not performed by this PR.