### PR TITLE
Align FPL season readiness guidance

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,18 +19,21 @@ systemd units and `/var/log/letletme` files are not part of the Docker deploymen
 5. **Bootstrap the internal service key** (one-time): generate a high-entropy plaintext key, store that plaintext only as the trusted Web server's `TOURNAMENT_API_KEY`, and put its lowercase SHA-256 hex digest in Data's `DATA_API_KEY_HASHES`. To rotate without downtime, add the new digest, deploy both services, switch the Web secret, verify mutations, then remove the old digest. Data never stores or prints the plaintext key.
 6. **Proxy + hardening**: terminate TLS in Nginx/Caddy, forward to `127.0.0.1:3000`, restrict Redis access to trusted sources on the VPS/network, and enable ufw.
 
-> ℹ️ **Testing note**: GitHub Actions executes only the unit test suite (no external services required). Run the integration tests locally (`bun test tests/integration`) as part of pre-release validation whenever the external dependencies are available.
+> ℹ️ **Testing note**: GitHub Actions runs lint, typecheck, unit tests, build,
+> both migration paths, migration idempotency/status checks, and integration
+> tests against isolated PostgreSQL and Redis services.
 
-## GitHub Actions Secrets
-Add the following repository secrets so the deploy workflow can push images and SSH into the VPS:
+## GitHub Actions configuration
 
-| Secret | Description |
-| --- | --- |
-| `GHCR_TOKEN` | Personal access token with `read:packages` + `write:packages` (used for pushing/pulling the container). |
-| `VPS_HOST` | Public IP / hostname for the VPS (e.g., `43.163.91.9`). |
-| `VPS_USER` | SSH user with Docker permissions (e.g., `deploy`). |
-| `VPS_SSH_KEY` | Private key that grants access to `VPS_USER`. |
-| `VPS_WORKDIR` | Absolute path containing `docker-compose.yml` on the server. |
+The workflow uses GitHub's built-in `GITHUB_TOKEN` for GHCR. Configure these
+repository variables and secret for the SSH deployment:
+
+| Type | Name | Description |
+| --- | --- | --- |
+| Variable | `VPS_HOST` | Public IP or hostname of the VPS |
+| Variable | `VPS_USER` | SSH user with Docker permissions, normally `deploy` |
+| Variable | `VPS_WORKDIR` | Absolute path containing `docker-compose.yml` |
+| Secret | `VPS_SSH_KEY` | Private key that grants access to `VPS_USER` |
 
 The workflow exports `APP_IMAGE=$IMAGE_REF` before running `docker compose pull/up`, ensuring the compose stack always references the freshly pushed GHCR tag.
 
@@ -40,6 +43,18 @@ The workflow exports `APP_IMAGE=$IMAGE_REF` before running `docker compose pull/
 - `scripts/deploy.sh logs api` – follow logs for a specific service.
 - `docker compose logs --since 1h api worker` – inspect bounded production stdout logs.
 - `docker compose run --rm -T api bun run db:migrate` – one-off migration run if needed.
+
+## Post-deploy season readiness
+
+`/health` proves API liveness. `/ready` additionally requires PostgreSQL,
+Redis, and a valid FPL-derived `Season:active`; a fresh Redis deployment can be
+healthy while readiness remains `503` until events sync completes.
+
+For a new season, run the staged write and independent PostgreSQL/Redis audit in
+[docs/fpl-season-readiness.md](docs/fpl-season-readiness.md). Do not set
+`Season:active` manually, infer an endpoint's availability from local data, or
+treat a successful container rollout as proof that current-season data is
+complete.
 
 ## Legacy Manual Deployment (Break Glass)
 The original bare-metal guide is retained below for emergencies when Docker/CI/CD are unavailable.

--- a/README.md
+++ b/README.md
@@ -1,190 +1,233 @@
-# Overall
+# LetLetMe Data
 
-Letletme_data is the sole writer for LetLetMe's FPL domain data. It fetches the
-Fantasy Premier League (FPL) APIs, validates and transforms the responses, and
-persists canonical rows in PostgreSQL plus disposable read models in Redis.
-Its REST surface is an internal ingestion/control plane; `letletme-graphql` is
-the public product data API.
+`letletme_data` is the sole writer for LetLetMe's Fantasy Premier League (FPL)
+domain data. It fetches official FPL endpoints, validates and transforms every
+accepted payload, persists canonical rows in PostgreSQL, and publishes
+rebuildable Redis read models. Its REST API is an internal ingestion and
+operations surface; product clients read through `letletme-graphql`.
 
-Key Features:
+## What this service owns
 
-- Real-time FPL data fetching and transformation
-- Protected operational REST endpoints for sync and tournament commands
-- Efficient data persistence with PostgreSQL
-- Performance optimization using Redis caching
-- Type-safe implementation with strict TypeScript
-- Docker containerization for easy deployment
+- Official FPL API access, retries, timeouts, and boundary validation.
+- Core season data: events, teams, fixtures, players, and phases.
+- Current-gameweek, entry, league, tournament, live, and price-change jobs.
+- Canonical FPL and tournament rows in PostgreSQL.
+- Data-owned Redis hashes, the `Season:active` authority key, and BullMQ jobs.
+- Protected operational endpoints for manual synchronization and recovery.
 
-# Architecture & Workflow
+It does not own browser authentication or the public product schema. See
+[System contracts](docs/SYSTEM_CONTRACTS.md) for the four-repository ownership
+model and [Redis contract](docs/redis-contract.md) for the binding key shapes.
 
-## System Architecture
-
-```mermaid
-graph TB
-    FPL[FPL API] --> |Raw Data| Fetcher[Data Fetcher]
-    Fetcher --> |JSON| Transform[Data Transformer]
-    Transform --> |Validated Data| Storage[Data Storage]
-    Storage --> |Write| DB[(PostgreSQL)]
-    Storage --> |Cache| Cache[(Redis)]
-    API[REST API] --> |Read| Cache
-    API --> |Read/Write| DB
-    Cron[Cron Jobs] --> |Trigger| Fetcher
-
-    subgraph Data Processing
-        Fetcher
-        Transform
-        Storage
-    end
-
-    subgraph Data Access
-        API
-    end
-
-    subgraph Scheduling
-        Cron
-    end
-```
-
-## Data Flow
-
-```mermaid
-sequenceDiagram
-    participant C as Cron Job
-    participant F as Fetcher
-    participant T as Transformer
-    participant P as PostgreSQL
-    participant R as Redis
-    participant A as API
-
-    C->>F: Trigger data fetch
-    F->>FPL: Request data
-    FPL-->>F: Return raw data
-    F->>T: Pass raw JSON
-    T->>T: Validate & transform
-    T->>P: Store processed data
-    T->>R: Cache frequently accessed data
-
-    Note over A,R: API Data Access Flow
-    A->>R: Check cache
-    alt Cache hit
-        R-->>A: Return cached data
-    else Cache miss
-        A->>P: Query database
-        P-->>A: Return data
-        A->>R: Update cache
-    end
-```
-
-See [docs/SYSTEM_CONTRACTS.md](docs/SYSTEM_CONTRACTS.md) for repository
-ownership, trust boundaries, authentication, cache ownership, and rollout
-rules. See [docs/redis-contract.md](docs/redis-contract.md) for the binding key
-inventory.
-
-## Data Processing Pipeline
+## Architecture
 
 ```mermaid
 flowchart LR
