### PR TITLE
Capture daily player market snapshots

### DIFF
--- a/docs/redis-contract.md
+++ b/docs/redis-contract.md
@@ -283,6 +283,22 @@ The PostgreSQL database stores **one FPL season at a time**:
 - `PlayerStat:{season}` in Redis is a **latest-event-wins view** (§5). Only
   syncs for the current gameweek write it; older-event backfills persist to
   DB only.
+- `player_market_snapshots` is the deliberate season-long exception: it keeps
+  one complete daily roster from the first capture through the end of the
+  current season. Include it in the read-only rollover inventory. After the
+  outgoing season is backed up and the new upstream roster is confirmed,
+  remove the outgoing rows before the new season's first 09:40 UTC+8 capture;
+  never mix seasons to manufacture a comparison window.
+
+Read-only inventory before the season reset:
+
+```sql
+SELECT min(snapshot_date) AS first_date,
+       max(snapshot_date) AS latest_date,
+       count(DISTINCT snapshot_date) AS observed_days,
+       count(*) AS rows
+FROM player_market_snapshots;
+```
 
 This is an accepted design decision, not a temporary limitation. Multi-season
 history would require additive schema changes and explicit consumer demand.

--- a/migrations/0037_create_player_market_snapshots.sql
+++ b/migrations/0037_create_player_market_snapshots.sql
@@ -1,0 +1,74 @@
+-- Canonical once-per-calendar-day FPL market observations. The daily player
+-- stats job writes one complete upstream roster in a transaction and retries
+-- update the same (snapshot_date, element_id) rows.
+
+CREATE TABLE IF NOT EXISTS public.player_market_snapshots (
+  id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  snapshot_date date NOT NULL,
+  captured_at timestamptz NOT NULL,
+  element_id integer NOT NULL REFERENCES public.players(id),
+  player_code integer NOT NULL,
+  web_name text NOT NULL,
+  first_name text NOT NULL,
+  second_name text NOT NULL,
+  team_id integer NOT NULL REFERENCES public.teams(id),
+  team_name text NOT NULL,
+  team_short_name text NOT NULL,
+  element_type integer NOT NULL,
+  position text NOT NULL,
+  price integer NOT NULL,
+  selected_by_percent numeric(6, 3) NOT NULL,
+  transfers_in integer NOT NULL,
+  transfers_out integer NOT NULL,
+  transfers_in_event integer NOT NULL,
+  transfers_out_event integer NOT NULL,
+  status text NOT NULL,
+  news text NOT NULL,
+  news_added timestamptz,
+  chance_of_playing_this_round integer,
+  chance_of_playing_next_round integer,
+  CONSTRAINT player_market_snapshots_element_type_check CHECK (element_type BETWEEN 1 AND 4),
+  CONSTRAINT player_market_snapshots_position_check CHECK (position IN ('GKP', 'DEF', 'MID', 'FWD')),
+  CONSTRAINT player_market_snapshots_price_check CHECK (price > 0),
+  CONSTRAINT player_market_snapshots_ownership_check CHECK (selected_by_percent BETWEEN 0 AND 100),
+  CONSTRAINT player_market_snapshots_transfer_counts_check CHECK (
+    transfers_in >= 0 AND transfers_out >= 0
+    AND transfers_in_event >= 0 AND transfers_out_event >= 0
+  ),
+  CONSTRAINT player_market_snapshots_chance_this_check CHECK (
+    chance_of_playing_this_round IS NULL OR chance_of_playing_this_round BETWEEN 0 AND 100
+  ),
+  CONSTRAINT player_market_snapshots_chance_next_check CHECK (
+    chance_of_playing_next_round IS NULL OR chance_of_playing_next_round BETWEEN 0 AND 100
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_player_market_snapshot_day
+  ON public.player_market_snapshots (snapshot_date, element_id);
+CREATE INDEX IF NOT EXISTS idx_player_market_snapshots_element_date
+  ON public.player_market_snapshots (element_id, snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_player_market_snapshots_date_ownership
+  ON public.player_market_snapshots (snapshot_date, selected_by_percent);
+
+ALTER TABLE public.player_market_snapshots ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.player_market_snapshots FROM PUBLIC;
+REVOKE ALL ON SEQUENCE public.player_market_snapshots_id_seq FROM PUBLIC;
+
+DO $$
+DECLARE
+  client_role text;
+BEGIN
+  FOREACH client_role IN ARRAY ARRAY['anon', 'authenticated']
+  LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = client_role) THEN
+      EXECUTE format(
+        'REVOKE ALL ON TABLE public.player_market_snapshots FROM %I',
+        client_role
+      );
+      EXECUTE format(
+        'REVOKE ALL ON SEQUENCE public.player_market_snapshots_id_seq FROM %I',
+        client_role
+      );
+    END IF;
+  END LOOP;
+END $$;

--- a/src/db/schemas/index.schema.ts
+++ b/src/db/schemas/index.schema.ts
@@ -14,6 +14,7 @@ export * from './events.schema';
 export * from './league-event-results.schema';
 export * from './phases.schema';
 export * from './player-stats.schema';
+export * from './player-market-snapshots.schema';
 export * from './player-values.schema';
 export * from './players.schema';
 export * from './teams.schema';

--- a/src/db/schemas/player-market-snapshots.schema.ts
+++ b/src/db/schemas/player-market-snapshots.schema.ts
@@ -1,0 +1,87 @@
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  date,
+  index,
+  integer,
+  numeric,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+
+import { autoIncrementId } from './_helpers.schema';
+import { players } from './players.schema';
+import { teams } from './teams.schema';
+
+export const playerMarketSnapshots = pgTable(
+  'player_market_snapshots',
+  {
+    ...autoIncrementId,
+    snapshotDate: date('snapshot_date', { mode: 'string' }).notNull(),
+    capturedAt: timestamp('captured_at', { withTimezone: true }).notNull(),
+    elementId: integer('element_id')
+      .notNull()
+      .references(() => players.id),
+    playerCode: integer('player_code').notNull(),
+    webName: text('web_name').notNull(),
+    firstName: text('first_name').notNull(),
+    secondName: text('second_name').notNull(),
+    teamId: integer('team_id')
+      .notNull()
+      .references(() => teams.id),
+    teamName: text('team_name').notNull(),
+    teamShortName: text('team_short_name').notNull(),
+    elementType: integer('element_type').notNull(),
+    position: text('position').notNull(),
+    price: integer('price').notNull(),
+    selectedByPercent: numeric('selected_by_percent', {
+      precision: 6,
+      scale: 3,
+      mode: 'number',
+    }).notNull(),
+    transfersIn: integer('transfers_in').notNull(),
+    transfersOut: integer('transfers_out').notNull(),
+    transfersInEvent: integer('transfers_in_event').notNull(),
+    transfersOutEvent: integer('transfers_out_event').notNull(),
+    status: text('status').notNull(),
+    news: text('news').notNull(),
+    newsAdded: timestamp('news_added', { withTimezone: true }),
+    chanceOfPlayingThisRound: integer('chance_of_playing_this_round'),
+    chanceOfPlayingNextRound: integer('chance_of_playing_next_round'),
+  },
+  (table) => [
+    uniqueIndex('unique_player_market_snapshot_day').on(table.snapshotDate, table.elementId),
+    index('idx_player_market_snapshots_element_date').on(table.elementId, table.snapshotDate),
+    index('idx_player_market_snapshots_date_ownership').on(
+      table.snapshotDate,
+      table.selectedByPercent,
+    ),
+    check('player_market_snapshots_element_type_check', sql`${table.elementType} between 1 and 4`),
+    check(
+      'player_market_snapshots_position_check',
+      sql`${table.position} in ('GKP', 'DEF', 'MID', 'FWD')`,
+    ),
+    check('player_market_snapshots_price_check', sql`${table.price} > 0`),
+    check(
+      'player_market_snapshots_ownership_check',
+      sql`${table.selectedByPercent} between 0 and 100`,
+    ),
+    check(
+      'player_market_snapshots_transfer_counts_check',
+      sql`${table.transfersIn} >= 0 and ${table.transfersOut} >= 0 and ${table.transfersInEvent} >= 0 and ${table.transfersOutEvent} >= 0`,
+    ),
+    check(
+      'player_market_snapshots_chance_this_check',
+      sql`${table.chanceOfPlayingThisRound} is null or ${table.chanceOfPlayingThisRound} between 0 and 100`,
+    ),
+    check(
+      'player_market_snapshots_chance_next_check',
+      sql`${table.chanceOfPlayingNextRound} is null or ${table.chanceOfPlayingNextRound} between 0 and 100`,
+    ),
+  ],
+);
+
+export type DbPlayerMarketSnapshot = Readonly<typeof playerMarketSnapshots.$inferSelect>;
+export type DbPlayerMarketSnapshotInsert = Readonly<typeof playerMarketSnapshots.$inferInsert>;

--- a/src/domain/player-market-snapshots.ts
+++ b/src/domain/player-market-snapshots.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+import type { ElementTypeId, PlayerId, TeamId } from '../types/base.type';
+
+export const MarketPositionSchema = z.enum(['GKP', 'DEF', 'MID', 'FWD']);
+export type MarketPosition = z.infer<typeof MarketPositionSchema>;
+
+const CalendarDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected YYYY-MM-DD');
+
+export interface PlayerMarketSnapshot {
+  readonly snapshotDate: string;
+  readonly capturedAt: Date;
+  readonly elementId: PlayerId;
+  readonly playerCode: number;
+  readonly webName: string;
+  readonly firstName: string;
+  readonly secondName: string;
+  readonly teamId: TeamId;
+  readonly teamName: string;
+  readonly teamShortName: string;
+  readonly elementType: ElementTypeId;
+  readonly position: MarketPosition;
+  readonly price: number;
+  readonly selectedByPercent: number;
+  readonly transfersIn: number;
+  readonly transfersOut: number;
+  readonly transfersInEvent: number;
+  readonly transfersOutEvent: number;
+  readonly status: string;
+  readonly news: string;
+  readonly newsAdded: Date | null;
+  readonly chanceOfPlayingThisRound: number | null;
+  readonly chanceOfPlayingNextRound: number | null;
+}
+
+export const PlayerMarketSnapshotSchema = z.object({
+  snapshotDate: CalendarDateSchema,
+  capturedAt: z.date(),
+  elementId: z.number().int().positive(),
+  playerCode: z.number().int().positive(),
+  webName: z.string().min(1).max(50),
+  firstName: z.string().max(100),
+  secondName: z.string().max(100),
+  teamId: z.number().int().positive(),
+  teamName: z.string().min(1).max(100),
+  teamShortName: z.string().min(1).max(10),
+  elementType: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  position: MarketPositionSchema,
+  price: z.number().int().positive(),
+  selectedByPercent: z.number().finite().min(0).max(100),
+  transfersIn: z.number().int().min(0),
+  transfersOut: z.number().int().min(0),
+  transfersInEvent: z.number().int().min(0),
+  transfersOutEvent: z.number().int().min(0),
+  status: z.string().min(1).max(20),
+  news: z.string(),
+  newsAdded: z.date().nullable(),
+  chanceOfPlayingThisRound: z.number().int().min(0).max(100).nullable(),
+  chanceOfPlayingNextRound: z.number().int().min(0).max(100).nullable(),
+});
+
+export function validatePlayerMarketSnapshot(snapshot: unknown): PlayerMarketSnapshot {
+  return PlayerMarketSnapshotSchema.parse(snapshot) as PlayerMarketSnapshot;
+}
+
+export function validateCompleteMarketSnapshotBatch(
+  snapshots: readonly PlayerMarketSnapshot[],
+  expectedCount: number,
+): void {
+  if (expectedCount <= 0 || snapshots.length !== expectedCount) {
+    throw new Error(
+      `Incomplete market snapshot batch: expected ${expectedCount}, received ${snapshots.length}`,
+    );
+  }
+
+  const snapshotDates = new Set(snapshots.map((snapshot) => snapshot.snapshotDate));
+  if (snapshotDates.size !== 1) {
+    throw new Error('Market snapshot batch must contain exactly one calendar day');
+  }
+
+  const elementIds = new Set(snapshots.map((snapshot) => snapshot.elementId));
+  if (elementIds.size !== snapshots.length) {
+    throw new Error('Market snapshot batch contains duplicate players');
+  }
+}

--- a/src/repositories/player-market-snapshots.ts
+++ b/src/repositories/player-market-snapshots.ts
@@ -1,0 +1,131 @@
+import { and, count, eq, notInArray, sql } from 'drizzle-orm';
+
+import {
+  playerMarketSnapshots,
+  type DbPlayerMarketSnapshotInsert,
+} from '../db/schemas/player-market-snapshots.schema';
+import { getDb, type DbOrTransaction } from '../db/singleton';
+import {
+  validateCompleteMarketSnapshotBatch,
+  type PlayerMarketSnapshot,
+} from '../domain/player-market-snapshots';
+import { DatabaseError } from '../utils/errors';
+import { logError, logInfo } from '../utils/logger';
+
+export const createPlayerMarketSnapshotsRepository = (dbInstance?: DbOrTransaction) => {
+  const getDbInstance = async () => dbInstance || (await getDb());
+
+  return {
+    upsertCompleteDay: async (
+      snapshots: readonly PlayerMarketSnapshot[],
+      expectedCount: number,
+    ): Promise<{ snapshotDate: string; persistedCount: number }> => {
+      try {
+        validateCompleteMarketSnapshotBatch(snapshots, expectedCount);
+
+        const snapshotDate = snapshots[0].snapshotDate;
+        const rows: DbPlayerMarketSnapshotInsert[] = snapshots.map((snapshot) => ({
+          snapshotDate: snapshot.snapshotDate,
+          capturedAt: snapshot.capturedAt,
+          elementId: snapshot.elementId,
+          playerCode: snapshot.playerCode,
+          webName: snapshot.webName,
+          firstName: snapshot.firstName,
+          secondName: snapshot.secondName,
+          teamId: snapshot.teamId,
+          teamName: snapshot.teamName,
+          teamShortName: snapshot.teamShortName,
+          elementType: snapshot.elementType,
+          position: snapshot.position,
+          price: snapshot.price,
+          selectedByPercent: snapshot.selectedByPercent,
+          transfersIn: snapshot.transfersIn,
+          transfersOut: snapshot.transfersOut,
+          transfersInEvent: snapshot.transfersInEvent,
+          transfersOutEvent: snapshot.transfersOutEvent,
+          status: snapshot.status,
+          news: snapshot.news,
+          newsAdded: snapshot.newsAdded,
+          chanceOfPlayingThisRound: snapshot.chanceOfPlayingThisRound,
+          chanceOfPlayingNextRound: snapshot.chanceOfPlayingNextRound,
+        }));
+
+        const db = await getDbInstance();
+        const persisted = await db
+          .insert(playerMarketSnapshots)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [playerMarketSnapshots.snapshotDate, playerMarketSnapshots.elementId],
+            set: {
+              capturedAt: sql`excluded.captured_at`,
+              playerCode: sql`excluded.player_code`,
+              webName: sql`excluded.web_name`,
+              firstName: sql`excluded.first_name`,
+              secondName: sql`excluded.second_name`,
+              teamId: sql`excluded.team_id`,
+              teamName: sql`excluded.team_name`,
+              teamShortName: sql`excluded.team_short_name`,
+              elementType: sql`excluded.element_type`,
+              position: sql`excluded.position`,
+              price: sql`excluded.price`,
+              selectedByPercent: sql`excluded.selected_by_percent`,
+              transfersIn: sql`excluded.transfers_in`,
+              transfersOut: sql`excluded.transfers_out`,
+              transfersInEvent: sql`excluded.transfers_in_event`,
+              transfersOutEvent: sql`excluded.transfers_out_event`,
+              status: sql`excluded.status`,
+              news: sql`excluded.news`,
+              newsAdded: sql`excluded.news_added`,
+              chanceOfPlayingThisRound: sql`excluded.chance_of_playing_this_round`,
+              chanceOfPlayingNextRound: sql`excluded.chance_of_playing_next_round`,
+            },
+          })
+          .returning({ elementId: playerMarketSnapshots.elementId });
+
+        if (persisted.length !== expectedCount) {
+          throw new Error(
+            `Incomplete market snapshot write: expected ${expectedCount}, persisted ${persisted.length}`,
+          );
+        }
+
+        const elementIds = snapshots.map((snapshot) => snapshot.elementId);
+        await db
+          .delete(playerMarketSnapshots)
+          .where(
+            and(
+              eq(playerMarketSnapshots.snapshotDate, snapshotDate),
+              notInArray(playerMarketSnapshots.elementId, elementIds),
+            ),
+          );
+
+        const [verification] = await db
+          .select({ count: count() })
+          .from(playerMarketSnapshots)
+          .where(eq(playerMarketSnapshots.snapshotDate, snapshotDate));
+        const persistedCount = verification?.count ?? 0;
+
+        if (persistedCount !== expectedCount) {
+          throw new Error(
+            `Incomplete market snapshot day: expected ${expectedCount}, found ${persistedCount}`,
+          );
+        }
+
+        logInfo('Complete player market snapshot persisted', {
+          snapshotDate,
+          expectedCount,
+          persistedCount,
+        });
+        return { snapshotDate, persistedCount };
+      } catch (error) {
+        logError('Failed to persist complete player market snapshot', error, { expectedCount });
+        throw new DatabaseError(
+          'Failed to persist complete player market snapshot',
+          'MARKET_SNAPSHOT_UPSERT_ERROR',
+          error instanceof Error ? error : undefined,
+        );
+      }
+    },
+  };
+};
+
+export const playerMarketSnapshotsRepository = createPlayerMarketSnapshotsRepository();

