### PR TITLE
fix: keep season-baseline Start rows out of the Redis price-change hash

### DIFF
--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -241,12 +241,15 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
       }
     }
 
+    // Start rows seed the season baseline for lastValue computation but are
+    // not price changes; only actual changes are published to the Redis hash.
+    // Filter before enrich: a Start row for a player who left the game must
+    // not fail the whole sync inside enrichStoredRows.
+    const cacheableRows = persistedRows.filter((row) => row.changeType !== 'Start');
     const elementsById = new Map(bootstrapData.elements.map((element) => [element.id, element]));
     const missingLivePlayerIds = Array.from(
       new Set(
-        persistedRows
-          .map((row) => row.elementId)
-          .filter((elementId) => !elementsById.has(elementId)),
+        cacheableRows.map((row) => row.elementId).filter((elementId) => !elementsById.has(elementId)),
       ),
     );
     const retainedPlayers =
@@ -255,16 +258,20 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
         : [];
     const retainedPlayersById = new Map(retainedPlayers.map((player) => [player.id, player]));
     const expectedCacheRows = enrichStoredRows(
-      persistedRows,
+      cacheableRows,
       elementsById,
       retainedPlayersById,
       teamsMap,
     );
     const cacheSnapshot = await dependencies.inspectCachedValues(changeDate);
     const cacheRepairs = planPlayerValueCacheRepairs(expectedCacheRows, cacheSnapshot);