-    A[Raw FPL Data] --> B[Validation Layer]
-    B --> C[Transform Layer]
-    C --> D[Business Logic]
-    D --> E[Storage Layer]
-
-    subgraph Validation
-        B --> |zod| B1[Schema Validation]
-    end
-
-    subgraph Transform
-        C --> C1[Data Mapping]
-        C --> C2[Error Handling]
-    end
-
-    subgraph Storage
-        E --> E1[PostgreSQL]
-        E --> E2[Redis Cache]
-    end
+    S["Cron scheduler or internal REST command"] --> Q["BullMQ queues"]
+    Q --> W["Background workers"]
+    W --> F["Official FPL API"]
+    F --> V["Zod boundary validation"]
+    V --> T["Domain transformation"]
+    T --> P[("PostgreSQL canonical state")]
+    T --> R[("Redis read models")]
+    P --> G["letletme-graphql"]
+    R --> G
+    G --> C["Product clients"]
 ```
 
-# Tech Stack
+The API process owns HTTP routes and cron registration. The worker process
+consumes the data, entry, live, league, tournament, and tournament-setup queue
+families. Run both processes; an API-only deployment can enqueue work but
+cannot complete it.
 
-Core:
+PostgreSQL is authoritative. Redis is disposable acceleration state. A failed
+FPL request or validation error fails the sync without replacing the last
+accepted canonical state.
 
-- TypeScript (with strict type checking)
-- Bun (runtime, package manager, bundler, and test runner)
-- ElysiaJS (REST API framework)
+## 2026/27 season compatibility
 
-Storage:
+The current code accepts the official pre-season placeholders observed for
+2026/27 without inventing substitute values:
 
-- PostgreSQL (primary database)
-- Redis (caching layer and BullMQ queues, via ioredis)
-- Drizzle ORM (type-safe ORM)
+| Upstream field | Accepted value | Meaning in this service |
+|---|---:|---|
+| Team `strength` | `null` | FPL has not published a strength rating |
+| Team `position` | `0` | Team is not ranked yet; it sorts after ranked teams |
+| Fixture `pulse_id` | `0` | Pulse identifier has not been assigned |
 
-Testing & Quality:
+Core discovery jobs run year-round so a newly published season is detected
+before the fixture-derived season window opens. The season code comes from the
+GW1 deadline or kickoff metadata (`2026/27` becomes `2627`); it is never guessed
+from the server calendar.
 
-- Bun Test Runner
-- ESLint & Prettier (code quality tools)
+The first core bootstrap updates five PostgreSQL tables and seven Redis
+families:
 
-Utilities:
+| Domain | PostgreSQL | Redis |
+|---|---|---|
+| Events | `events` | `Season:active`, `Event:{season}` |
+| Teams | `teams` | `Team:{season}` |
+| Fixtures | `event_fixtures` | `Fixtures:{season}:*`, `FixturesByTeam:{season}:*` |
+| Players | `players` | `Player:{season}` |
+| Phases | `phases` | `Phase:{season}` |
 
-- Pino (structured logging)
-- Zod (runtime type validation)
+Entry records, player statistics and values, picks, event-live data, results,
+and tournament derivatives require their own upstream data and job gates. They
+are not evidence that the core bootstrap failed when GW1 or a current event has
+not been published yet.
 
-DevOps:
+Endpoint availability changes throughout pre-season. Do not copy a one-time
+"active endpoint count" into operational decisions. Use the read-only checks
+and staged update matrix in the
+[FPL season readiness runbook](docs/fpl-season-readiness.md).
 
-- Docker (containerization)
-- Docker Compose (multi-container orchestration)
+## Season rollover guarantees
 
-# Domain-Driven Design
+- Empty core arrays preserve existing database and cache state.
+- `Season:active` advances only to a newer, valid four-digit season derived
+  from FPL metadata.
+- When that key advances through a core write, all documented season-scoped
+  Data cache families are scanned and prior-season keys are removed. This does
+  not flush Redis, BullMQ state, price history, or consumer-owned keys.
+- PostgreSQL intentionally stores one FPL season at a time. IDs reused by FPL
+  overwrite the prior season's canonical rows.
+- Player stats/values and live/selection jobs require both the fixture-derived
+  season window and a current event. Core discovery jobs do not; bounded
+  post-match result jobs intentionally remain eligible after the GW38 date.
+- League and tournament results poll only during the bounded 24-hour window
+  after the final fixture's expected end. Hourly provisional/final job IDs
+  deduplicate repeated ticks, failed deterministic jobs remain retryable, and
+  a final league correction runs after fresh `event_lives` persistence.
 
-The project follows DDD principles with clear domain boundaries and type-safe implementations.
+## Local setup
 
-```mermaid
-graph TB
-    subgraph Core Domain
-        Event[Event Domain]
-        Player[Player Domain]
-        Team[Team Domain]
-        Entry[Entry Domain]
-        League[League Domain]
-    end
+Prerequisites:
 
-    subgraph Supporting Domains
-        Scout[Scout Domain]
-        Stats[Statistics Domain]
-        Live[Live Domain]
-    end
+- Bun `1.3.3` (the version pinned in `package.json`)
+- PostgreSQL
+- Redis for cache and BullMQ; queue Redis may use a separate database
 
-    Event --> Stats
-    Player --> Stats
-    Team --> Stats
-    Entry --> Stats
-    League --> Stats
+Install and configure:
 
-    Stats --> Live
-    Scout --> Live
+```bash
+cp .env.example .env
+bun install --frozen-lockfile
+bun run env:check
+bun run db:migrate
+bun run db:apply-sql
+bun run db:migrate:status
 ```
 
-Each domain follows a standard structure with entities, repositories, services, and types, ensuring clear separation of concerns and maintainable code.
+At minimum, configure `DATABASE_URL` and `REDIS_*`. `QUEUE_REDIS_*` defaults to
+the cache Redis connection. Supabase and notification variables are optional
+runtime integrations. Production must use `ENABLE_AUTH=true` with at least one
+SHA-256 digest in `DATA_API_KEY_HASHES`.
+
+Start the two processes in separate terminals:
+
+```bash
+bun run dev
+```
+
+```bash
+bun run worker:dev
+```
+
+The API listens on `http://localhost:3000` by default.
+
+## Health and readiness
+
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/ready
+```
+
+- `/health` checks API process liveness.
+- `/ready` requires PostgreSQL, Redis, and a valid FPL-derived
+  `Season:active`. A fresh Redis instance is expected to return `503` until a
+  successful events sync establishes the active season.
+
+Do not write `Season:active` manually to make readiness green. Trigger events
+sync and let the validated GW1 metadata establish it:
+
+```bash
+curl -X POST http://localhost:3000/events/sync \
+  -H "x-api-key: $DATA_API_KEY"
+```
+
+The header is required when `ENABLE_AUTH=true` and may be omitted in an
+explicitly unauthenticated local environment.
+
+## Manual core-season bootstrap
+
+Each mutation returns after enqueueing a job. Keep the worker running and wait
+for each job to complete before moving to the next dependency-sensitive step:
+
+```bash
+curl -X POST http://localhost:3000/events/sync \
+  -H "x-api-key: $DATA_API_KEY"
+curl -X POST http://localhost:3000/teams/sync \
+  -H "x-api-key: $DATA_API_KEY"
+curl -X POST http://localhost:3000/fixtures/sync \
+  -H "x-api-key: $DATA_API_KEY"
+curl -X POST http://localhost:3000/players/sync \
+  -H "x-api-key: $DATA_API_KEY"
+curl -X POST http://localhost:3000/phases/sync \
+  -H "x-api-key: $DATA_API_KEY"
+```
+
+Teams precede fixtures because the `FixturesByTeam` cache is rebuilt from the
+active team hash. The writer preserves an existing team-fixture view if teams
+are absent, but the ordered bootstrap avoids an incomplete first build.
+
+Use `GET /jobs` to list manual operational triggers. Full request examples are
+in the [API cheat sheet](docs/api-cheat-sheet.md).
+
+## Development commands
+
+| Command | Purpose |
+|---|---|
+| `bun run dev` | Start the API with watch mode |
+| `bun run worker:dev` | Start all BullMQ workers with watch mode |
+| `bun run build` | Build API and worker into `dist/` |
+| `bun start` | Run the production API bundle |
+| `bun run worker:start` | Run the production worker bundle |
+| `bun run test` or `bun test tests/unit` | Run the hermetic unit suite |
+| `bun run test:integration` | Run guarded PostgreSQL/Redis integration tests |
+| `RUN_INTEGRATION=1 bun run test:all` | Run unit and integration tests with the guarded test environment |
+| `bun run typecheck` | Type-check without emitting files |
+| `bun run lint` | Run ESLint |
+| `bun run coverage` | Run unit tests with coverage |
+| `bun run db:migrate` | Apply Drizzle-journaled migrations |
+| `bun run db:apply-sql` | Apply repository-numbered SQL migrations |
+| `bun run db:migrate:status` | Verify both migration histories and checksums |
+
+Integration tests refuse production-like database or Redis targets. See
+[tests/README.md](tests/README.md) for the required isolated setup.
 
 ## Deployment
 
-- The production stack runs inside Docker containers orchestrated by `docker compose`; copy `.env.deploy.example` to `.env.deploy`, then run `scripts/deploy.sh` to build images, start services, and execute database migrations locally or on the VPS.
-- Continuous delivery is handled via GitHub Actions (`.github/workflows/deploy.yml`), which builds a container image, pushes it to GHCR, and refreshes the VPS stack using the same compose file.
-- Refer to `DEPLOYMENT.md` for the full checklist and required GitHub secrets.
-- Production mutations require `ENABLE_AUTH=true` and one or more SHA-256
-  digests in `DATA_API_KEY_HASHES`. The web server keeps the matching plaintext
-  key in its server-only `TOURNAMENT_API_KEY`; browsers never receive it.
+Production uses the API and worker images in `docker-compose.yml`. Migrations
+run before either service is restarted, logs go to bounded Docker JSON files,
+and the worker health check uses its heartbeat file.
 
-## Testing
+```bash
+cp .env.deploy.example .env.deploy
+bash scripts/deploy.sh deploy
+```
 
-- Run `bun test tests/unit` for the fast, deterministic suite that validates transformers, repositories, and utilities (this is what the CI workflow executes).
-- Run `bun run test:integration` locally before production releases; these tests require PostgreSQL and Redis and are gated to test-only infrastructure. See `tests/README.md` for setup details.
+Merges to `main` deploy only after the CI workflow succeeds. See
+[DEPLOYMENT.md](DEPLOYMENT.md) for host bootstrap, GitHub configuration,
+rollback, and troubleshooting. Merging is not permission to bypass the
+production data audit in the season-readiness runbook.
 
-## Scheduled major upgrades
+## Documentation
 
-The following major-version upgrades are planned once the current fix plan lands and CI is green:
-
-- Zod 4
-- Pino 10
-- ESLint 10
-
-Track them in dependency-renovation PRs; do not mix them with fix-plan items.
+- [FPL season readiness runbook](docs/fpl-season-readiness.md)
+- [System contracts](docs/SYSTEM_CONTRACTS.md)
+- [Redis key contract](docs/redis-contract.md)
+- [Job schedule and gates](docs/job-schedule.md)
+- [Internal API cheat sheet](docs/api-cheat-sheet.md)
+- [Migration ownership](migrations/README.md)
+- [Test strategy](tests/README.md)
+- [Deployment guide](DEPLOYMENT.md)

--- a/docs/SYSTEM_CONTRACTS.md
+++ b/docs/SYSTEM_CONTRACTS.md
@@ -19,7 +19,9 @@ This repository participates in one four-repository system:
    rebuildable acceleration layer, never the system of record.
 5. GraphQL reads PostgreSQL and Data-owned positive hashes, then exposes the
    product schema. It must preserve a database fallback or an explicit error;
-   cache misses cannot become invented data.
+   cache misses cannot become invented data. Team strength is nullable while
+   FPL has not published its pre-season rating; readers must preserve that
+   unknown state rather than substitute a numeric value.
 6. Web signs short-lived user and ingress envelopes for GraphQL. Web-authenticated
    tournament mutations are forwarded to Data with a separate internal API key.
 7. The Mini Program obtains a hashed bearer session from Web and uses it for
@@ -74,6 +76,20 @@ for deployments that have not completed the migration.
   authenticated `events-sync` job from the trusted network. It derives the
   season from FPL GW1 metadata and establishes the key; do not set a guessed
   calendar value merely to make `/ready` green.
+- Core discovery jobs (events, teams, fixtures, players, phases) run year-round
+  so new-season metadata can be accepted before the fixture-derived season
+  window opens. Empty core arrays are no-ops that preserve accepted state.
+- Valid pre-season placeholders remain explicit: team `strength=null`, team
+  `position=0`, and fixture `pulseId=0`. They mean unknown, unranked, and not
+  assigned respectively; downstream code must not infer stronger values.
+- When a core write advances `Season:active`, Data removes prior-season keys
+  for every family in `SEASON_CACHE_PREFIXES`. Price-history, ops, lock,
+  cascade-coordination, BullMQ, and consumer-owned keys remain outside that
+  cleanup.
+- League and tournament result polling uses the fixture-bounded 24-hour
+  post-match window rather than the calendar season boundary. Final league
+  results are corrected again after fresh `event_lives` persistence so GW38
+  and delayed FPL finalization cannot leave a stale snapshot.
 - LiveBonus V2 is additive. Keep GraphQL `LIVE_POINTS_V2=false` until the V2 hash
   has been sampled for single and double gameweeks.
 - Never deploy one repository's contract switch before its producer/validator

--- a/docs/api-cheat-sheet.md
+++ b/docs/api-cheat-sheet.md
@@ -1,6 +1,7 @@
 # API Cheat Sheet
 
-Current production base URL:
+Examples use this placeholder internal base URL; substitute the actual trusted
+environment endpoint:
 
 - `http://data.internal.example`
 
