### PR TITLE
Import official FPL Classic league members

### DIFF
--- a/src/clients/fpl.ts
+++ b/src/clients/fpl.ts
@@ -371,10 +371,16 @@ const StandingsLeagueSchema = z
   .object({
     id: z.number(),
     name: z.string(),
+    start_event: z.number().int().min(1).max(38).optional(),
+    scoring: z.string().optional(),
   })
   .passthrough();
 export const LeagueStandingsSchema = z
-  .object({ standings: StandingsSchema, league: StandingsLeagueSchema.optional() })
+  .object({
+    standings: StandingsSchema,
+    new_entries: StandingsSchema.optional(),
+    league: StandingsLeagueSchema.optional(),
+  })
   .passthrough();
 
 // Entry history schemas (FPL: /api/entry/{entryId}/history/)
@@ -902,18 +908,20 @@ class FPLClient {
 
   async getLeagueClassicStandings(
     leagueId: number,
-    page: number,
+    standingsPage: number,
+    newEntriesPage = 1,
   ): Promise<RawFPLLeagueStandingsResponse> {
-    const url = `${this.baseUrl}/leagues-classic/${leagueId}/standings/?page_standings=${page}`;
-    return this.getLeagueStandings(url, leagueId, page, 'classic');
+    const url = `${this.baseUrl}/leagues-classic/${leagueId}/standings/?page_standings=${standingsPage}&page_new_entries=${newEntriesPage}`;
+    return this.getLeagueStandings(url, leagueId, standingsPage, 'classic');
   }
 
   async getLeagueH2HStandings(
     leagueId: number,
-    page: number,
+    standingsPage: number,
+    newEntriesPage = 1,
   ): Promise<RawFPLLeagueStandingsResponse> {
-    const url = `${this.baseUrl}/leagues-h2h/${leagueId}/standings/?page_standings=${page}`;
-    return this.getLeagueStandings(url, leagueId, page, 'h2h');
+    const url = `${this.baseUrl}/leagues-h2h/${leagueId}/standings/?page_standings=${standingsPage}&page_new_entries=${newEntriesPage}`;
+    return this.getLeagueStandings(url, leagueId, standingsPage, 'h2h');
   }
 
   async getEntryTransfers(entryId: number): Promise<RawFPLEntryTransfersResponse> {

--- a/src/domain/tournament.ts
+++ b/src/domain/tournament.ts
@@ -267,7 +267,13 @@ export const parseLeagueUrl = (rawUrl: string): { leagueId: number; leagueType: 
     );
   }
 
-  if (parsedUrl.hostname !== FPL_HOSTNAME) {
+  if (
+    parsedUrl.protocol !== 'https:' ||
+    parsedUrl.hostname !== FPL_HOSTNAME ||
+    parsedUrl.port ||
+    parsedUrl.username ||
+    parsedUrl.password
+  ) {
     throw new ValidationError(
       'Only URLs from fantasy.premierleague.com are allowed.',
       'TOURNAMENT_LEAGUE_URL_HOST_INVALID',
@@ -275,15 +281,33 @@ export const parseLeagueUrl = (rawUrl: string): { leagueId: number; leagueType: 
   }
 
   const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
-  if (pathSegments.length < 3 || pathSegments[0] !== 'leagues') {
+  const hasLocalePrefix = /^[a-z]{2}(?:-[a-z]{2})?$/i.test(pathSegments[0] ?? '');
+  const leaguesIndex =
+    pathSegments[0] === 'leagues' ? 0 : hasLocalePrefix && pathSegments[1] === 'leagues' ? 1 : -1;
+  if (leaguesIndex < 0 || pathSegments.length < leaguesIndex + 3) {
     throw new ValidationError(
       'Unsupported league URL format.',
       'TOURNAMENT_LEAGUE_URL_FORMAT_INVALID',
     );
   }
 
-  const leagueId = Number(pathSegments[1]);
-  if (!Number.isInteger(leagueId) || leagueId <= 0) {
+  const surface = pathSegments[leaguesIndex + 2];
+  if (!['standings', 'admin', 'join'].includes(surface)) {
+    throw new ValidationError(
+      'Unsupported league URL format.',
+      'TOURNAMENT_LEAGUE_URL_FORMAT_INVALID',
+    );
+  }
+  const standingsSuffix = surface === 'standings' ? pathSegments[leaguesIndex + 3] : undefined;
+  if (standingsSuffix && !['c', 'classic', 'h', 'h2h'].includes(standingsSuffix.toLowerCase())) {
+    throw new ValidationError(
+      'Unsupported league standings type.',
+      'TOURNAMENT_LEAGUE_URL_FORMAT_INVALID',
+    );
+  }
+
+  const leagueId = Number(pathSegments[leaguesIndex + 1]);
+  if (!Number.isSafeInteger(leagueId) || leagueId <= 0) {
     throw new ValidationError(
       'League ID could not be parsed from the URL.',
       'TOURNAMENT_LEAGUE_ID_INVALID',
@@ -292,7 +316,7 @@ export const parseLeagueUrl = (rawUrl: string): { leagueId: number; leagueType: 
 
   return {
     leagueId,
-    leagueType: inferLeagueType(pathSegments),
+    leagueType: inferLeagueType(pathSegments.slice(leaguesIndex)),
   };
 };
 

--- a/src/services/tournament-create.service.ts
+++ b/src/services/tournament-create.service.ts
@@ -1,69 +1,20 @@
-import { fplClient } from '../clients/fpl';
 import {
-  mapStandingsResultToParticipant,
   normalizeTournamentName,
-  parseLeagueUrl,
   planTournamentStructure,
   selectParticipants,
   tournamentCreateInputSchema,
   uniqueParticipantIds,
   validateTournamentCreateInput,
-  type LeagueType,
   type TournamentCreateInput,
-  type TournamentParticipant,
   type TournamentSetupStatus,
 } from '../domain/tournament';
 import { enqueueTournamentSetup } from '../jobs/tournament-setup.jobs';
 import { tournamentInfoRepository } from '../repositories/tournament-infos';
-import { ConflictError, ValidationError } from '../utils/errors';
+import { ConflictError } from '../utils/errors';
+import { fetchLeagueParticipants } from './tournament-league-members.service';
 
 export { tournamentCreateInputSchema, validateTournamentCreateInput };
 export type { TournamentCreateInput, TournamentSetupStatus };
-
-async function fetchLeagueParticipants(leagueUrl: string): Promise<{
-  leagueId: number;
-  leagueType: LeagueType;
-  participants: TournamentParticipant[];
-}> {
-  const { leagueId, leagueType } = parseLeagueUrl(leagueUrl);
-  const participantMap = new Map<string, TournamentParticipant>();
-  let page = 1;
-  let hasNext = true;
-
-  while (hasNext) {
-    const response =
-      leagueType === 'h2h'
-        ? await fplClient.getLeagueH2HStandings(leagueId, page)
-        : await fplClient.getLeagueClassicStandings(leagueId, page);
-
-    for (const rawResult of response.standings.results) {
-      const participant = mapStandingsResultToParticipant(rawResult);
-      if (participant) {
-        participantMap.set(participant.id, participant);
-      }
-    }
-
-    hasNext = response.standings.has_next;
-    page += 1;
-
-    if (page > 100) {
-      throw new ValidationError(
-        'League standings pagination exceeded the safety limit.',
-        'TOURNAMENT_LEAGUE_PAGINATION_LIMIT',
-      );
-    }
-  }
-
-  const participants = Array.from(participantMap.values());
-  if (participants.length === 0) {
-    throw new ValidationError(
-      'No participants were found for that league.',
-      'TOURNAMENT_LEAGUE_EMPTY',
-    );
-  }
-
-  return { leagueId, leagueType, participants };
-}
 
 export async function checkTournamentNameAvailability(name: string) {
   const normalizedName = normalizeTournamentName(name);

--- a/src/services/tournament-league-members.service.ts
+++ b/src/services/tournament-league-members.service.ts
@@ -1,0 +1,68 @@
+import { fplClient } from '../clients/fpl';
+import {
+  mapStandingsResultToParticipant,
+  parseLeagueUrl,
+  type LeagueType,
+  type TournamentParticipant,
+} from '../domain/tournament';
+import { ValidationError } from '../utils/errors';
+
+const MAX_LEAGUE_PAGES = 100;
+
+export async function fetchLeagueParticipants(leagueUrl: string): Promise<{
+  leagueId: number;
+  leagueType: LeagueType;
+  participants: TournamentParticipant[];
+}> {
+  const { leagueId, leagueType } = parseLeagueUrl(leagueUrl);
+  const participantMap = new Map<string, TournamentParticipant>();
+  let standingsPage = 1;
+  let newEntriesPage = 1;
+  let readStandings = true;
+  let readNewEntries = true;
+
+  while (readStandings || readNewEntries) {
+    const response =
+      leagueType === 'h2h'
+        ? await fplClient.getLeagueH2HStandings(leagueId, standingsPage, newEntriesPage)
+        : await fplClient.getLeagueClassicStandings(leagueId, standingsPage, newEntriesPage);
+
+    // Ranked standings are authoritative if an entry briefly appears in both
+    // cursors because they carry current rank and points.
+    for (const rawResult of readStandings ? response.standings.results : []) {
+      const participant = mapStandingsResultToParticipant(rawResult);
+      if (participant) participantMap.set(participant.id, participant);
+    }
+
+    for (const rawResult of readNewEntries ? (response.new_entries?.results ?? []) : []) {
+      const participant = mapStandingsResultToParticipant(rawResult);
+      if (participant && !participantMap.has(participant.id)) {
+        participantMap.set(participant.id, participant);
+      }
+    }
+
+    const standingsHasNext: boolean = readStandings && response.standings.has_next;
+    const newEntriesHasNext: boolean = readNewEntries && response.new_entries?.has_next === true;
+    if (standingsHasNext) standingsPage += 1;
+    if (newEntriesHasNext) newEntriesPage += 1;
+    readStandings = standingsHasNext;
+    readNewEntries = newEntriesHasNext;
+
+    if (standingsPage > MAX_LEAGUE_PAGES || newEntriesPage > MAX_LEAGUE_PAGES) {
+      throw new ValidationError(
+        'League membership pagination exceeded the safety limit.',
+        'TOURNAMENT_LEAGUE_PAGINATION_LIMIT',
+      );
+    }
+  }
+
+  const participants = Array.from(participantMap.values());
+  if (participants.length === 0) {
+    throw new ValidationError(
+      'No participants were found for that league.',
+      'TOURNAMENT_LEAGUE_EMPTY',
+    );
+  }
+
+  return { leagueId, leagueType, participants };
+}

--- a/tests/unit/fpl-client.test.ts
+++ b/tests/unit/fpl-client.test.ts
@@ -161,6 +161,42 @@ describe('FPL boundary schemas (FP-04)', () => {
     const result = await fplClient.getEntryEventPicks(123, 1);
     expect(result.active_chip).toBeNull();
   });
+
+  test('classic standings retain preseason new entries and both pagination cursors', async () => {
+    let requestedUrl = '';
+    const payload = {
+      league: {
+        id: 8863,
+        name: 'Classic League',
+        start_event: 1,
+        scoring: 'c',
+      },
+      standings: { has_next: false, page: 1, results: [] },
+      new_entries: {
+        has_next: true,
+        page: 2,
+        results: [
+          {
+            entry: 7819,
+            entry_name: 'Preseason Team',
+            player_first_name: 'Preseason',
+            player_last_name: 'Manager',
+          },
+        ],
+      },
+    };
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      requestedUrl = String(url);
+      return new Response(JSON.stringify(payload), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await fplClient.getLeagueClassicStandings(8863, 1, 2);
+
+    expect(requestedUrl).toContain('page_standings=1');
+    expect(requestedUrl).toContain('page_new_entries=2');
+    expect(result.league?.start_event).toBe(1);
+    expect(result.new_entries?.results[0]?.entry).toBe(7819);
+  });
 });
 
 describe('chip mapping at the DB boundary', () => {

--- a/tests/unit/tournament-create.test.ts
+++ b/tests/unit/tournament-create.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { fetchLeagueParticipants } from '../../src/services/tournament-league-members.service';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('tournament league membership import', () => {
+  test('combines ranked standings with every preseason new-entry page', async () => {
+    const requestedUrls: string[] = [];
+    globalThis.fetch = mock(async (request: string | URL | Request) => {
+      const url = new URL(String(request));
+      requestedUrls.push(url.toString());
+      const newEntriesPage = Number(url.searchParams.get('page_new_entries'));
+      const payload = {
+        league: { id: 8863, name: 'Classic League', start_event: 1, scoring: 'c' },
+        standings: {
+          page: 1,
+          has_next: false,
+          results: [
+            {
+              entry: 100,
+              entry_name: 'Ranked Team',
+              player_name: 'Ranked Manager',
+              rank: 1,
+              total: 100,
+            },
+          ],
+        },
+        new_entries: {
+          page: newEntriesPage,
+          has_next: newEntriesPage === 1,
+          results: [
+            {
+              entry: 200 + newEntriesPage,
+              entry_name: `New Team ${newEntriesPage}`,
+              player_first_name: 'New',
+              player_last_name: `Manager ${newEntriesPage}`,
+            },
+            ...(newEntriesPage === 1
+              ? [
+                  {
+                    entry: 100,
+                    entry_name: 'Unranked duplicate',
+                    player_first_name: 'Duplicate',
+                    player_last_name: 'Manager',
+                  },
+                ]
+              : []),
+          ],
+        },
+      };
+      return new Response(JSON.stringify(payload), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchLeagueParticipants(
+      'https://fantasy.premierleague.com/en/leagues/8863/standings/c',
+    );
+
+    expect(result.leagueId).toBe(8863);
+    expect(result.leagueType).toBe('classic');
+    expect(result.participants.map((participant) => participant.id)).toEqual(['100', '201', '202']);
+    expect(result.participants.find((participant) => participant.id === '100')).toMatchObject({
+      team: 'Ranked Team',
+      overallRank: 1,
+      totalPoints: 100,
+    });
+    expect(requestedUrls).toHaveLength(2);
+    expect(requestedUrls[1]).toContain('page_new_entries=2');
+  });
+});

--- a/tests/unit/tournament-domain.test.ts
+++ b/tests/unit/tournament-domain.test.ts
@@ -29,6 +29,15 @@ describe('parseLeagueUrl', () => {
     });
   });
 
+  test('parses the localized classic standings URL copied from FPL', () => {
+    expect(parseLeagueUrl('https://fantasy.premierleague.com/en/leagues/8863/standings/c')).toEqual(
+      {
+        leagueId: 8863,
+        leagueType: 'classic',
+      },
+    );
+  });
+
   test('parses h2h league URLs', () => {
     expect(parseLeagueUrl('https://fantasy.premierleague.com/leagues/99/standings/h')).toEqual({
       leagueId: 99,
@@ -40,6 +49,18 @@ describe('parseLeagueUrl', () => {
     expect(() => parseLeagueUrl('https://example.com/leagues/1/standings/c')).toThrow(
       ValidationError,
     );
+  });
+
+  test('rejects arbitrary path prefixes before leagues', () => {
+    expect(() =>
+      parseLeagueUrl('https://fantasy.premierleague.com/not-a-locale/leagues/1/standings/c'),
+    ).toThrow(ValidationError);
+  });
+
+  test('rejects league IDs that cannot be represented safely', () => {
+    expect(() =>
+      parseLeagueUrl('https://fantasy.premierleague.com/leagues/9007199254740992/standings/c'),
+    ).toThrow(ValidationError);
   });
 });
 


### PR DESCRIPTION
## What changed

- Accept localized official FPL league URLs such as `/en/leagues/8863/standings/c`.
- Import membership from both ranked standings and preseason `new_entries`, with independent pagination and deduplication.
- Keep ranked standings authoritative when FPL briefly exposes an entry in both cursors.
- Reuse the existing tournament persistence, setup, and calculation pipeline.

## Why

Before the season starts, an official Classic league can have an empty `standings.results` array while every member is present under `new_entries`. The existing creation service therefore treated valid leagues as empty.

## Impact

Official Classic leagues can be copied into LetLetMe with all current members, including preseason leagues. H2H behavior is unchanged and the existing custom tournament formats remain supported.

## Validation

- `bun run lint` (no errors; seven existing warnings)
- `bun run typecheck`
- `bun test tests/unit` — 521 passed
- `bun run build`
- Live league 8863 import — 75 members, administrator present