-    // Even when every history field already matches, rewrite one verified
-    // positive field before deleting the negative marker. This makes a retry
-    // recover when a prior HSET succeeded but its subsequent DEL failed.
+    // When every history field already matches, rewrite one verified positive
+    // field before deleting the negative marker so a retry recovers when a
+    // prior HSET succeeded but its subsequent DEL failed. On Start-only days
+    // there is no positive field: merge() is skipped, any stale fields are
+    // deleted below, and a lingering negative marker expires on its own
+    // (GraphQL sets it with a 10-minute TTL and reads the hash first, so it
+    // can never shadow positive data).
     const cacheWrites =
       cacheRepairs.writes.length > 0 ? cacheRepairs.writes : expectedCacheRows.slice(0, 1);
     if (cacheWrites.length > 0) {

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -249,7 +249,9 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
     const elementsById = new Map(bootstrapData.elements.map((element) => [element.id, element]));
     const missingLivePlayerIds = Array.from(
       new Set(
-        cacheableRows.map((row) => row.elementId).filter((elementId) => !elementsById.has(elementId)),
+        cacheableRows
+          .map((row) => row.elementId)
+          .filter((elementId) => !elementsById.has(elementId)),
       ),
     );
     const retainedPlayers =

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -93,6 +93,8 @@ describe('player-values synchronization orchestration', () => {
     );
     const enqueuePlayerPrices = mock(async () => ({ id: 'unexpected' }) as never);
     const notify = mock(async () => undefined);
+    const mergeCachedValues = mock(async () => undefined);
+    const deleteCachedFields = mock(async () => undefined);
     const sync = createPlayerValuesSync(
       buildDependencies({
         resolvePlayerSyncEvent: async () =>
@@ -116,11 +118,16 @@ describe('player-values synchronization orchestration', () => {
         },
         enqueuePlayerPrices,
         notify,
+        mergeCachedValues,
+        deleteCachedFields,
       }),
     );
 
     expect(await sync(changeDate)).toEqual({ count: 1 });
     expect(persisted[0]).toMatchObject({ changeType: 'Start', lastValue: 0 });
+    // Start rows seed the DB baseline but must never be published to Redis.
+    expect(mergeCachedValues).not.toHaveBeenCalled();
+    expect(deleteCachedFields).not.toHaveBeenCalled();
     expect(enqueuePlayerPrices).not.toHaveBeenCalled();
     expect(notify).not.toHaveBeenCalled();
   });
@@ -200,7 +207,7 @@ describe('player-values synchronization orchestration', () => {
   });
 
   test('retries negative-marker deletion after a complete positive hash write', async () => {
-    const persisted = storedValue(singleRawFPLElementFixture.now_cost, 'Start', 0);
+    const persisted = storedValue(singleRawFPLElementFixture.now_cost, 'Rise', 141);
     const cachedValue: PlayerValue = {
       ...persisted,
       elementType: 4,
@@ -235,7 +242,7 @@ describe('player-values synchronization orchestration', () => {
   });
 
   test('writes verified fields before deleting stale or mis-keyed fields', async () => {
-    const persisted = storedValue(singleRawFPLElementFixture.now_cost, 'Start', 0);
+    const persisted = storedValue(singleRawFPLElementFixture.now_cost, 'Rise', 141);
     const cachedValue: PlayerValue = {
       ...persisted,
       elementType: 4,
@@ -273,6 +280,81 @@ describe('player-values synchronization orchestration', () => {
 
     expect(await sync(changeDate)).toEqual({ count: 0 });
     expect(operations).toEqual(['hset', 'hdel']);
+  });
+
+  test('excludes Start rows from the cache while persisting them', async () => {
+    const riseRow = storedValue(singleRawFPLElementFixture.now_cost, 'Rise', 141);
+    const startRow: StoredPlayerValue = {
+      elementId: 999, // newly listed player; deliberately absent from bootstrap
+      elementType: 4,
+      eventId: 1,
+      value: 55,
+      changeDate,
+      changeType: 'Start',
+      lastValue: 0,
+    };
+    const mergeCachedValues = mock(async (_date: string, rows: PlayerValue[]) => {
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        elementId: singleRawFPLElementFixture.id,
+        changeType: 'Rise',
+      });
+    });
+    const deleteCachedFields = mock(async () => undefined);
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        findLatestForAllPlayers: async () => [
+          {
+            elementId: singleRawFPLElementFixture.id,
+            value: singleRawFPLElementFixture.now_cost,
+            changeDate: '20260802',
+          },
+        ],
+        findByChangeDate: async () => [riseRow, startRow],
+        mergeCachedValues,
+        deleteCachedFields,
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(mergeCachedValues).toHaveBeenCalledTimes(1);
+    expect(deleteCachedFields).not.toHaveBeenCalled();
+  });
+
+  test('a Start-only day deletes stale hash fields without merging', async () => {
+    const persisted = storedValue(singleRawFPLElementFixture.now_cost, 'Start', 0);
+    const staleValue: PlayerValue = {
+      ...persisted,
+      elementType: 4,
+      elementTypeName: 'FWD',
+      webName: 'Ghost Player',
+      teamId: singleRawFPLElementFixture.team,
+      teamName: 'Manchester City',
+      teamShortName: 'MCI',
+    };
+    const mergeCachedValues = mock(async () => undefined);
+    const deleteCachedFields = mock(async (_date: string, fields: string[]) => {
+      expect(fields).toEqual(['999']);
+    });
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        findLatestForAllPlayers: async () => [
+          {
+            elementId: singleRawFPLElementFixture.id,
+            value: singleRawFPLElementFixture.now_cost,
+            changeDate: '20260802',
+          },
+        ],
+        findByChangeDate: async () => [persisted],
+        inspectCachedValues: async () => ({ fields: ['999'], entries: [['999', staleValue]] }),
+        mergeCachedValues,
+        deleteCachedFields,
+      }),
+    );
+
+    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(mergeCachedValues).not.toHaveBeenCalled();
+    expect(deleteCachedFields).toHaveBeenCalledTimes(1);
   });
 
   test('repairs persisted history from retained player data after a roster omission', async () => {


### PR DESCRIPTION
## 问题

2026-08-02 新赛季首次每日同步：564 名球员全部 `changeType='Start', lastValue=0`（赛季基线，非价格变动）。DB 落库正确，但缓存修复路径 `expectedCacheRows = enrichStoredRows(persistedRows, ...)` 把全部 Start 行 HSET 进 `PlayerValue:20260802`（无 TTL）。下游 GraphQL/web 据此展示了 564 条伪涨价。

通知路径（`nonStart`）与 `hasPersistedPriceChanges`（只看 Rise/Faller）早已排除 Start——缓存 merge 是唯一漏口。

## 修复

- `syncForDate` 在持久化校验后、enrich 前过滤 `changeType === 'Start'` 得到 `cacheableRows`，缓存 enrich/repair 全部改用之（先过滤再 enrich：Start 行对应的离队球员不再触发 `enrichStoredRows` throw 拖垮整个 sync）。
- Start-only 日：`cacheWrites` 为空 → 跳过 `merge()`（GraphQL 侧自行维护 10 分钟 `PlayerValueMissing:` 负缓存）；若当日 key 已脏，repair 会将旧字段判 stale 并 HDEL 自清。
- DB 行为不变：Start 行仍落库作基线。

## 测试

- 季前用例新增断言：Start 落库但 `mergeCachedValues` 不被调用（回归测试）。
- 两个原先用 Start fixture 编码错误行为的用例改用 Rise fixture（保留 HSET-before-marker-DEL / hset→hdel 顺序覆盖）。
- 新增：混合日 merge 仅含 Rise；Start-only 脏快照只 HDEL 不 merge。
- `bun test`：516 pass / 0 fail。

## 部署后

- 已存在的脏 key `PlayerValue:20260802`（TTL -1）已手动 DEL；crawler 不会回溯清理非当日 key。
- 关联修复：letletme-graphql 与 letletme-web 各有一层配套 PR。