@@ -13,9 +14,16 @@ Important:
   `Season:active` key are ready. On a fresh Redis restore, use the authenticated
   `events-sync` trigger to establish the key, then confirm `/ready`.
 - `POST`, `PUT`, `PATCH`, and `DELETE` require an API key in the `x-api-key` header when `ENABLE_AUTH=true`.
+- Mutation examples below omit the repeated auth header for readability unless
+  it is the focus of the example. Add `-H "x-api-key: $API_KEY"` to every
+  mutation in an authenticated environment.
 - Generate a random key outside the service, store its SHA-256 digest in
   `DATA_API_KEY_HASHES`, and store the plaintext only in the trusted caller's
   secret manager. Comma-separated digests allow overlap during rotation.
+- Sync responses normally confirm enqueueing, not completion. Keep the worker
+  running and verify the BullMQ job result before auditing database/cache data.
+- For new-season order, readiness stages, and read-only verification, use the
+  [FPL season readiness runbook](fpl-season-readiness.md).
 
 ## Auth header for mutations
 
@@ -96,18 +104,25 @@ curl -X POST http://data.internal.example/events/sync -H "x-api-key: $API_KEY"
   - `curl http://data.internal.example/jobs`
 - `POST /jobs/:name/trigger`
   - `curl -X POST http://data.internal.example/jobs/events-sync/trigger`
+  - `curl -X POST -H 'content-type: application/json' -d '{"changeDate":"20260803"}' http://data.internal.example/jobs/player-prices/trigger`
   - `curl -X POST http://data.internal.example/jobs/event-lives-db-sync/trigger`
   - `curl -X POST http://data.internal.example/jobs/live-scores/trigger`
 
 Supported job names:
 
 - `events-sync`
+- `event-current-refresh`
 - `fixtures-sync`
 - `teams-sync`
 - `players-sync`
+- `player-prices` (requires JSON body `{ "changeDate": "YYYYMMDD" }`)
 - `player-stats-sync`
 - `phases-sync`
 - `player-values-sync`
+- `entry-info-daily`
+- `entry-event-picks-daily`
+- `entry-event-transfers-daily`
+- `entry-event-results-daily`
 - `league-event-picks-sync`
 - `league-event-results-sync`
 - `tournament-event-picks-sync`
@@ -115,10 +130,12 @@ Supported job names:
 - `tournament-event-transfers-pre-sync`
 - `tournament-event-transfers-post-sync`
 - `tournament-event-cup-results-sync`
+- `tournament-selection-stats-sync`
 - `tournament-info-sync`
 - `tournament-points-race-results-sync`
 - `tournament-battle-race-results-sync`
 - `tournament-knockout-results-sync`
+- `tournament-materialized-views-refresh`
 - `event-lives-cache-update`
 - `event-lives-db-sync`
 - `event-live-summary-sync`
@@ -126,3 +143,8 @@ Supported job names:
 - `event-overall-result-sync`
 - `live-scores`
 - `post-match-consolidation`
+- `launch-warning`
+- `launch-happening`
+
+`GET /jobs` is the runtime authority for the complete trigger list and current
+descriptions.

--- a/docs/cache-ttl-summary.md
+++ b/docs/cache-ttl-summary.md
@@ -1,52 +1,57 @@
-# Cache TTL Summary
+# Cache retention summary
 
-All cache TTL (Time To Live) configurations in seconds.
+This page is a quick retention view. The binding key names, shapes, ownership,
+and rollover rules are in [redis-contract.md](redis-contract.md).
 
-**Note:** TTL -1 means no expiration (cache persists indefinitely until manually deleted).
+## Data read models
 
-## Cache TTL Values (No Expiration Strategy)
+Data hashes do not expire by TTL. They are replaced by sync writers and the
+season-scoped families are removed when `Season:active` advances.
 
-| Cache Type | TTL (seconds) | TTL (human) | Cache Key Pattern | Category |
-|------------|---------------|-------------|-------------------|----------|
-| **EVENTS** | -1 | No expiration | `Event:{season}` | Basic/Static |
-| **TEAMS** | -1 | No expiration | `Team:{season}` | Basic/Static |
-| **PHASES** | -1 | No expiration | `Phase:{season}` | Basic/Static |
-| **PLAYERS** | -1 | No expiration | `Player:{season}` | Basic/Static |
-| **FIXTURES** | -1 | No expiration | `Fixtures:{season}:{eventId}` | Game Data |
-| **PLAYER_STATS** | -1 | No expiration | `PlayerStat:{season}` | Game Data |
-| **player_values** | -1 | No expiration | `PlayerValue:{changeDate}` | Game Data |
-| **EVENT_LIVE** | -1 | No expiration | `EventLive:{season}:{eventId}` | Live Match Data |
-| **EVENT_LIVE_EXPLAIN** | -1 | No expiration | `EventLiveExplain:{season}:{eventId}` | Live Match Data |
-| **LIVE_FIXTURE** | -1 | No expiration | `LiveFixture:{season}:{eventId}` | Live Match Data |
-| **LIVE_BONUS** | -1 | No expiration | `LiveBonus:{season}:{eventId}` | Live Match Data |
-| **EVENT_LIVE_SUMMARY** | -1 | No expiration | `EventLiveSummary:{season}:{eventId}` | Aggregated Data |
-| **EVENT_OVERALL_RESULT** | -1 | No expiration | `EventOverallResult:{season}` | Aggregated Data |
-| **EVENT_STANDINGS** | -1 | No expiration | `EventStandings:{season}` | Aggregated Data |
-| **LIVE_DATA** | -1 | No expiration | N/A | Live Match Data |
+| Family | Key pattern | TTL |
+|---|---|---:|
+| Events | `Event:{season}` | none |
+| Teams | `Team:{season}` | none |
+| Phases | `Phase:{season}` | none |
+| Players | `Player:{season}` | none |
+| Player stats | `PlayerStat:{season}` | none |
+| Entry info | `EntryInfo:{season}` | none |
+| Fixtures | `Fixtures:{season}:{eventId}` | none |
+| Unscheduled fixtures | `Fixtures:{season}:unscheduled` | none |
+| Team fixtures | `FixturesByTeam:{season}:{teamId}` | none |
+| Event live | `EventLive:{season}:{eventId}` | none |
+| Event live explain | `EventLiveExplain:{season}:{eventId}` | none |
+| Event live summary | `EventLiveSummary:{season}:{eventId}` | none |
+| Overall result | `EventOverallResult:{season}` | none |
+| Live fixtures | `LiveFixture:{season}:{eventId}` | none |
+| Live bonus | `LiveBonus:{season}:{eventId}` | none |
+| Live bonus V2 | `LiveBonusV2:{season}:{eventId}` | none |
 