--- a/src/repositories/player-stats.ts
+++ b/src/repositories/player-stats.ts
@@ -1,18 +1,15 @@
 import { sql } from 'drizzle-orm';
 
 import { playerStats, type DbPlayerStatInsert } from '../db/schemas/index.schema';
-import { getDb } from '../db/singleton';
+import { getDb, type DbOrTransaction } from '../db/singleton';
 import { DatabaseError } from '../utils/errors';
 import { logError, logInfo } from '../utils/logger';
 
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { PlayerStat } from '../domain/player-stats';
-
-type DatabaseInstance = PostgresJsDatabase<Record<string, never>>;
 
 export type PlayerStatsRepository = ReturnType<typeof createPlayerStatsRepository>;
 
-export const createPlayerStatsRepository = (dbInstance?: DatabaseInstance) => {
+export const createPlayerStatsRepository = (dbInstance?: DbOrTransaction) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   return {

--- a/src/services/player-stats.service.ts
+++ b/src/services/player-stats.service.ts
@@ -1,7 +1,10 @@
 import { playerStatsCache } from '../cache/operations';
 import { fplClient } from '../clients/fpl';
+import { getDb } from '../db/singleton';
 import { shouldWritePlayerStatsView } from '../domain/player-stats';
-import { playerStatsRepository } from '../repositories/player-stats';
+import { createPlayerMarketSnapshotsRepository } from '../repositories/player-market-snapshots';
+import { createPlayerStatsRepository, playerStatsRepository } from '../repositories/player-stats';
+import { transformPlayerMarketSnapshots } from '../transformers/player-market-snapshots';
 import {
   createTeamsMap,
   transformCurrentGameweekPlayerStats,
@@ -17,6 +20,8 @@ export async function syncCurrentPlayerStats(): Promise<{
   count: number;
   eventId: EventId;
   errors: number;
+  marketSnapshotCount: number;
+  snapshotDate: string;
 }> {
   logInfo('Starting player stats sync for current gameweek');
 
@@ -40,7 +45,9 @@ export async function syncCurrentPlayerStats(): Promise<{
     eventId: syncEvent.event.id,
   });
 
+  const capturedAt = new Date();
   const transformedPlayerStats = transformCurrentGameweekPlayerStats(fplData, syncEvent.event.id);
+  const marketSnapshots = transformPlayerMarketSnapshots(fplData, capturedAt);
   const errors = fplData.elements.length - transformedPlayerStats.length;
 
   logInfo('Player stats transformed', {
@@ -50,10 +57,32 @@ export async function syncCurrentPlayerStats(): Promise<{
     eventId: syncEvent.event.id,
   });
 
-  const upsertResult = await playerStatsRepository.upsertBatch(transformedPlayerStats);
-  logInfo('Player stats upserted to database', { count: upsertResult.count });
+  const db = await getDb();
+  const persisted = await db.transaction(async (tx) => {
+    const txPlayerStatsRepository = createPlayerStatsRepository(tx);
+    const txMarketSnapshotsRepository = createPlayerMarketSnapshotsRepository(tx);
 
-  if (upsertResult.count > 0) {
+    const upsertResult = await txPlayerStatsRepository.upsertBatch(transformedPlayerStats);
+    if (upsertResult.count !== fplData.elements.length) {
+      throw new Error(
+        `Incomplete player stats write: expected ${fplData.elements.length}, persisted ${upsertResult.count}`,
+      );
+    }
+
+    const marketResult = await txMarketSnapshotsRepository.upsertCompleteDay(
+      marketSnapshots,
+      fplData.elements.length,
+    );
+    return { upsertResult, marketResult };
+  });
+  logInfo('Player stats and market snapshot committed', {
+    expectedCount: fplData.elements.length,
+    playerStatsCount: persisted.upsertResult.count,
+    marketSnapshotCount: persisted.marketResult.persistedCount,
+    snapshotDate: persisted.marketResult.snapshotDate,
+  });
+
+  if (persisted.upsertResult.count > 0) {
     await playerStatsCache.setByEvent(syncEvent.event.id, transformedPlayerStats);
     logInfo('Player stats cache updated', {
       eventId: syncEvent.event.id,
@@ -62,9 +91,11 @@ export async function syncCurrentPlayerStats(): Promise<{
   }
 
   const result = {
-    count: upsertResult.count,
+    count: persisted.upsertResult.count,
     eventId: syncEvent.event.id,
     errors,
+    marketSnapshotCount: persisted.marketResult.persistedCount,
+    snapshotDate: persisted.marketResult.snapshotDate,
   };
 
   logInfo('Player stats sync completed', result);

--- a/src/transformers/player-market-snapshots.ts
+++ b/src/transformers/player-market-snapshots.ts
@@ -1,0 +1,84 @@
+import type { FPLBootstrapResponse, RawFPLElement } from '../clients/fpl';
+import {
+  validateCompleteMarketSnapshotBatch,
+  validatePlayerMarketSnapshot,
+  type PlayerMarketSnapshot,
+} from '../domain/player-market-snapshots';
+import { getPlayerPosition } from '../domain/players';
+import { formatCronCalendarDate } from '../utils/timezone';
+
+function parseOwnership(rawOwnership: string, elementId: number): number {
+  const ownership = Number(rawOwnership);
+  if (!Number.isFinite(ownership) || ownership < 0 || ownership > 100) {
+    throw new Error(`Invalid ownership for player ${elementId}: ${rawOwnership}`);
+  }
+  return ownership;
+}
+
+function parseNewsAdded(rawTimestamp: string | null, elementId: number): Date | null {
+  if (rawTimestamp === null) {
+    return null;
+  }
+
+  const timestamp = new Date(rawTimestamp);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(`Invalid news timestamp for player ${elementId}: ${rawTimestamp}`);
+  }
+  return timestamp;
+}
+
+function transformPlayerMarketSnapshot(
+  rawElement: RawFPLElement,
+  teamsById: ReadonlyMap<number, FPLBootstrapResponse['teams'][number]>,
+  capturedAt: Date,
+  snapshotDate: string,
+): PlayerMarketSnapshot {
+  const team = teamsById.get(rawElement.team);
+  if (!team) {
+    throw new Error(`Missing team ${rawElement.team} for player ${rawElement.id}`);
+  }
+
+  return validatePlayerMarketSnapshot({
+    snapshotDate,
+    capturedAt,
+    elementId: rawElement.id,
+    playerCode: rawElement.code,
+    webName: rawElement.web_name,
+    firstName: rawElement.first_name,
+    secondName: rawElement.second_name,
+    teamId: rawElement.team,
+    teamName: team.name,
+    teamShortName: team.short_name,
+    elementType: rawElement.element_type,
+    position: getPlayerPosition(rawElement.element_type),
+    price: rawElement.now_cost,
+    selectedByPercent: parseOwnership(rawElement.selected_by_percent, rawElement.id),
+    transfersIn: rawElement.transfers_in,
+    transfersOut: rawElement.transfers_out,
+    transfersInEvent: rawElement.transfers_in_event,
+    transfersOutEvent: rawElement.transfers_out_event,
+    status: rawElement.status,
+    news: rawElement.news,
+    newsAdded: parseNewsAdded(rawElement.news_added, rawElement.id),
+    chanceOfPlayingThisRound: rawElement.chance_of_playing_this_round,
+    chanceOfPlayingNextRound: rawElement.chance_of_playing_next_round,
+  });
+}
+
+export function transformPlayerMarketSnapshots(
+  bootstrap: Pick<FPLBootstrapResponse, 'elements' | 'teams'>,
+  capturedAt: Date = new Date(),
+): PlayerMarketSnapshot[] {
+  if (Number.isNaN(capturedAt.getTime())) {
+    throw new Error('Market snapshot capture time must be a valid timestamp');
+  }
+
+  const snapshotDate = formatCronCalendarDate(capturedAt);
+  const teamsById = new Map(bootstrap.teams.map((team) => [team.id, team]));
+  const snapshots = bootstrap.elements.map((element) =>
+    transformPlayerMarketSnapshot(element, teamsById, capturedAt, snapshotDate),
+  );
+
+  validateCompleteMarketSnapshotBatch(snapshots, bootstrap.elements.length);
+  return snapshots;
+}

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -20,6 +20,11 @@ export function formatCronDateKey(date: Date = new Date()): string {
   return `${getPart(parts, 'year')}${getPart(parts, 'month')}${getPart(parts, 'day')}`;
 }
 
+export function formatCronCalendarDate(date: Date = new Date()): string {
+  const dateKey = formatCronDateKey(date);
+  return `${dateKey.slice(0, 4)}-${dateKey.slice(4, 6)}-${dateKey.slice(6, 8)}`;
+}
+
 export function getCronMinute(date: Date = new Date()): number {
   const minute = Number.parseInt(getPart(utc8Formatter.formatToParts(date), 'minute'), 10);
   return Number.isFinite(minute) ? minute : 0;

--- a/tests/integration/database-trust-boundary.test.ts
+++ b/tests/integration/database-trust-boundary.test.ts
@@ -24,6 +24,7 @@ const DATA_TABLES = [
   'league_event_results',
   'phases',
   'player_stats',
+  'player_market_snapshots',
   'player_values',
   'players',
   'teams',

--- a/tests/integration/player-stats.test.ts
+++ b/tests/integration/player-stats.test.ts
@@ -3,27 +3,48 @@ import { assertIntegrationEnv } from './helpers/env-guard';
 assertIntegrationEnv();
 import { beforeAll, describe, expect, test } from 'bun:test';
 
-import { eq } from 'drizzle-orm';
+import { count, eq } from 'drizzle-orm';
 
 import { playerStatsCache } from '../../src/cache/operations';
-import { playerStats } from '../../src/db/schemas/index.schema';
+import { playerMarketSnapshots, playerStats } from '../../src/db/schemas/index.schema';
 import { getDb } from '../../src/db/singleton';
 import {
   syncCurrentPlayerStats,
   syncPlayerStatsForEvent,
 } from '../../src/services/player-stats.service';
-import { resolveCurrentEvent } from './helpers/current-event';
-import { ensurePlayers } from './helpers/reference-data';
+import { resolvePlayerSyncEvent } from '../../src/services/player-sync-event.service';
+import { ensureEvents, ensurePlayers } from './helpers/reference-data';
 
 let syncedEventId: number;
-const currentEvent = await resolveCurrentEvent();
+let syncedSnapshotDate: string;
+await ensureEvents();
+const syncEvent = await resolvePlayerSyncEvent();
 
-describe.skipIf(!currentEvent)('Player Stats Operational Integration', () => {
+describe.skipIf(!syncEvent)('Player Stats Operational Integration', () => {
   beforeAll(async () => {
     await ensurePlayers();
     await playerStatsCache.clearAll();
     const result = await syncCurrentPlayerStats();
     syncedEventId = result.eventId;
+    syncedSnapshotDate = result.snapshotDate;
+  });
+
+  test('syncCurrentPlayerStats stores one complete idempotent daily market roster', async () => {
+    const db = await getDb();
+    const [beforeRetry] = await db
+      .select({ count: count() })
+      .from(playerMarketSnapshots)
+      .where(eq(playerMarketSnapshots.snapshotDate, syncedSnapshotDate));
+
+    const retry = await syncCurrentPlayerStats();
+    const [afterRetry] = await db
+      .select({ count: count() })
+      .from(playerMarketSnapshots)
+      .where(eq(playerMarketSnapshots.snapshotDate, syncedSnapshotDate));
+
+    expect(beforeRetry.count).toBeGreaterThan(0);
+    expect(beforeRetry.count).toBe(retry.marketSnapshotCount);
+    expect(afterRetry.count).toBe(beforeRetry.count);
   });
 
   test('syncCurrentPlayerStats stores event data in DB and cache', async () => {

--- a/tests/unit/migration-history.test.ts
+++ b/tests/unit/migration-history.test.ts
@@ -50,3 +50,15 @@ describe('public Data API lockdown migration', () => {
     expect(migration).not.toContain('ALTER DEFAULT PRIVILEGES');
   });
 });
+
+describe('player market snapshot migration', () => {
+  test('creates a unique complete-day store behind the service trust boundary', () => {
+    const migration = readFileSync('migrations/0037_create_player_market_snapshots.sql', 'utf8');
+
+    expect(migration).toContain('player_market_snapshots');
+    expect(migration).toContain('snapshot_date, element_id');
+    expect(migration).toContain('selected_by_percent BETWEEN 0 AND 100');
+    expect(migration).toContain('ENABLE ROW LEVEL SECURITY');
+    expect(migration).toContain('REVOKE ALL ON TABLE');
+  });
+});

--- a/tests/unit/player-market-snapshots.test.ts
+++ b/tests/unit/player-market-snapshots.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { FPLBootstrapResponse, RawFPLElement } from '../../src/clients/fpl';
+import {
+  validateCompleteMarketSnapshotBatch,
+  type PlayerMarketSnapshot,
+} from '../../src/domain/player-market-snapshots';
+import { createPlayerMarketSnapshotsRepository } from '../../src/repositories/player-market-snapshots';
+import { transformPlayerMarketSnapshots } from '../../src/transformers/player-market-snapshots';
+import { rawFPLElementsFixture } from '../fixtures/player-stats.fixtures';
+
+const teams = [
+  { id: 1, name: 'Arsenal', short_name: 'ARS' },
+  { id: 2, name: 'Manchester City', short_name: 'MCI' },
+  { id: 3, name: 'Liverpool', short_name: 'LIV' },
+] as unknown as FPLBootstrapResponse['teams'];
+
+function bootstrap(elements: RawFPLElement[]) {
+  return { elements, teams } as Pick<FPLBootstrapResponse, 'elements' | 'teams'>;
+}
+
+describe('player market snapshot transformation', () => {
+  test('captures the complete upstream identity, ownership, transfer, and availability state', () => {
+    const element = {
+      ...rawFPLElementsFixture[0],
+      status: 'd',
+      selected_by_percent: '17.125',
+      news: 'Hamstring injury - 25% chance of playing',
+      news_added: '2026-08-02T08:15:00Z',
+      chance_of_playing_this_round: 25,
+      chance_of_playing_next_round: 50,
+    };
+    const capturedAt = new Date('2026-08-02T23:40:00Z');
+
+    const [snapshot] = transformPlayerMarketSnapshots(bootstrap([element]), capturedAt);
+
+    expect(snapshot).toMatchObject({
+      snapshotDate: '2026-08-03',
+      capturedAt,
+      elementId: element.id,
+      playerCode: element.code,
+      webName: element.web_name,
+      teamId: element.team,
+      teamName: 'Arsenal',
+      teamShortName: 'ARS',
+      position: 'GKP',
+      price: element.now_cost,
+      selectedByPercent: 17.125,
+      transfersIn: element.transfers_in,
+      transfersOut: element.transfers_out,
+      transfersInEvent: element.transfers_in_event,
+      transfersOutEvent: element.transfers_out_event,
+      status: 'd',
+      news: element.news,
+      chanceOfPlayingThisRound: 25,
+      chanceOfPlayingNextRound: 50,
+    });
+    expect(snapshot.newsAdded?.toISOString()).toBe('2026-08-02T08:15:00.000Z');
+  });
+
+  test('accepts a newly added player as another full-roster observation', () => {
+    const newcomer = {
+      ...rawFPLElementsFixture[0],
+      id: 999,
+      code: 999_001,
+      web_name: 'Newcomer',
+      team: 2,
+    };
+
+    const snapshots = transformPlayerMarketSnapshots(
+      bootstrap([...rawFPLElementsFixture, newcomer]),
+      new Date('2026-08-03T01:40:00Z'),
+    );
+
+    expect(snapshots).toHaveLength(rawFPLElementsFixture.length + 1);
+    expect(snapshots.at(-1)).toMatchObject({
+      elementId: 999,
+      webName: 'Newcomer',
+      teamName: 'Manchester City',
+    });
+  });
+
+  test.each([
+    ['ownership above 100', { selected_by_percent: '100.1' }],
+    ['non-numeric ownership', { selected_by_percent: 'unknown' }],
+    ['negative cumulative transfers', { transfers_in: -1 }],
+    ['negative event transfers', { transfers_out_event: -1 }],
+    ['invalid news timestamp', { news_added: 'not-a-timestamp' }],
+    ['invalid playing chance', { chance_of_playing_this_round: 101 }],
+  ])('rejects %s', (_label, overrides) => {
+    const invalid = { ...rawFPLElementsFixture[0], ...overrides } as RawFPLElement;
+    expect(() =>
+      transformPlayerMarketSnapshots(bootstrap([invalid]), new Date('2026-08-03T01:40:00Z')),
+    ).toThrow();
+  });
+
+  test('rejects missing teams, duplicate players, and empty upstream rosters', () => {
+    expect(() =>
+      transformPlayerMarketSnapshots(
+        bootstrap([{ ...rawFPLElementsFixture[0], team: 999 }]),
+        new Date('2026-08-03T01:40:00Z'),
+      ),
+    ).toThrow('Missing team 999');
+
+    const duplicated = [rawFPLElementsFixture[0], rawFPLElementsFixture[0]];
+    expect(() =>
+      transformPlayerMarketSnapshots(bootstrap(duplicated), new Date('2026-08-03T01:40:00Z')),
+    ).toThrow('duplicate players');
+
+    expect(() =>
+      transformPlayerMarketSnapshots(bootstrap([]), new Date('2026-08-03T01:40:00Z')),
+    ).toThrow('Incomplete market snapshot batch');
+  });
+});
+
+describe('complete daily market snapshot repository', () => {
+  function createSnapshot(overrides: Partial<PlayerMarketSnapshot> = {}): PlayerMarketSnapshot {
+    return {
+      ...transformPlayerMarketSnapshots(
+        bootstrap([rawFPLElementsFixture[0]]),
+        new Date('2026-08-03T01:40:00Z'),
+      )[0],
+      ...overrides,
+    };
+  }
+
+  function createMemoryDb(options: { dropLastReturn?: boolean } = {}) {
+    const rows = new Map<string, Record<string, unknown>>();
+    return {
+      rows,
+      db: {
+        insert: () => ({
+          values: (values: Array<Record<string, unknown>>) => ({
+            onConflictDoUpdate: () => ({
+              returning: async () => {
+                for (const value of values) {
+                  rows.set(`${value.snapshotDate}:${value.elementId}`, value);
+                }
+                const returned = values.map((value) => ({ elementId: value.elementId }));
+                return options.dropLastReturn ? returned.slice(0, -1) : returned;
+              },
+            }),
+          }),
+        }),
+        delete: () => ({ where: async () => undefined }),
+        select: () => ({
+          from: () => ({
+            where: async () => [{ count: rows.size }],
+          }),
+        }),
+      },
+    };
+  }
+
+  test('updates a same-day player observation without duplicating the row', async () => {
+    const memory = createMemoryDb();
+    const repository = createPlayerMarketSnapshotsRepository(memory.db as never);
+    const first = createSnapshot();
+    const retry = createSnapshot({
+      capturedAt: new Date('2026-08-03T02:10:00Z'),
+      selectedByPercent: 18.4,
+    });
+
+    await repository.upsertCompleteDay([first], 1);
+    const result = await repository.upsertCompleteDay([retry], 1);
+
+    expect(result).toEqual({ snapshotDate: '2026-08-03', persistedCount: 1 });
+    expect(memory.rows.size).toBe(1);
+    expect(memory.rows.get('2026-08-03:1')).toMatchObject({
+      capturedAt: retry.capturedAt,
+      selectedByPercent: 18.4,
+    });
+  });
+
+  test('fails the whole day when the database does not return every upstream player', async () => {
+    const first = createSnapshot();
+    const second = createSnapshot({ elementId: 2, playerCode: 2 });
+    validateCompleteMarketSnapshotBatch([first, second], 2);
+    const memory = createMemoryDb({ dropLastReturn: true });
+    const repository = createPlayerMarketSnapshotsRepository(memory.db as never);
+
+    await expect(repository.upsertCompleteDay([first, second], 2)).rejects.toThrow(
+      'Failed to persist complete player market snapshot',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add migration `0037` and a typed repository for one complete daily FPL player-market roster
- capture identity, team, position, price, ownership, transfers, availability, and news using the UTC+8 scheduler calendar day
- persist player stats and the market snapshot in one transaction, rejecting partial batches
- make same-day retries idempotent and remove stale same-day players only after a complete write
- document the season-long retention and rollover boundary

## Impact

The daily 09:40 player-stats sync now also records a complete market observation for longitudinal analysis. Existing player-stat cache behavior remains unchanged. Deployment applies one new locked-down PostgreSQL table; no Redis shape changes are introduced.

## Validation

- `bun test tests/unit` — 533 passed
- `bun run typecheck`
- `bun run lint` — 0 errors, 7 existing warnings
- `bun run build`
- Prettier check for supported changed files
- `git diff --check`

GitHub CI additionally exercises the migration twice and runs the fresh PostgreSQL/Redis integration suite.