-## Default Cache Config
+`PlayerValue:{YYYYMMDD}` is date-scoped historical data, also with no TTL, but
+it is deliberately outside automatic season rollover.
 
-- **DEFAULT_CACHE_CONFIG.ttl**: 300 seconds (5 minutes)
-  - Used by generic cache operations when no specific TTL is provided
+## Control and internal state
 
-## TTL Strategy Rationale
+| Key family | Retention |
+|---|---|
+| `Season:active` | No TTL; advances only from validated FPL season metadata |
+| `event:current` | No TTL; overwritten in place from the active Event hash |
+| `LaunchNotification:*` | No TTL; year/season suffix provides re-arming |
+| `letletme:entry-info-sync:daily:*` | Expires at the next UTC midnight, minimum 60 seconds |
+| `mutation-lock:*` | Millisecond TTL from `MUTATION_LOCK_TTL_MS` |
+| `tournament-cascade:*` | 24 hours, except the refresh lease at 120 seconds |
+| `bull:*` | Managed by BullMQ queue/worker retention settings |
 
-### Why No Expiration (TTL -1)?
-Since **read operations don't update the cache** (only sync operations do), using TTL -1 (no expiration) ensures:
-- **No cache misses** - Cache persists indefinitely until manually cleared
-- **Consistent performance** - No unexpected cache expiration
-- **Reduced database load** - Cache always available
-- **Predictable behavior** - Cache only updates during sync operations
+Post-match jobs with deterministic IDs retain successful BullMQ jobs for 24
+hours to deduplicate repeated ticks. Failed deterministic jobs are removed so
+the same hourly slot can be retried.
 
-### Cache Update Strategy
-- **Delete before insert**: All cache `set()` operations delete the existing key before inserting new data
-- **Sync-only updates**: Caches are updated by scheduled sync jobs (not by read operations)
-- **Manual cleanup**: Caches can be manually cleared when needed (e.g., during data migrations or when stale data is detected)
+## Update and rollover behavior
 
-### Cache Operations
-All cache `set()` methods follow this pattern:
-1. Delete existing cache key (`del(key)`)
-2. Insert new data (`hset(key, data)`)
-3. Set expiration only if TTL > 0 (skip if TTL is -1)
-
-This ensures clean cache updates without stale data accumulation.
+- Entity writers replace affected hashes; reads do not extend retention.
+- Empty core upstream arrays preserve the previously accepted cache.
+- The first core write that advances `Season:active` scans all fifteen
+  season-scoped families and deletes prior-season keys.
+- Rollover does not delete player-value history, notification markers, locks,
+  cascade coordination, BullMQ state, or consumer-owned negative markers.
+- Never use `FLUSHDB` or `FLUSHALL` for cache maintenance.

--- a/docs/endpoint-review.md
+++ b/docs/endpoint-review.md
@@ -1,5 +1,11 @@
 # Job Review
 
+> Historical review snapshot from July 2026. Findings and proposed improvements
+> below describe the code at review time and are retained for traceability. Use
+> [job-schedule.md](job-schedule.md) for current cron expressions and gates,
+> [redis-contract.md](redis-contract.md) for current cache behavior, and
+> [fpl-season-readiness.md](fpl-season-readiness.md) for season rollover.
+
 Assumption: background jobs are the only source of trust.
 
 ## Data Sync Jobs (queue-based)
@@ -76,16 +82,13 @@ Assumption: background jobs are the only source of trust.
 - Location: `src/jobs/player-values-window.jobs.ts`, `src/jobs/data-sync.queue.ts`,
   `src/workers/data-sync.worker.ts`.
 - Aim: refresh current player value changes.
-- Main logic: cron 09:25-09:35 (every minute) runs `syncCurrentPlayerValues()` directly and skips the
-  remaining minutes once a change-date row exists; manual triggers still enqueue the data-sync job.
-- Deep dive: `syncCurrentPlayerValues()` uses bootstrap, finds current event, compares current
-  `now_cost` with last stored values, transforms via `transformPlayerValuesWithChanges()`, inserts
-  new records, then caches by `changeDate`.
-- Potential issues: empty `elements` yields `{ count: 0 }` with no explicit warning; transform errors
-  are logged but not surfaced in result; event-specific sync uses ISO `changeDate`, which doesn’t
-  match the `YYYYMMDD` date cache convention.
-- Improvements: season gate added; consider empty-response guard and warning counts; align
-  event-sync `changeDate` format with date cache keys.
+- Main logic: before GW1 only the 09:25 tick runs against the next event. Once an event is current,
+  09:25-09:35 ticks enqueue `player-values` until the UTC+8 date has a Rise/Faller batch.
+- Deep dive: `syncCurrentPlayerValues()` compares bootstrap `now_cost` with persisted history,
+  inserts one strict logical row per player/date, repairs Redis with `HSET`, then enqueues the
+  separate `player-prices` current-price job before best-effort notifications.
+- No-change behavior: if bootstrap prices match history and the date has no persisted batch, the
+  service performs no database or Redis mutation.
 
 ## Entry Sync Jobs (queue-based)
 

--- a/docs/fpl-season-readiness.md
+++ b/docs/fpl-season-readiness.md
@@ -1,0 +1,203 @@
+# FPL season readiness and rollover runbook
+
+Use this runbook when official FPL starts publishing a new season or when
+deciding which data can be synchronized safely. It deliberately separates two
+questions:
+
+1. Does the official upstream endpoint return a usable response now?
+2. Has this environment validated, persisted, and cached that data?
+
+An upstream `200` does not prove PostgreSQL or Redis is current. A local empty
+table does not prove the upstream endpoint is unavailable.
+
+## External endpoint inventory
+
+The FPL client has ten logical endpoint patterns. Test them read-only with real,
+current IDs where required; do not treat an expected pre-publication `404` as a
+schema failure.
+
+| Endpoint pattern | Client method | Becomes useful when |
+|---|---|---|
+| `/bootstrap-static/` | `getBootstrap()` | FPL publishes events, teams, players, and phases |
+| `/fixtures/` or `/fixtures/?event={eventId}` | `getFixtures()` | The fixture list or requested GW exists |
+| `/event/{eventId}/live/` | `getEventLive()` | The gameweek live feed is published |
+| `/entry/{entryId}/` | `getEntrySummary()` | The entry exists in the new season |
+| `/entry/{entryId}/event/{eventId}/picks/` | `getEntryEventPicks()` | Picks for that GW are published |
+| `/entry/{entryId}/transfers/` | `getEntryTransfers()` | The entry has a current-season transfer feed |
+| `/entry/{entryId}/history/` | `getEntryHistory()` | The entry has current/past history data |
+| `/entry/{entryId}/cup/` | `getEntryCup()` | Cup data exists; `404` is handled as unavailable |
+| `/leagues-classic/{leagueId}/standings/` | `getLeagueClassicStandings()` | A current classic league ID exists |
+| `/leagues-h2h/{leagueId}/standings/` | `getLeagueH2HStandings()` | A current H2H league ID exists |
+
+Record the HTTP result, validation result, tested IDs, response counts, and
+timestamp for each live audit. Endpoint counts are observations, not durable
+configuration.
+
+## Boundary compatibility
+
+Pre-season payloads can contain valid placeholders that would be invalid once
+the competition is ranked. Preserve them exactly:
+
+| Domain field | Accepted placeholder | Downstream behavior |
+|---|---:|---|
+| `Team.strength` | `null` | Unknown; never treated as a strong team or included in a strength range |
+| `Team.position` | `0` | Unranked; sorts after ranked teams when points are tied |
+| `Fixture.pulseId` | `0` | Not assigned; remains a non-null integer in PostgreSQL |
+
+Migration `0035_allow_preseason_team_strength.sql` makes
+`public.teams.strength` nullable. Migration
+`0036_align_fpl_runtime_types.sql` aligns the remaining live runtime types.
+Apply and verify both migration ledgers before any write.
+
+## Staged synchronization matrix
+
+### Stage 1: core season metadata
+
+This stage is safe once bootstrap and fixtures validate with non-empty core
+arrays. It does not require a current gameweek.
+
+| Sync | PostgreSQL target | Redis target | Minimum upstream evidence |
+|---|---|---|---|
+| Events | `events` | `Season:active`, `Event:{season}` | GW1 has a valid deadline |
+| Teams | `teams` | `Team:{season}` | Non-empty teams array validates |
+| Fixtures | `event_fixtures` | `Fixtures:{season}:*`, `FixturesByTeam:{season}:*` | Non-empty fixtures array validates |
+| Players | `players` | `Player:{season}` | Non-empty elements array validates |
+| Phases | `phases` | `Phase:{season}` | Non-empty phases array validates |
+
+Run in this order: events, teams, fixtures, players, phases. Wait for each
+BullMQ job to complete. An HTTP `202` means only that the command was queued.
+
+### Stage 2: bound entries and metadata
+
+`entry_infos`, `entry_history_infos`, and `entry_league_infos` depend on known,
+current entry IDs. Seed or sync only explicitly bound entries. They are not part
+of automatic core-season bootstrap.
+
+### Stage 3: current-event and match data
+
+Wait until a current event exists and the relevant endpoint is published before
+enabling or manually triggering:
+
+- player statistics and player values;
+- picks, transfers, and per-entry results;
+- event-live rows, explanations, summaries, live fixtures, and bonus views;
+- league and tournament results or their derived materialized views.
+
+The ordinary cron gates perform these checks, but a manual trigger may bypass a
+time window. Manual execution is an operations decision, not proof that
+upstream data is ready.
+
+## Write procedure
+
+1. Confirm the target environment and take a read-only count/key inventory.
+2. Apply migrations and require `bun run db:migrate:status` to pass.
+3. Start both the API and worker processes.
+4. Trigger the five Stage 1 syncs in order.
+5. Audit job completion and error counts; do not rely only on enqueue responses.
+6. Verify PostgreSQL and Redis independently.
+7. Sample records, including nullable/zero placeholder fields.
+8. Report missing fields or rejected records before advancing to Stage 2 or 3.
+
+Example authenticated triggers:
+
+```bash
+export DATA_URL='http://localhost:3000'
+export DATA_API_KEY='<plaintext internal key>'
+
+curl -X POST "$DATA_URL/events/sync" -H "x-api-key: $DATA_API_KEY"
+curl -X POST "$DATA_URL/teams/sync" -H "x-api-key: $DATA_API_KEY"
+curl -X POST "$DATA_URL/fixtures/sync" -H "x-api-key: $DATA_API_KEY"
+curl -X POST "$DATA_URL/players/sync" -H "x-api-key: $DATA_API_KEY"
+curl -X POST "$DATA_URL/phases/sync" -H "x-api-key: $DATA_API_KEY"
+```
+
+## Read-only verification
+
+### PostgreSQL
+
+Run against the intended database using a read-only session or role:
+
+```sql
+SELECT 'events' AS table_name, count(*) AS row_count FROM public.events
+UNION ALL
+SELECT 'teams', count(*) FROM public.teams
+UNION ALL
+SELECT 'event_fixtures', count(*) FROM public.event_fixtures
+UNION ALL
+SELECT 'players', count(*) FROM public.players
+UNION ALL
+SELECT 'phases', count(*) FROM public.phases
+ORDER BY table_name;
+```
+
+Check placeholder preservation:
+
+```sql
+SELECT id, name, position, strength
+FROM public.teams
+WHERE position = 0 OR strength IS NULL
+ORDER BY id;
+
+SELECT id, event_id, pulse_id
+FROM public.event_fixtures
+WHERE pulse_id = 0
+ORDER BY id
+LIMIT 20;
+```
+
+### Redis
+
+Use `SCAN`, not `KEYS`, in production:
+
+```bash
+redis-cli GET Season:active
+redis-cli HLEN Event:2627
+redis-cli HLEN Team:2627
+redis-cli HLEN Player:2627
+redis-cli HLEN Phase:2627
+redis-cli --scan --pattern 'Fixtures:2627:*' | wc -l
+redis-cli --scan --pattern 'FixturesByTeam:2627:*' | wc -l
+```
+
+The expected season must come from the accepted GW1 metadata. Replace `2627`
+with the observed value; never use the example as an instruction to overwrite
+`Season:active`.
+
+## Post-match result readiness
+
+League and tournament result schedulers poll every ten minutes but enqueue only
+inside the 24-hour period after the last fixture's expected end
+(`kickoff + 2 hours`). Each hour has a deterministic slot:
+
+- `provisional-N` while FPL has not marked event data checked;
+- `final-N` after `data_checked=true`.
+
+Successful deterministic jobs are retained for 24 hours to deduplicate repeated
+ticks. Failed deterministic jobs are removed so a later tick can retry the same
+slot. After an `event_lives` database sync succeeds, the worker enqueues a
+distinct final league correction when the event is checked. This keeps league
+snapshots aligned with freshly persisted live totals, including the day after
+GW38.
+
+Tournament result completion starts its cascade only when active tournament
+entries were actually processed. An empty result does not fan out no-op
+derivative jobs.
+
+## Audit report template
+
+Report these sections separately:
+
+- **Upstream:** endpoint, tested identifiers, HTTP status, validation status,
+  response count, and observation time.
+- **PostgreSQL:** target, before/after count, rejected records, and sampled
+  placeholder values.
+- **Redis:** `Season:active`, hash/key counts by family, stale-season inventory,
+  and BullMQ keys kept separate from data caches.
+- **Deferred:** every dataset still waiting for a current event, published GW
+  data, or explicit entry/league identifiers.
+- **Decision:** ready/not ready for each stage, with missing fields listed
+  explicitly.
+
+For deletion and stale-season recovery, follow the sign-off rules in the
+[Redis contract](redis-contract.md). Never use `FLUSHDB` or `FLUSHALL` as a
+season rollover procedure.

--- a/docs/job-schedule.md
+++ b/docs/job-schedule.md
@@ -1,46 +1,137 @@
-# Job Schedule
+# Job schedule and execution gates
 
-## Daily Data Sync
-- ✅ `events-sync`: daily 06:35 (`35 6 * * *`) via data sync queue.
-- ✅ `teams-sync`: daily 06:37 (`37 6 * * *`) via data sync queue.
-- ✅ `fixtures-sync`: daily 06:40 (`40 6 * * *`) via data sync queue.
-- ✅ `players-sync`: daily 06:43 (`43 6 * * *`) via data sync queue.
-- ✅ `phases-sync`: daily 06:45 (`45 6 * * *`) via data sync queue.
-- ✅ `player-stats-sync`: daily 09:40 (`40 9 * * *`) via data sync queue.
+All cron expressions run in `Asia/Shanghai` (UTC+8). Cron ticks are candidates,
+not guarantees of a write: each job applies its documented season, current
+event, fixture-window, and data-availability gates before enqueueing.
 
-## Player Values Poller
-- ✅ `player-values-sync`: 09:25-09:35 every minute (`25-35 9 * * *`), stops once the day’s price changes have been stored.
+## Core season discovery
 
-## Entry **Jobs**
-- ✅ `entry-info-daily`: daily 10:30 (`30 10 * * *`) via entry sync queue.
-- ✅ `entry-event-picks-daily`: daily 10:35 (`35 10 * * *`) via entry sync queue.
-- ✅ `entry-event-transfers-daily`: daily 10:40 (`40 10 * * *`) via entry sync queue.
-- ✅ `entry-event-results-daily`: daily 10:45 (`45 10 * * *`) via entry sync queue.
-- ✅ Entry sync retries failed entry IDs up to 2 cycles.
+These jobs run year-round so a newly published season can be discovered before
+the fixture-derived `isFPLSeason` window opens.
 
-## Matchday Jobs
-- ✅ `event-lives-cache-trigger`: every minute (`* * * * *`), gated by `isMatchDayTime`.
-- ✅ `event-lives-db-trigger`: every 10 minutes (`*/10 * * * *`), gated by `isMatchDayTime`.
-- ✅ `live-scores`: every 15 minutes (`*/15 * * * *`), gated by `isMatchDayTime`.
-- ✅ `post-match-consolidation`: 06:00/08:00/10:00 (`0 6,8,10 * * *`), gated by `isAfterMatchDay`.
-- ✅ Cascade-only live jobs (no direct cron): `event-live-summary`, `event-live-explain`, `event-overall-result`.
-- ✅ Minute-triggered cache jobs: `live-fixture-cache`, `live-bonus-cache`.
+| Job | Cron | Gate |
+|---|---|---|
+| `events-sync` | `35 6 * * *` | None; empty events preserve existing state |
+| `teams-sync` | `37 6 * * *` | None; empty teams preserve existing state |
+| `fixtures-sync` | `40 6 * * *` | None; empty fixtures preserve existing state |
+| `players-sync` | `43 6 * * *` | None; empty players preserve existing state |
+| `phases-sync` | `45 6 * * *` | None; empty phases preserve existing state |
 
-## Selection Window Jobs (Pre-deadline)
-- ✅ `league-event-picks-sync`: every 5 minutes (`*/5 * * * *`), gated by `isSelectTime`.
-- ✅ `tournament-event-picks-sync`: every 5 minutes (`*/5 * * * *`), gated by `isSelectTime`.
-- ✅ `tournament-event-transfers-pre-sync`: every 5 minutes (`*/5 * * * *`), gated by `isSelectTime`.
+`player-stats-sync` runs at `40 9 * * *` but is not a discovery job. Player
+values and stats use the player-specific `current ?? next` resolver so GW1 can
+be initialized before the ordinary current-event gate opens.
 
-## Post-Matchday Jobs
-- ✅ `league-event-results-sync`: every 10 minutes (`*/10 * * * *`), gated by `isAfterMatchDay`.
-- ✅ `tournament-event-results-sync`: every 10 minutes (`*/10 * * * *`), gated by `isAfterMatchDay`.
-- ✅ Cascade-only tournament jobs (no direct cron): `tournament-points-race`, `tournament-battle-race`, `tournament-knockout`, `tournament-transfers-post`, `tournament-cup-results`.
+## Season launch and current-event control
 
-## Daily Tournament Metadata
-- ✅ `tournament-info-sync`: daily 10:45 (`45 10 * * *`).
+| Job | Cron | Gate / behavior |
+|---|---|---|
+| `launch-warning` | `* * * * *` | Year-round; sends once per year when bootstrap events are empty |
+| `launch-happening` | `* * * * *` | Year-round; sends once per FPL-derived season when a current-year GW1 deadline appears |
+| `event-current-refresh` | `* * * * *` | `isFPLSeason`; rebuilds `event:current` and enqueues events sync when the GW changes |
 
-## Matchday Helpers
-- ✅ `isMatchDay`: today is in fixture kickoff dates (UTC), skips if event finished.
-- ✅ `isMatchDayTime`: between earliest kickoff and (latest kickoff + 2h).
-- ✅ `isAfterMatchDay`: event finished or now > (latest kickoff + 2h).
-- ✅ `isSelectTime`: between deadline + 30m and +60m on matchday.
+Launch jobs call the FPL bootstrap endpoint directly from the API process. All
+other synchronization work is queue-backed.
+
+## Player values
+
+| Job | Cron | Gate / behavior |
+|---|---|---|
+| `player-values-sync` | `25-35 9 * * *` | Before GW1 only 09:25 runs against the next event; once current, every minute until that UTC+8 date's Rise/Faller batch exists |
+| `player-prices-sync` | `40 9 * * *` | Replays that UTC+8 date's persisted Rise/Faller rows into affected current players; skips cleanly when none exist |
+| `player-stats-sync` | `40 9 * * *` | Refreshes the current event, or the next event only when no current event exists |
+
+The window uses one deterministic daily job ID to prevent overlap. The data
+worker retries failures, and settled deterministic jobs are removed so another
+tick can enqueue when needed.
+
+## Entry jobs
+
+| Job | Cron | Gate / behavior |
+|---|---|---|
+| `entry-info-daily` | `30 10 * * *` | `isFPLSeason`; once per UTC date marker |
+| `entry-event-picks-window` | `*/5 * * * *` | `isFPLSeason`, current event, selection publication window |
+| `entry-event-transfers-daily` | `40 10 * * *` | `isFPLSeason`, current event, `isAfterMatchDay` |
+| `entry-event-results-daily` | `45 10 * * *` | `isFPLSeason` and current event |
+
+Entry jobs operate only on known `entry_infos`; core season bootstrap does not
+create entry bindings. Failed entry IDs can be retried by the entry worker's
+bounded retry cycle.
+
+## Match-window live jobs
+
+| Job | Cron | Gate / behavior |
+|---|---|---|
+| `event-lives-cache-trigger` | `* * * * *` | `isFPLSeason`, current event, `isMatchDayTime` |
+| `event-lives-db-trigger` | `*/10 * * * *` | Same gate; DB persistence then dependent cascade |
+| `live-scores` | `* * * * *` | Same gate; updates in-progress fixture scores |
+| `post-match-consolidation` | `0 6,8,10 * * *` | Current event and bounded post-match result slot |
+
+After an event-lives DB sync succeeds, the worker always enqueues summary,
+explain, and overall-result jobs. Live-fixture and live-bonus jobs are included
+only while the match window remains open. If the event is data-checked inside
+the post-match window, the worker also enqueues a distinct final league-results
+correction after the fresh `event_lives` rows are persisted.
+
+## Selection publication window
+
+The following poll every five minutes:
+
+- `league-event-picks-trigger`
+- `tournament-event-picks-trigger`
+- `tournament-event-transfers-pre-trigger`
+
+They require `isFPLSeason`, a current event, and `isSelectTime`. Selection time
+is the UTC match date from 30 through 90 minutes after the FPL deadline. It is
+the post-deadline publication window for immutable picks, despite the legacy
+"pre" name on tournament transfer tracking.
+
+## Post-match league and tournament results
+
+| Job | Cron | Gate / behavior |
+|---|---|---|
+| `league-event-results-trigger` | `*/10 * * * *` | Current event plus bounded post-match slot |
+| `tournament-event-results-trigger` | `*/10 * * * *` | Current event plus bounded post-match slot |
+
+The result window starts after the final fixture's expected end
+(`latest kickoff + 2 hours`) and remains open for 24 hours. It intentionally
+does not use the calendar `isFPLSeason` gate, so the next-day GW38 finalization
+can still run.
+
+Each hour maps to `provisional-N` or `final-N` according to the event's
+`data_checked` flag. Deterministic job IDs make repeated ten-minute ticks
+idempotent. Successful jobs remain in BullMQ for 24 hours; failed jobs are
+removed so a later tick can retry the same slot.
+
+The tournament event-results job starts its cascade only when at least one
+active tournament entry was processed. The cascade contains:
+
+- points-race, battle-race, and knockout structure jobs;
+- post-event transfer calculation and selection stats;
+- cup results;
+- one materialized-view refresh after the three structure jobs reach their
+  Redis-backed completion barrier.
+
+## Tournament metadata
+
+| Job | Cron | Gate / behavior |
+|---|---|---|
+| `tournament-info-sync` | `45 10 * * *` | `isFPLSeason` |
+
+## Gate definitions
+
+- `isFPLSeason`: UTC day range from the earliest GW1 kickoff through the
+  latest GW38 kickoff date. It returns false until both fixture sets exist.
+- `isMatchDay`: today matches at least one fixture kickoff date and the event
+  is not finished.
+- `isMatchDayTime`: any fixture is between kickoff and kickoff +2h; a started,
+  unfinished fixture may keep its interval open up to +6h for delayed FPL
+  finish flags.
+- `isAfterMatchDay`: event is finished or now is later than the final kickoff
+  +2h.
+- `isSelectTime`: match day and 30–90 minutes after the event deadline.
+- Post-match result slot: later than final kickoff +2h but earlier than 24
+  hours after that expected end.
+
+Manual triggers are listed by `GET /jobs`. Some manual paths intentionally
+bypass a cron time gate for recovery; operators must verify upstream readiness
+before using them.

--- a/docs/redis-contract.md
+++ b/docs/redis-contract.md
@@ -1,6 +1,6 @@
 # Redis Key Contract — letletme_data
 
-**Status:** authoritative inventory of every Redis key this system writes, as of 2026-07-17.
+**Status:** authoritative inventory of every Redis key this system writes, as of 2026-08-01.
 **Audience:** anyone changing cache code, and every external system that reads this Redis.
 
 ## Ground rules (binding)
@@ -72,19 +72,19 @@ live Redis state and belong in this inventory.
 | Key pattern | Type | Hash field | Value | Retention / ownership |
 |---|---|---|---|---|
 | `PlayerValue:{YYYYMMDD}` | hash | `elementId` | Domain `PlayerValue` JSON | **Written by this service.** No automatic retention job — one key per price-change date accumulates forever. Broader retention requires consumer sign-off (manual runbook only). |
-| `PlayerValueMissing:{YYYYMMDD}` | *(consumer-owned)* | — | *(consumer-defined)* | **Not written by this service** — an external consumer creates it. **This service deletes it** on every `playerValuesCache.set` / `clear` for that date (`src/cache/player-values-cache.ts`), defensively, whenever the real `PlayerValue:{date}` hash is refreshed or cleared. Freeze/sign-off rules still apply: do not rename or repurpose the key; the delete-on-refresh behavior is part of the contract. |
+| `PlayerValueMissing:{YYYYMMDD}` | *(consumer-owned)* | — | *(consumer-defined)* | **Not written by this service** — an external consumer creates it. A positive `HSET` repair clears the marker only after the real history fields are written; a true no-change run leaves both keys untouched. Explicit cache clearing also removes the matching marker. |
 
 ## 5. `PlayerStat:{season}` — latest-event-wins view (important)
 
-`PlayerStat:{season}` is a **current view**, not an archive: each stats sync
-replaces the *entire* hash (`DEL` + `HSET`) with the stats of the event being
-synced. Consumers must read it as "stats as of the latest synced event", never
-as per-event history.
+`PlayerStat:{season}` is a **current view**, not an archive: each eligible stats
+sync builds a complete staging hash and atomically renames it over the entire
+view. Consumers must read it as "stats for the current event", or the next event
+only when no current event exists, never as per-event history.
 
-Writer rule (FP-12): only a sync for the **current event** may write this view
-(enforced by `shouldWritePlayerStatsView` in `player-stats.service.ts`);
-syncs of older events persist to the DB only, so a backfill can never clobber
-the current view.
+Writer rule (FP-12): a sync for the **current event** may write this view. When
+there is no current event, the next event may write it for preseason. Historical
+and manual backfills persist to the DB only, so they cannot clobber the latest
+view (enforced by `shouldWritePlayerStatsView`).
 
 The misleadingly-named internal helper `clearByEvent(eventId)` also clears the
 **whole** hash — it is not per-event (documented at the method; the argument
@@ -109,6 +109,19 @@ view; existing keys stay intact until a later sync with teams present.
 |---|---|---|
 | `mutation-lock:{scope}` | string | Redlock-style mutex (`SET NX PX` with a random token, TTL from `MUTATION_LOCK_TTL_MS`). Scopes come from `src/domain/mutation-scope.ts` (e.g. `tournament-structure:global`, `entry-event:event:N`). Internal coordination only — **do not read or write from other systems.** |
 
+Tournament result cascades also use short-lived internal coordination keys:
+
+| Key pattern | Type | TTL | Notes |
+|---|---|---:|---|
+| `tournament-cascade:meta:{cascadeId}` | string | 24h | Expected structure participant count |
+| `tournament-cascade:structure-done:{cascadeId}:{jobKey}` | string | 24h | Idempotent success or enqueue-failure slot per structure job |
+| `tournament-cascade:refresh-pending:{cascadeId}` | string | 24h | Structure barrier completed; materialized-view refresh is pending |
+| `tournament-cascade:refresh-enqueued:{cascadeId}` | string | 24h | Durable refresh-enqueued marker |
+| `tournament-cascade:refresh-lease:{cascadeId}` | string | 120s | Recoverable lease around refresh enqueue |
+
+These are worker coordination state, not consumer data. They expire
+automatically and must not be included in season cleanup.
+
 ## 8. BullMQ queue keys (internal)
 
 BullMQ stores queue state under `bull:{queueName}:*` on the **queue Redis**
@@ -117,6 +130,12 @@ BullMQ stores queue state under `bull:{queueName}:*` on the **queue Redis**
 `tournament-setup`. When `ENABLE_TIERED_MUTATION_QUEUES` is on (default off),
 each base queue is replaced by `…-p0` / `…-p1` / `…-p2` / `…-p3` tier queues.
 Internal to the worker fleet — do not consume directly.
+
+Post-match league and tournament schedulers use deterministic hourly job IDs.
+Successful deterministic jobs remain for 24 hours to deduplicate repeated cron
+ticks. Failed deterministic jobs are removed so a later tick can retry the same
+slot. This retention applies only to BullMQ job state; it does not change the
+entity-key retention rules above.
 
 ## 9. Consumers
 
@@ -127,50 +146,53 @@ Internal to the worker fleet — do not consume directly.
 
 ## 10. Season rollover
 
-### Automatic today (when `Season:active` changes)
+### Automatic today (when `Season:active` advances)
 
-Entity writers call `finalizeSeasonCacheWrite(season, prefixes)`, which:
+Core entity writers call `finalizeSeasonCacheWrite(season, prefixes)`, which:
 
-1. Updates `Season:active` if the write season is newer.
-2. If (and only if) that value **changed**, calls `clearStaleSeasonCache` to
-   `DEL` keys under the given prefixes that are **not** for the new active
-   season.
+1. Updates `Season:active` only when the validated FPL-derived season is newer.
+2. If (and only if) that value **changed**, expands the cleanup set to the full
+   `SEASON_CACHE_PREFIXES` inventory and deletes keys that are not scoped to the
+   new active season.
 
-Prefixes currently passed in by writers:
+The automatic rollover prefixes are:
 
-| Prefixes | Call site family |
+| Core metadata | Current-event and entry views |
 |---|---|
-| `Event` | events cache |
-| `Team` | teams cache |
-| `Player` | players cache |
-| `Phase` | phases cache |
-| `Fixtures`, `FixturesByTeam` | fixtures cache |
+| `Event` | `EventLive` |
+| `Team` | `EventLiveSummary` |
+| `Player` | `EventLiveExplain` |
+| `Phase` | `LiveFixture` |
+| `Fixtures` | `LiveBonus` |
+| `FixturesByTeam` | `LiveBonusV2` |
+|  | `EventOverallResult` |
+|  | `EntryInfo` |
+|  | `PlayerStat` |
 
-So on a real season transition, the **next** sync for those entities can delete
-prior-season `Event:*`, `Team:*`, `Player:*`, `Phase:*`, `Fixtures*`, and
-`FixturesByTeam*` keys automatically. This is **not** a full Redis wipe.
+The first core cache write that advances `Season:active` therefore removes
+prior-season keys for all fifteen families in one pass, even if that family is
+not part of the current write. This is **not** a full Redis wipe.
 
-### Not auto-deleted today
+### Not auto-deleted
 
-Examples that **do not** go through the prefix cleanup above (and must not be
-assumed gone after rollover):
+These keys are outside `SEASON_CACHE_PREFIXES` and must not be assumed gone
+after rollover:
 
-- `PlayerValue:{YYYYMMDD}` (explicit no-auto-delete / retention policy; still deleted only via explicit `clear` or future runbook)
-- `PlayerValueMissing:{YYYYMMDD}` (consumer-owned; this service only DELs it when refreshing/clearing that date’s `PlayerValue` — see §4)
-- `EntryInfo:{season}`, live hashes (`EventLive*`, `LiveFixture`, `LiveBonus*`),
-  `EventOverallResult`, `event:current`
-- Ops markers (`LaunchNotification:*`, `letletme:entry-info-sync:*`)
-- `mutation-lock:*`, BullMQ `bull:*` keys
+- `PlayerValue:{YYYYMMDD}` (explicit no-auto-delete retention policy).
+- `PlayerValueMissing:{YYYYMMDD}` (consumer-owned; Data clears the matching
+  marker only after a positive history write or an explicit clear; see §4).
+- `event:current` (overwritten in place from the active Event hash).
+- Ops markers (`LaunchNotification:*`, `letletme:entry-info-sync:*`).
+- `mutation-lock:*`, `tournament-cascade:*`, and BullMQ `bull:*` keys.
 
-### Manual rollover runbook (FP-17)
+### Manual rollover recovery runbook (FP-17)
 
-Automatic cleanup intentionally covers only the prefixes above. Everything
-else is deleted **manually, after consumer sign-off** — there are no automatic
-retention jobs, and none may be added without updating this contract.
+Manual deletion is a recovery path for a bypassed or failed automatic rollover,
+not an ordinary season-start step. It always requires consumer sign-off.
 
-**When to run:** after `Season:active` has advanced to the new season and the
-first full round of new-season syncs (events, teams, players, phases,
-fixtures) has completed.
+**When to run:** only after `Season:active` has advanced, the first full core
+sync (events, teams, fixtures, players, phases) has completed, and the read-only
+inventory still shows old-season keys.
 
 **Step 1 — verify the new season is live (read-only)**
 
@@ -211,6 +233,12 @@ Delete **only** the leftover old-season keys from Step 2. Never use
 `FLUSHDB`/`FLUSHALL`; prefer `--scan` batches over `KEYS` in production:
 
 ```bash
+redis-cli --scan --pattern "Event:$OLD"              | xargs -r redis-cli DEL
+redis-cli --scan --pattern "Team:$OLD"               | xargs -r redis-cli DEL
+redis-cli --scan --pattern "Player:$OLD"             | xargs -r redis-cli DEL
+redis-cli --scan --pattern "Phase:$OLD"              | xargs -r redis-cli DEL
+redis-cli --scan --pattern "Fixtures:$OLD:*"         | xargs -r redis-cli DEL
+redis-cli --scan --pattern "FixturesByTeam:$OLD:*"   | xargs -r redis-cli DEL
 redis-cli --scan --pattern "EntryInfo:$OLD"          | xargs -r redis-cli DEL
 redis-cli --scan --pattern "EventLive:$OLD:*"        | xargs -r redis-cli DEL
 redis-cli --scan --pattern "EventLiveExplain:$OLD:*" | xargs -r redis-cli DEL
@@ -222,9 +250,8 @@ redis-cli --scan --pattern "LiveBonusV2:$OLD:*"      | xargs -r redis-cli DEL
 redis-cli --scan --pattern "PlayerStat:$OLD"         | xargs -r redis-cli DEL
 ```
 
-(`Event`, `Team`, `Player`, `Phase`, `Fixtures*`, `FixturesByTeam*` for the old
-season are normally already gone via the automatic prefix pass; delete them
-manually only if Step 2 shows leftovers.)
+(All fifteen season-scoped families are normally already gone via the automatic
+prefix pass. Delete only the explicit leftovers reported by Step 2.)
 
 **Step 5 — verify**
 
@@ -235,12 +262,13 @@ manually only if Step 2 shows leftovers.)
 
 - `PlayerValue:{YYYYMMDD}` — historical price data; stays until Tong and
   consumers agree on a retention window. No automatic retention job, ever.
-- `PlayerValueMissing:{YYYYMMDD}` — consumer-owned; this service only deletes
-  it when refreshing/clearing the matching `PlayerValue` date (§4).
+- `PlayerValueMissing:{YYYYMMDD}` — consumer-owned; this service clears it only
+  after a positive history write or an explicit clear of the matching date (§4).
 - `Season:active`, `event:current` — live control keys; `event:current` is
   overwritten in place, nothing to clean.
 - `LaunchNotification:*` — re-arms per year/season by design (§3).
-- `letletme:entry-info-sync:daily:*`, `mutation-lock:*` — expire via TTL.
+- `letletme:entry-info-sync:daily:*`, `mutation-lock:*`, and
+  `tournament-cascade:*` — expire via TTL.
 - `bull:*` — managed by BullMQ (§8).
 
 ## 11. Database single-season semantics (FP-21)

--- a/src/jobs/live.jobs.ts
+++ b/src/jobs/live.jobs.ts
@@ -116,8 +116,9 @@ async function runEventLivesDbSync() {
   }
 }
 
-// Post-match consolidation: catches FPL overnight data finalization (bonus points, corrected
-// scores, data_checked flag). Runs on match days in the morning AFTER isMatchDayTime has ended.
+// Post-match consolidation catches delayed FPL finalization (bonus points,
+// corrected scores, data_checked). Fixed morning ticks enqueue only while the
+// fixture-bounded 24-hour result window is open, including the day after GW38.
 export async function runPostMatchConsolidation() {
   const now = new Date();
   const currentEvent = await getCurrentEvent();
@@ -206,7 +207,7 @@ export function registerLiveJobs(app: Elysia) {
         }),
       )
 
-      // Post-match consolidation - 06:00, 08:00, 10:00 on match days
+      // Post-match consolidation - 06:00, 08:00, 10:00 during the result window
       // FPL finalises bonus points, corrects scores, and sets data_checked hours after matches end.
       // This catches those overnight updates that the 10-min live job misses once isMatchDayTime ends.
       .use(

--- a/src/services/job-trigger.service.ts
+++ b/src/services/job-trigger.service.ts
@@ -77,7 +77,7 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'events-sync',
     description: 'Sync events from FPL API',
-    schedule: 'Daily at 6:35 AM',
+    schedule: 'Daily at 06:35 UTC+8 (year-round discovery)',
   },
   {
     name: 'event-current-refresh',
@@ -88,17 +88,17 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'fixtures-sync',
     description: 'Sync fixtures from FPL API',
-    schedule: 'Daily at 6:40 AM',
+    schedule: 'Daily at 06:40 UTC+8 (year-round discovery)',
   },
   {
     name: 'teams-sync',
     description: 'Sync teams from FPL API',
-    schedule: 'Daily at 6:37 AM',
+    schedule: 'Daily at 06:37 UTC+8 (year-round discovery)',
   },
   {
     name: 'players-sync',
     description: 'Sync players from FPL API',
-    schedule: 'Daily at 6:43 AM',
+    schedule: 'Daily at 06:43 UTC+8 (year-round discovery)',
   },
   {
     name: 'player-prices',
@@ -113,7 +113,7 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'phases-sync',
     description: 'Sync phases from FPL API',
-    schedule: 'Daily at 6:45 AM',
+    schedule: 'Daily at 06:45 UTC+8 (year-round discovery)',
   },
   {
     name: 'player-values-sync',
@@ -128,7 +128,7 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'entry-event-picks-daily',
     description: 'Sync entry picks for current event',
-    schedule: 'Daily at 10:35 AM (selection window)',
+    schedule: 'Every 5 minutes during the selection publication window',
   },
   {
     name: 'entry-event-transfers-daily',
@@ -148,7 +148,7 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'league-event-results-sync',
     description: 'Sync league results (per-tournament jobs)',
-    schedule: 'Every 10 minutes (post-matchday)',
+    schedule: 'Every 10 minutes in the 24-hour post-match result window',
   },
   {
     name: 'tournament-event-picks-sync',
@@ -158,7 +158,7 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'tournament-event-results-sync',
     description: 'Sync tournament results (triggers cascade)',
-    schedule: 'Every 10 minutes post-matchday',
+    schedule: 'Every 10 minutes in the 24-hour post-match result window',
   },
   {
     name: 'tournament-event-transfers-pre-sync',
@@ -203,7 +203,7 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
     name: 'tournament-materialized-views-refresh',
     description: 'Refresh tournament materialized views for GraphQL APIs',
-    schedule: 'Cascade 30s after event-results cascade jobs',
+    schedule: 'Cascade after the three structure jobs complete their barrier',
   },
   {
     name: 'event-lives-cache-update',
@@ -230,21 +230,25 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
     description: 'Sync event overall results (cascaded from DB sync)',
     schedule: 'Cascade after DB sync',
   },
-  { name: 'live-scores', description: 'Update live scores', schedule: 'Every 15 minutes' },
+  {
+    name: 'live-scores',
+    description: 'Update live scores',
+    schedule: 'Every minute during matches',
+  },
   {
     name: 'post-match-consolidation',
     description: 'Catch FPL overnight data finalization (bonus, corrected scores)',
-    schedule: '06:00, 08:00, 10:00 on match days',
+    schedule: '06:00, 08:00, 10:00 UTC+8 inside the 24-hour post-match window',
   },
   {
     name: 'launch-warning',
     description: 'Pre-season monitor message when FPL events are absent',
-    schedule: 'Manual only (launch cron not registered)',
+    schedule: 'Every minute year-round (deduplicated once per year)',
   },
   {
     name: 'launch-happening',
     description: 'Season-start monitor message when new deadline appears',
-    schedule: 'Manual only (launch cron not registered)',
+    schedule: 'Every minute year-round (deduplicated once per season)',
   },
 ];
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,9 +6,13 @@ This directory contains the test suite for `letletme_data`. Tests are split by s
 
 | Command | What it runs | Infrastructure |
 |---|---|---|
-| `bun test` / `bun run test` | Unit tests only (`tests/unit`) | None |
+| `bun run test` or `bun test tests/unit` | Unit tests only (`tests/unit`) | None |
 | `bun run test:integration` | Integration tests (`tests/integration`) | Postgres + Redis (test instance only) |
-| `bun run test:all` | Unit + integration | Postgres + Redis (test instance only) |
+| `RUN_INTEGRATION=1 bun run test:all` | Unit + integration | Postgres + Redis (test instance only) |
+
+Do not use bare `bun test` as a unit-test shortcut. Bun discovers both test
+directories directly, so the integration environment guard will reject the run
+unless the explicit test-only infrastructure variables are present.
 
 Integration tests are gated by `tests/integration/helpers/env-guard.ts`. They refuse to start unless **all** of the following are true:
 


### PR DESCRIPTION
## Summary

- add an operational FPL season-readiness runbook
- align deployment, cache, endpoint, job-schedule, testing, and system-contract documentation with current 2026/27 behavior
- update public job descriptions and post-match comments so runtime metadata matches the real scheduler gates

## Impact

Operators get one source of truth for upstream readiness, staged synchronization, rollover behavior, cache ownership, and post-match checks. Runtime behavior is unchanged apart from corrected descriptive metadata.

## Validation

- `bun run test` — 521 passed
- `bun run typecheck`
- `bun run lint` — 0 errors, 7 existing warnings
- `bun run build`
- Prettier check for every changed file
- `git diff --check`