### PR TITLE
feat(sync): harden non-live job orchestration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 RATE_LIMIT_MUTATIONS_PER_MINUTE=60
 ENABLE_TIERED_MUTATION_QUEUES=false
 ENABLE_MUTATION_CONFLICT_GUARD=true
+# Structured non-live attempt reports; set false only for emergency log rollback.
+DATA_SYNC_ATTEMPT_REPORTING_ENABLED=true
 # Keep the new-tournament official roster default off until lifecycle E2E and
 # setup benchmarks pass. Eligible owners can still opt in explicitly.
 TOURNAMENT_OFFICIAL_SYNC_DEFAULT_ENABLED=false

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -166,6 +166,57 @@ comparable samples exist. Segment materially different participant/event windows
 them. These measurements are operational evidence only; this release does not expose an ETA to
 users.
 
+## Non-live synchronization operations
+
+Data, entry, league, and launch-monitor workers emit one bounded `data_sync_attempt` event for each
+top-level BullMQ or cron attempt. Live workers deliberately do not use this report. The event
+contains a run ID, target GW when relevant, required/reused/succeeded/failed counts, queue wait and
+duration, plus bounded FPL endpoint/outcome counters. It excludes raw URLs, payloads, entry names,
+league URLs, and administrator identity.
+
+Trace one run or one target event:
+
+```bash
+docker compose logs --no-color --no-log-prefix --since 24h worker \
+  | jq -Rc --arg runId "entry-picks-2627-7" --argjson eventId 7 '
+      fromjson?
+      | select(.event == "data_sync_attempt")
+      | select(.runId == $runId or .targetEventId == $eventId)
+    '
+```
+
+Inspect checkpoint reuse without exposing participant details:
+
+```sql
+SELECT
+  count(*) AS total_entries,
+  count(*) FILTER (WHERE entry_snapshot_synced_through_event_id >= 7) AS snapshot_current,
+  count(*) FILTER (WHERE entry_transfers_synced_through_event_id >= 7) AS transfers_current
+FROM public.entry_infos;
+```
+
+Aggregate outcome, upstream pressure, and reuse for a comparable observation window:
+
+```bash
+docker compose logs --no-color --no-log-prefix --since 7d worker \
+  | jq -Rsc '
+      split("\n")
+      | map(fromjson? | select(.event == "data_sync_attempt")) as $rows
+      | {
+          sampleCount: ($rows | length),
+          outcomes: ($rows | group_by(.outcome) | map({outcome: .[0].outcome, count: length})),
+          logicalRequests: ([$rows[] | .fpl.logicalRequests // 0] | add // 0),
+          retries: ([$rows[] | .fpl.retries // 0] | add // 0),
+          rateLimitedAttempts: ([$rows[] | .fpl.attemptsByOutcome["429"] // 0] | add // 0),
+          requiredUnits: ([$rows[] | .requiredUnits // 0] | add // 0),
+          reusedUnits: ([$rows[] | .reusedUnits // 0] | add // 0)
+        }
+    '
+```
+
+Do not infer success from a worker completion line alone: a `partial` outcome or non-zero failed
+unit count remains actionable. Existing final-failure Telegram alerts remain the alerting path.
+
 ## Post-deploy season readiness
 
 `/health` proves API liveness. `/ready` additionally requires PostgreSQL,

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -177,7 +177,7 @@ league URLs, and administrator identity.
 Trace one run or one target event:
 
 ```bash
-docker compose logs --no-color --no-log-prefix --since 24h worker \
+docker compose logs --no-color --no-log-prefix --since 24h api worker \
   | jq -Rc --arg runId "entry-picks-2627-7" --argjson eventId 7 '
       fromjson?
       | select(.event == "data_sync_attempt")
@@ -198,7 +198,7 @@ FROM public.entry_infos;
 Aggregate outcome, upstream pressure, and reuse for a comparable observation window:
 
 ```bash
-docker compose logs --no-color --no-log-prefix --since 7d worker \
+docker compose logs --no-color --no-log-prefix --since 7d api worker \
   | jq -Rsc '
       split("\n")
       | map(fromjson? | select(.event == "data_sync_attempt")) as $rows
@@ -216,6 +216,11 @@ docker compose logs --no-color --no-log-prefix --since 7d worker \
 
 Do not infer success from a worker completion line alone: a `partial` outcome or non-zero failed
 unit count remains actionable. Existing final-failure Telegram alerts remain the alerting path.
+
+A retained `LaunchNotification:*:lock` means delivery may have succeeded while the durable marker
+could not be written. Check the notification destination first. If it was delivered, write the
+corresponding marker before deleting the lock; if delivery definitely failed, delete only that
+exact transition lock so the next monitor tick can retry.
 
 ## Post-deploy season readiness
 

--- a/docs/api-cheat-sheet.md
+++ b/docs/api-cheat-sheet.md
@@ -145,8 +145,7 @@ Supported job names:
 - `event-overall-result-sync`
 - `live-scores` (compatibility alias; cache-only snapshot)
 - `post-match-consolidation`
-- `launch-warning`
-- `launch-happening`
+- `launch-monitor`
 
 `GET /jobs` is the runtime authority for the complete trigger list and current
 descriptions.

--- a/docs/job-schedule.md
+++ b/docs/job-schedule.md
@@ -25,12 +25,11 @@ be initialized before the ordinary current-event gate opens.
 
 | Job | Cron | Gate / behavior |
 |---|---|---|
-| `launch-warning` | `* * * * *` | Year-round; sends once per year when bootstrap events are empty |
-| `launch-happening` | `* * * * *` | Year-round; sends once per FPL-derived season when a current-year GW1 deadline appears |
+| `launch-monitor` | `*/5 * * * *` | One bootstrap read detects both an empty-event warning and a published current-year GW1; each notification is sent once |
 | `event-current-refresh` | `* * * * *` | `isFPLSeason`; rebuilds `event:current` and enqueues events sync when the GW changes |
 
-Launch jobs call the FPL bootstrap endpoint directly from the API process. All
-other synchronization work is queue-backed.
+The launch monitor calls the FPL bootstrap endpoint directly from the API
+process. All other synchronization work is queue-backed.
 
 ## Player values
 

--- a/src/api/entry-info.api.ts
+++ b/src/api/entry-info.api.ts
@@ -1,11 +1,18 @@
 import { Elysia, t } from 'elysia';
-import { syncEntryInfo } from '../services/entry-info.service';
+import { enqueueEntryInfoSyncJob } from '../jobs/entry-sync-enqueue';
 
 export const entryInfoAPI = new Elysia({ prefix: '/entry-info' }).post(
   '/:entryId/sync',
-  async ({ params }) => {
-    const res = await syncEntryInfo(params.entryId);
-    return { success: true, data: res };
+  async ({ params, set }) => {
+    const job = await enqueueEntryInfoSyncJob('api', { entryIds: [params.entryId] });
+    if (job.id === undefined) throw new Error('Entry info queue did not assign a job ID');
+    set.status = 202;
+    return {
+      success: true,
+      status: 'queued' as const,
+      jobId: String(job.id),
+      message: 'Entry info sync queued',
+    };
   },
   {
     params: t.Object({ entryId: t.Numeric() }),

--- a/src/api/phases.api.ts
+++ b/src/api/phases.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { syncPhases } from '../services/phases.service';
+import { enqueuePhasesSyncJob } from '../jobs/data-sync-enqueue';
 
 /**
  * Phases API Routes
@@ -9,7 +9,14 @@ import { syncPhases } from '../services/phases.service';
  * - POST /phases/sync - Trigger phases sync
  */
 
-export const phasesAPI = new Elysia({ prefix: '/phases' }).post('/sync', async () => {
-  const result = await syncPhases();
-  return { success: true, message: 'Phases sync completed', ...result };
+export const phasesAPI = new Elysia({ prefix: '/phases' }).post('/sync', async ({ set }) => {
+  const job = await enqueuePhasesSyncJob('api');
+  if (job.id === undefined) throw new Error('Phases sync queue did not assign a job ID');
+  set.status = 202;
+  return {
+    success: true,
+    status: 'queued' as const,
+    jobId: String(job.id),
+    message: 'Phases sync queued',
+  };
 });

--- a/src/api/teams.api.ts
+++ b/src/api/teams.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { syncTeams } from '../services/teams.service';
+import { enqueueTeamsSyncJob } from '../jobs/data-sync-enqueue';
 
 /**
  * Teams API Routes
@@ -9,7 +9,14 @@ import { syncTeams } from '../services/teams.service';
  * - POST /teams/sync - Trigger teams sync
  */
 
-export const teamsAPI = new Elysia({ prefix: '/teams' }).post('/sync', async () => {
-  const result = await syncTeams();
-  return { success: true, message: 'Teams sync completed', ...result };
+export const teamsAPI = new Elysia({ prefix: '/teams' }).post('/sync', async ({ set }) => {
+  const job = await enqueueTeamsSyncJob('api');
+  if (job.id === undefined) throw new Error('Teams sync queue did not assign a job ID');
+  set.status = 202;
+  return {
+    success: true,
+    status: 'queued' as const,
+    jobId: String(job.id),
+    message: 'Teams sync queued',
+  };
 });

--- a/src/domain/entry-sync.ts
+++ b/src/domain/entry-sync.ts
@@ -1,0 +1,17 @@
+import type { EntrySyncJobName } from '../queues/entry-sync.queue';
+
+export async function resolveEntrySyncTargetEventId(
+  jobName: EntrySyncJobName,
+  requestedEventId: number | undefined,
+  findCurrentEventId: () => Promise<number | null>,
+): Promise<number | undefined> {
+  if (jobName === 'entry-info' || requestedEventId !== undefined) {
+    return requestedEventId;
+  }
+
+  const currentEventId = await findCurrentEventId();
+  if (currentEventId === null) {
+    throw new Error('No current event found');
+  }
+  return currentEventId;
+}

--- a/src/jobs/data-sync-enqueue.ts
+++ b/src/jobs/data-sync-enqueue.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { getDataSyncJobPriority, type DataSyncPriorityJobName } from '../domain/job-priority';
 import { getDataSyncQueue, type DataSyncJobName } from '../queues/data-sync.queue';
 import { logError, logInfo } from '../utils/logger';
@@ -43,6 +45,7 @@ async function enqueueDataSyncJob(
       {
         source,
         triggeredAt: new Date().toISOString(),
+        runId: randomUUID(),
         ...(options.eventId !== undefined ? { eventId: options.eventId } : {}),
         ...(options.changeDate !== undefined ? { changeDate: options.changeDate } : {}),
       },

--- a/src/jobs/data-sync-enqueue.ts
+++ b/src/jobs/data-sync-enqueue.ts
@@ -1,33 +1,15 @@
-import { randomUUID } from 'node:crypto';
-
 import { getDataSyncJobPriority, type DataSyncPriorityJobName } from '../domain/job-priority';
 import { getDataSyncQueue, type DataSyncJobName } from '../queues/data-sync.queue';
 import { logError, logInfo } from '../utils/logger';
 import { formatCronDateKey } from '../utils/timezone';
+import {
+  createDataSyncJobData,
+  defaultDataSyncJobId,
+  type DataSyncEnqueueOptions,
+  type DataSyncJobSource,
+} from './data-sync-job-definition';
 
-export type DataSyncJobSource = 'cron' | 'manual' | 'api' | 'event-transition' | 'cascade';
-
-export interface DataSyncEnqueueOptions {
-  jobId?: string;
-  eventId?: number;
-  changeDate?: string;
-  /** When true (default for explicit jobId), remove job on settle so re-triggers work. */
-  removeOnSettle?: boolean;
-}
-
-function defaultDataSyncJobId(
-  jobName: DataSyncJobName,
-  source: DataSyncJobSource,
-  options: DataSyncEnqueueOptions,
-): string | undefined {
-  // API/manual triggers dedupe in the waiting room; cron stays unique per tick.
-  if (source !== 'api' && source !== 'manual') {
-    return undefined;
-  }
-  const eventPart = options.eventId !== undefined ? `-e${options.eventId}` : '';
-  const datePart = options.changeDate !== undefined ? `-${options.changeDate}` : '';
-  return `${jobName}${eventPart}${datePart}-${source}`;
-}
+export type { DataSyncEnqueueOptions, DataSyncJobSource } from './data-sync-job-definition';
 
 async function enqueueDataSyncJob(
   jobName: DataSyncJobName,
@@ -40,25 +22,15 @@ async function enqueueDataSyncJob(
     const jobId = options.jobId ?? defaultDataSyncJobId(jobName, source, options);
     const hasDeterministicId = jobId !== undefined;
     const removeOnSettle = options.removeOnSettle ?? hasDeterministicId;
-    const job = await queue.add(
-      jobName,
-      {
-        source,
-        triggeredAt: new Date().toISOString(),
-        runId: randomUUID(),
-        ...(options.eventId !== undefined ? { eventId: options.eventId } : {}),
-        ...(options.changeDate !== undefined ? { changeDate: options.changeDate } : {}),
+    const job = await queue.add(jobName, createDataSyncJobData(source, options), {
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 60_000,
       },
-      {
-        attempts: 3,
-        backoff: {
-          type: 'exponential',
-          delay: 60_000,
-        },
-        jobId,
-        ...(removeOnSettle ? { removeOnComplete: true, removeOnFail: true } : {}),
-      },
-    );
+      jobId,
+      ...(removeOnSettle ? { removeOnComplete: true, removeOnFail: true } : {}),
+    });
 
     logInfo('Data sync job enqueued', {
       jobId: job.id,

--- a/src/jobs/data-sync-enqueue.ts
+++ b/src/jobs/data-sync-enqueue.ts
@@ -22,7 +22,8 @@ async function enqueueDataSyncJob(
     const jobId = options.jobId ?? defaultDataSyncJobId(jobName, source, options);
     const hasDeterministicId = jobId !== undefined;
     const removeOnSettle = options.removeOnSettle ?? hasDeterministicId;
-    const job = await queue.add(jobName, createDataSyncJobData(source, options), {
+    const jobData = createDataSyncJobData(source, options);
+    const job = await queue.add(jobName, jobData, {
       attempts: 3,
       backoff: {
         type: 'exponential',
@@ -34,6 +35,10 @@ async function enqueueDataSyncJob(
 
     logInfo('Data sync job enqueued', {
       jobId: job.id,
+      // BullMQ returns the existing job when a deterministic ID is already
+      // queued. Log that stored correlation ID rather than the discarded
+      // candidate so an operator can join a trigger to its attempt report.
+      runId: job.data?.runId ?? jobData.runId,
       jobName,
       source,
       tier,

--- a/src/jobs/data-sync-job-definition.ts
+++ b/src/jobs/data-sync-job-definition.ts
@@ -1,0 +1,37 @@
+import { randomUUID } from 'node:crypto';
+
+import type { DataSyncJobName } from '../queues/data-sync.queue';
+
+export type DataSyncJobSource = 'cron' | 'manual' | 'api' | 'event-transition' | 'cascade';
+
+export interface DataSyncEnqueueOptions {
+  jobId?: string;
+  eventId?: number;
+  changeDate?: string;
+  /** When true (default for explicit jobId), remove job on settle so re-triggers work. */
+  removeOnSettle?: boolean;
+}
+
+export function defaultDataSyncJobId(
+  jobName: DataSyncJobName,
+  source: DataSyncJobSource,
+  options: DataSyncEnqueueOptions,
+): string | undefined {
+  // API/manual triggers dedupe in the waiting room; cron stays unique per tick.
+  if (source !== 'api' && source !== 'manual') {
+    return undefined;
+  }
+  const eventPart = options.eventId !== undefined ? `-e${options.eventId}` : '';
+  const datePart = options.changeDate !== undefined ? `-${options.changeDate}` : '';
+  return `${jobName}${eventPart}${datePart}-${source}`;
+}
+
+export function createDataSyncJobData(source: DataSyncJobSource, options: DataSyncEnqueueOptions) {
+  return {
+    source,
+    triggeredAt: new Date().toISOString(),
+    runId: randomUUID(),
+    ...(options.eventId !== undefined ? { eventId: options.eventId } : {}),
+    ...(options.changeDate !== undefined ? { changeDate: options.changeDate } : {}),
+  };
+}

--- a/src/jobs/entry-info-sync-marker.ts
+++ b/src/jobs/entry-info-sync-marker.ts
@@ -8,11 +8,16 @@ export function getEntryInfoSyncDateKey(date: Date) {
 }
 
 /**
- * Only mark the day synced after the final chunk completes with zero failures.
- * Mid-chunk success or pending failed-id retries must not suppress same-day re-enqueue.
+ * Only mark the day synced after the final database-scan chunk completes with
+ * zero failures. Targeted API work, mid-chunk success, and failed-id retries
+ * must not suppress the scheduled full scan.
  */
-export function shouldMarkEntryInfoSynced(hasMore: boolean, failed: number): boolean {
-  return !hasMore && failed === 0;
+export function shouldMarkEntryInfoSynced(
+  fetchedFromDb: boolean,
+  hasMore: boolean,
+  failed: number,
+): boolean {
+  return fetchedFromDb && !hasMore && failed === 0;
 }
 
 function getSecondsUntilNextDay(now: Date) {

--- a/src/jobs/entry-results.jobs.ts
+++ b/src/jobs/entry-results.jobs.ts
@@ -31,8 +31,11 @@ export function registerEntryResultsJobs(app: Elysia) {
               logInfo('Skipping entry results sync - no current event');
               return;
             }
-            const job = await enqueueEntryResultsSyncJob('cron');
-            logInfo('Entry results sync job enqueued via cron', { jobId: job.id });
+            const job = await enqueueEntryResultsSyncJob('cron', { eventId: currentEvent.id });
+            logInfo('Entry results sync job enqueued via cron', {
+              jobId: job.id,
+              eventId: currentEvent.id,
+            });
           });
         } catch {
           // Failure details are already emitted by runTrackedJob.

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -69,9 +69,11 @@ async function enqueueEntrySyncJob(
         (job) =>
           job.name === jobName &&
           job.data.source === 'manual' &&
-          // Manual scans are event-scoped when a target GW is supplied. Do
-          // not reuse a prior GW's root job and silently skip this request.
-          (job.data.eventId ?? null) === (options.eventId ?? null) &&
+          // Manual scans are event-scoped when a target GW is supplied. An
+          // unscoped root is resolved by the worker before it creates the
+          // continuation chunks, so it must also reuse those resolved chunks
+          // instead of starting a second full-table chain.
+          (options.eventId === undefined || job.data.eventId === options.eventId) &&
           (job.data.queueKey === 'manual' ||
             (job.data.queueKey === undefined && job.data.runId === 'manual')),
       );

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -23,6 +23,8 @@ export interface EntrySyncJobOptions {
   delayMs?: number;
   eventId?: number;
   runId?: string;
+  /** Stable deduplication key for every table-scan chunk in one trigger lane. */
+  queueKey?: string;
 }
 
 function hashEntryListKey(
@@ -59,7 +61,7 @@ async function enqueueEntrySyncJob(
     // runId. Every new manual scan gets a distinct correlation ID; its first
     // chunk still uses a separate stable queue key to dedupe concurrent triggers.
     const runId = options.runId ?? (source === 'cron' ? `${Date.now()}` : randomUUID());
-    const tableScanQueueKey = source === 'manual' && options.runId === undefined ? 'manual' : runId;
+    const tableScanQueueKey = options.queueKey ?? (source === 'manual' ? 'manual' : runId);
 
     const jobData = {
       source,
@@ -72,13 +74,14 @@ async function enqueueEntrySyncJob(
       throttleMs,
       eventId: options.eventId,
       runId,
+      queueKey: tableScanQueueKey,
     };
 
     const chunkKey =
       options.eventId !== undefined ? `${chunkOffset}-event-${options.eventId}` : `${chunkOffset}`;
     // Entry-list jobs (API with explicit IDs) keep their content-based ID.
-    // Table-scan chunks get deterministic IDs keyed by runId + offset so retries
-    // dedupe and cannot fork parallel chains.
+    // Table-scan chunks get deterministic IDs keyed by the trigger lane + offset
+    // so correlation IDs can vary without forking parallel manual chains.
     const isEntryList = options.entryIds !== undefined;
     const defaultJobId = isEntryList
       ? `${jobName}-entry-list-${hashEntryListKey(options.entryIds ?? [], options.eventId, options.retryCount)}`

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -55,13 +55,11 @@ async function enqueueEntrySyncJob(
     const concurrency = sanitizePositiveInt(options.concurrency, ENTRY_SYNC_DEFAULT_CONCURRENCY);
     const throttleMs = sanitizePositiveInt(options.throttleMs, ENTRY_SYNC_DEFAULT_THROTTLE_MS);
 
-    // Stable runId for this chain. Retries keep the same runId so retried chunks
-    // reuse the same deterministic jobId and cannot fork duplicate chains (FP-14f).
-    // Manual table-scans default to a stable runId so repeat triggers dedupe in the
-    // waiting room; cron ticks use a fresh runId so every cycle queues its own job.
-    const runId =
-      options.runId ??
-      (source === 'cron' ? `${Date.now()}` : source === 'manual' ? 'manual' : randomUUID());
+    // Stable runId for this chain. Retries and following chunks keep the same
+    // runId. Every new manual scan gets a distinct correlation ID; its first
+    // chunk still uses a separate stable queue key to dedupe concurrent triggers.
+    const runId = options.runId ?? (source === 'cron' ? `${Date.now()}` : randomUUID());
+    const tableScanQueueKey = source === 'manual' && options.runId === undefined ? 'manual' : runId;
 
     const jobData = {
       source,
@@ -84,7 +82,7 @@ async function enqueueEntrySyncJob(
     const isEntryList = options.entryIds !== undefined;
     const defaultJobId = isEntryList
       ? `${jobName}-entry-list-${hashEntryListKey(options.entryIds ?? [], options.eventId, options.retryCount)}`
-      : `${jobName}-${runId}-chunk-${chunkKey}`;
+      : `${jobName}-${tableScanQueueKey}-chunk-${chunkKey}`;
     const jobId = options.jobId ?? defaultJobId;
     // Deterministic IDs must not block re-triggers after settle.
     const removeOnSettle = isEntryList || source === 'manual';

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -57,6 +57,31 @@ async function enqueueEntrySyncJob(
     const concurrency = sanitizePositiveInt(options.concurrency, ENTRY_SYNC_DEFAULT_CONCURRENCY);
     const throttleMs = sanitizePositiveInt(options.throttleMs, ENTRY_SYNC_DEFAULT_THROTTLE_MS);
 
+    const isManualScanRoot =
+      source === 'manual' &&
+      options.entryIds === undefined &&
+      chunkOffset === 0 &&
+      options.runId === undefined &&
+      options.queueKey === undefined;
+    if (isManualScanRoot) {
+      const pendingJobs = await queue.getJobs(['waiting', 'delayed', 'active', 'paused']);
+      const existingManualScan = pendingJobs.find(
+        (job) =>
+          job.name === jobName && job.data.source === 'manual' && job.data.queueKey === 'manual',
+      );
+      if (existingManualScan) {
+        logInfo('Entry sync manual scan already active; reusing existing', {
+          jobId: existingManualScan.id,
+          jobName,
+          source,
+          tier,
+          queue: queue.name,
+          runId: existingManualScan.data.runId,
+        });
+        return existingManualScan;
+      }
+    }
+
     // Stable runId for this chain. Retries and following chunks keep the same
     // runId. Every new manual scan gets a distinct correlation ID; its first
     // chunk still uses a separate stable queue key to dedupe concurrent triggers.
@@ -109,7 +134,7 @@ async function enqueueEntrySyncJob(
       queue: queue.name,
       chunkOffset,
       chunkSize,
-      runId,
+      runId: job.data.runId ?? runId,
     });
     return job;
   } catch (error) {

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -67,7 +67,10 @@ async function enqueueEntrySyncJob(
       const pendingJobs = await queue.getJobs(['waiting', 'delayed', 'active', 'paused']);
       const existingManualScan = pendingJobs.find(
         (job) =>
-          job.name === jobName && job.data.source === 'manual' && job.data.queueKey === 'manual',
+          job.name === jobName &&
+          job.data.source === 'manual' &&
+          (job.data.queueKey === 'manual' ||
+            (job.data.queueKey === undefined && job.data.runId === 'manual')),
       );
       if (existingManualScan) {
         logInfo('Entry sync manual scan already active; reusing existing', {

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -9,6 +9,7 @@ import {
   ENTRY_SYNC_DEFAULT_THROTTLE_MS,
 } from '../queues/entry-sync.queue';
 import { getEntrySyncJobPriority, type EntrySyncPriorityJobName } from '../domain/job-priority';
+import { getCurrentEvent } from '../services/events.service';
 import { logError, logInfo } from '../utils/logger';
 import { stableHash } from '../utils/stable-hash';
 
@@ -65,15 +66,34 @@ async function enqueueEntrySyncJob(
       options.queueKey === undefined;
     if (isManualScanRoot) {
       const pendingJobs = await queue.getJobs(['waiting', 'delayed', 'active', 'paused']);
+      const hasEventScopedManualScan = pendingJobs.some(
+        (job) =>
+          job.name === jobName &&
+          job.data.source === 'manual' &&
+          job.data.eventId !== undefined &&
+          (job.data.queueKey === 'manual' ||
+            (job.data.queueKey === undefined && job.data.runId === 'manual')),
+      );
+      // Results/picks/transfers roots historically omitted eventId and let the
+      // worker resolve it. Once a continuation has resolved its target, an
+      // unscoped root must resolve the same current event before deciding
+      // whether it can be reused; otherwise a continuation from the previous
+      // GW can suppress the new scan after the event advances.
+      const resolvedManualEventId =
+        options.eventId ??
+        (jobName !== 'entry-info' && hasEventScopedManualScan
+          ? (await getCurrentEvent())?.id
+          : undefined);
       const existingManualScan = pendingJobs.find(
         (job) =>
           job.name === jobName &&
           job.data.source === 'manual' &&
           // Manual scans are event-scoped when a target GW is supplied. An
-          // unscoped root is resolved by the worker before it creates the
-          // continuation chunks, so it must also reuse those resolved chunks
-          // instead of starting a second full-table chain.
-          (options.eventId === undefined || job.data.eventId === options.eventId) &&
+          // unscoped root is resolved before this reuse check when a resolved
+          // continuation is present, so it cannot reuse a prior GW's chain.
+          (resolvedManualEventId === undefined
+            ? job.data.eventId === undefined
+            : job.data.eventId === resolvedManualEventId) &&
           (job.data.queueKey === 'manual' ||
             (job.data.queueKey === undefined && job.data.runId === 'manual')),
       );

--- a/src/jobs/entry-sync-enqueue.ts
+++ b/src/jobs/entry-sync-enqueue.ts
@@ -69,6 +69,9 @@ async function enqueueEntrySyncJob(
         (job) =>
           job.name === jobName &&
           job.data.source === 'manual' &&
+          // Manual scans are event-scoped when a target GW is supplied. Do
+          // not reuse a prior GW's root job and silently skip this request.
+          (job.data.eventId ?? null) === (options.eventId ?? null) &&
           (job.data.queueKey === 'manual' ||
             (job.data.queueKey === undefined && job.data.runId === 'manual')),
       );

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -168,6 +168,14 @@ async function sendLaunchNotificationOnce(
         logInfo('Launch notification was rejected by Telegram; releasing the retry lock', {
           status: rejectedDelivery.status,
         });
+        // The lock was made persistent before the request. Restore a bounded
+        // lease first so a Redis failure during the compare-and-delete cannot
+        // strand a definite rejection forever.
+        try {
+          await redis.set(lockKey, token, 'PX', NOTIFICATION_PRE_DELIVERY_LEASE_MS, 'XX');
+        } catch (error) {
+          logError('Failed to restore rejected launch notification lock lease', error);
+        }
       }
       try {
         await releaseNotificationLock(redis, lockKey, token);

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -14,6 +14,8 @@ import { CRON_TIMEZONE } from '../utils/timezone';
 
 export const LAUNCH_MONITOR_CRON_PATTERN = '*/5 * * * *';
 const NOTIFICATION_LOCK_TTL_MS = 10 * 60_000;
+const NOTIFICATION_MARKER_ATTEMPTS = 3;
+const NOTIFICATION_MARKER_RETRY_MS = 50;
 
 type LaunchRedisClient = {
   get: (key: string) => Promise<string | null>;
@@ -27,6 +29,7 @@ export interface LaunchMonitorDependencies {
   sendNotification: (message: string) => Promise<void>;
   now: () => Date;
   createLockToken: () => string;
+  wait?: (milliseconds: number) => Promise<void>;
 }
 
 export interface LaunchMonitorResult {
@@ -45,6 +48,7 @@ const defaultDependencies: LaunchMonitorDependencies = {
   sendNotification: sendTelegramMessage,
   now: () => new Date(),
   createLockToken: randomUUID,
+  wait: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
 };
 
 const RELEASE_LOCK_SCRIPT = [
@@ -62,6 +66,26 @@ async function releaseNotificationLock(
   await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, token);
 }
 
+async function persistNotificationMarker(
+  redis: LaunchRedisClient,
+  doneKey: string,
+  value: string,
+  dependencies: LaunchMonitorDependencies,
+): Promise<void> {
+  for (let attempt = 1; attempt <= NOTIFICATION_MARKER_ATTEMPTS; attempt += 1) {
+    try {
+      const persisted = await redis.set(doneKey, value);
+      if (persisted !== 'OK') throw new Error('Launch notification marker was not persisted.');
+      return;
+    } catch (error) {
+      if (attempt === NOTIFICATION_MARKER_ATTEMPTS) throw error;
+      await (dependencies.wait ?? defaultDependencies.wait)?.(
+        NOTIFICATION_MARKER_RETRY_MS * attempt,
+      );
+    }
+  }
+}
+
 async function sendLaunchNotificationOnce(
   redis: LaunchRedisClient,
   doneKey: string,
@@ -76,20 +100,31 @@ async function sendLaunchNotificationOnce(
   if (acquired !== 'OK') return 'locked';
 
   let deliveryError: unknown;
+  let notificationDelivered = false;
+  let markerPersisted = false;
   try {
     if (await redis.get(doneKey)) return 'already_sent';
     await dependencies.sendNotification(message);
-    await redis.set(doneKey, dependencies.now().toISOString());
+    notificationDelivered = true;
+    await persistNotificationMarker(redis, doneKey, dependencies.now().toISOString(), dependencies);
+    markerPersisted = true;
     return 'sent';
   } catch (error) {
     deliveryError = error;
     throw error;
   } finally {
-    try {
-      await releaseNotificationLock(redis, lockKey, token);
-    } catch (error) {
-      logError('Failed to release launch notification lock', error);
-      if (deliveryError === undefined) throw error;
+    if (notificationDelivered && !markerPersisted) {
+      logError(
+        'Launch notification was delivered but its marker was not persisted; retaining lock',
+        deliveryError,
+      );
+    } else {
+      try {
+        await releaseNotificationLock(redis, lockKey, token);
+      } catch (error) {
+        logError('Failed to release launch notification lock', error);
+        if (deliveryError === undefined) throw error;
+      }
     }
   }
 }
@@ -103,8 +138,8 @@ function result(
     outcome: sent ? 'ready' : 'noop',
     notification,
     delivery,
-    requiredUnits: 1,
-    reusedUnits: sent ? 0 : 1,
+    requiredUnits: sent ? 1 : 0,
+    reusedUnits: 0,
     succeededUnits: sent ? 1 : 0,
     failedUnits: 0,
   };

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -9,7 +9,7 @@ import { fplClient, type FPLBootstrapResponse } from '../clients/fpl';
 import { runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
-import { sendTelegramMessage } from '../utils/notify';
+import { sendTelegramMessage, type NotificationDeliveryResult } from '../utils/notify';
 import { CRON_TIMEZONE } from '../utils/timezone';
 
 export const LAUNCH_MONITOR_CRON_PATTERN = '*/5 * * * *';
@@ -26,7 +26,7 @@ type LaunchRedisClient = {
 export interface LaunchMonitorDependencies {
   getBootstrap: () => Promise<FPLBootstrapResponse>;
   getRedis: () => Promise<LaunchRedisClient>;
-  sendNotification: (message: string) => Promise<void>;
+  sendNotification: (message: string) => Promise<NotificationDeliveryResult>;
   now: () => Date;
   createLockToken: () => string;
   wait?: (milliseconds: number) => Promise<void>;
@@ -35,7 +35,7 @@ export interface LaunchMonitorDependencies {
 export interface LaunchMonitorResult {
   outcome: 'ready' | 'noop';
   notification: 'warning' | 'happening' | 'none';
-  delivery: 'sent' | 'already_sent' | 'locked' | 'not_applicable';
+  delivery: 'sent' | 'skipped' | 'already_sent' | 'locked' | 'not_applicable';
   requiredUnits: number;
   reusedUnits: number;
   succeededUnits: number;
@@ -119,13 +119,18 @@ async function sendLaunchNotificationOnce(
 
   let deliveryError: unknown;
   let deliveryAttempted = false;
+  let deliverySkipped = false;
   let notificationDelivered = false;
   let markerPersisted = false;
   try {
     if (await redis.get(doneKey)) return 'already_sent';
     if (!(await persistNotificationLock(redis, lockKey, token))) return 'locked';
     deliveryAttempted = true;
-    await dependencies.sendNotification(message);
+    const delivery = await dependencies.sendNotification(message);
+    if (delivery === 'skipped') {
+      deliverySkipped = true;
+      return 'skipped';
+    }
     notificationDelivered = true;
     await persistNotificationMarker(redis, doneKey, dependencies.now().toISOString(), dependencies);
     markerPersisted = true;
@@ -134,7 +139,7 @@ async function sendLaunchNotificationOnce(
     deliveryError = error;
     throw error;
   } finally {
-    if (deliveryAttempted && !markerPersisted) {
+    if (deliveryAttempted && !deliverySkipped && !markerPersisted) {
       logError(
         notificationDelivered
           ? 'Launch notification was delivered but its marker was not persisted; retaining lock'

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -13,7 +13,6 @@ import { sendTelegramMessage } from '../utils/notify';
 import { CRON_TIMEZONE } from '../utils/timezone';
 
 export const LAUNCH_MONITOR_CRON_PATTERN = '*/5 * * * *';
-const NOTIFICATION_LOCK_TTL_MS = 10 * 60_000;
 const NOTIFICATION_MARKER_ATTEMPTS = 3;
 const NOTIFICATION_MARKER_RETRY_MS = 50;
 
@@ -96,7 +95,11 @@ async function sendLaunchNotificationOnce(
 
   const lockKey = `${doneKey}:lock`;
   const token = dependencies.createLockToken();
-  const acquired = await redis.set(lockKey, token, 'PX', NOTIFICATION_LOCK_TTL_MS, 'NX');
+  // This once-per-transition side effect spans Telegram and Redis, so there is
+  // no atomic commit. Keep the lock without an expiry: confirmed pre-delivery
+  // failures release it, while an ambiguous delivered-without-marker state
+  // remains at-most-once until an operator reconciles it.
+  const acquired = await redis.set(lockKey, token, 'NX');
   if (acquired !== 'OK') return 'locked';
 
   let deliveryError: unknown;

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -9,7 +9,11 @@ import { fplClient, type FPLBootstrapResponse } from '../clients/fpl';
 import { runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
-import { sendTelegramMessage, type NotificationDeliveryResult } from '../utils/notify';
+import {
+  NotificationDeliveryRejectedError,
+  sendTelegramMessage,
+  type NotificationDeliveryResult,
+} from '../utils/notify';
 import { CRON_TIMEZONE } from '../utils/timezone';
 
 export const LAUNCH_MONITOR_CRON_PATTERN = '*/5 * * * *';
@@ -150,7 +154,9 @@ async function sendLaunchNotificationOnce(
         logError('Failed to restore skipped launch notification lock lease', error);
       }
     }
-    if (deliveryAttempted && !deliverySkipped && !markerPersisted) {
+    const rejectedDelivery =
+      deliveryError instanceof NotificationDeliveryRejectedError ? deliveryError : null;
+    if (deliveryAttempted && !deliverySkipped && !markerPersisted && !rejectedDelivery) {
       logError(
         notificationDelivered
           ? 'Launch notification was delivered but its marker was not persisted; retaining lock'
@@ -158,6 +164,11 @@ async function sendLaunchNotificationOnce(
         deliveryError,
       );
     } else {
+      if (rejectedDelivery) {
+        logInfo('Launch notification was rejected by Telegram; releasing the retry lock', {
+          status: rejectedDelivery.status,
+        });
+      }
       try {
         await releaseNotificationLock(redis, lockKey, token);
       } catch (error) {

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -15,6 +15,7 @@ import { CRON_TIMEZONE } from '../utils/timezone';
 export const LAUNCH_MONITOR_CRON_PATTERN = '*/5 * * * *';
 const NOTIFICATION_MARKER_ATTEMPTS = 3;
 const NOTIFICATION_MARKER_RETRY_MS = 50;
+const NOTIFICATION_PRE_DELIVERY_LEASE_MS = 60_000;
 
 type LaunchRedisClient = {
   get: (key: string) => Promise<string | null>;
@@ -57,12 +58,27 @@ const RELEASE_LOCK_SCRIPT = [
   'return 0',
 ].join('\n');
 
+const PERSIST_LOCK_SCRIPT = [
+  'if redis.call("get", KEYS[1]) == ARGV[1] then',
+  '  return redis.call("persist", KEYS[1])',
+  'end',
+  'return 0',
+].join('\n');
+
 async function releaseNotificationLock(
   redis: LaunchRedisClient,
   lockKey: string,
   token: string,
 ): Promise<void> {
   await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, token);
+}
+
+async function persistNotificationLock(
+  redis: LaunchRedisClient,
+  lockKey: string,
+  token: string,
+): Promise<boolean> {
+  return (await redis.eval(PERSIST_LOCK_SCRIPT, 1, lockKey, token)) === 1;
 }
 
 async function persistNotificationMarker(
@@ -95,10 +111,10 @@ async function sendLaunchNotificationOnce(
 
   const lockKey = `${doneKey}:lock`;
   const token = dependencies.createLockToken();
-  // This once-per-transition side effect spans Telegram and Redis, so there is
-  // no atomic commit. Keep the lock without an expiry once delivery is attempted:
-  // a thrown transport error can still mean Telegram accepted the request.
-  const acquired = await redis.set(lockKey, token, 'NX');
+  // A crash before delivery must recover automatically. Convert this short
+  // pre-delivery lease into a durable ambiguity lock immediately before the
+  // Telegram request begins.
+  const acquired = await redis.set(lockKey, token, 'PX', NOTIFICATION_PRE_DELIVERY_LEASE_MS, 'NX');
   if (acquired !== 'OK') return 'locked';
 
   let deliveryError: unknown;
@@ -107,6 +123,7 @@ async function sendLaunchNotificationOnce(
   let markerPersisted = false;
   try {
     if (await redis.get(doneKey)) return 'already_sent';
+    if (!(await persistNotificationLock(redis, lockKey, token))) return 'locked';
     deliveryAttempted = true;
     await dependencies.sendNotification(message);
     notificationDelivered = true;
@@ -129,7 +146,6 @@ async function sendLaunchNotificationOnce(
         await releaseNotificationLock(redis, lockKey, token);
       } catch (error) {
         logError('Failed to release launch notification lock', error);
-        if (deliveryError === undefined) throw error;
       }
     }
   }

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -1,98 +1,189 @@
+import { randomUUID } from 'node:crypto';
+
 import { cron } from '@elysiajs/cron';
 import { Elysia } from 'elysia';
 
 import { deriveSeasonFromEvents } from '../cache/cache-season';
 import { redisSingleton } from '../cache/singleton';
-import { fplClient } from '../clients/fpl';
+import { fplClient, type FPLBootstrapResponse } from '../clients/fpl';
+import { runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { executeTrackedCron } from '../utils/job-run-logger';
+import { logError, logInfo } from '../utils/logger';
 import { sendTelegramMessage } from '../utils/notify';
-import { logInfo } from '../utils/logger';
 import { CRON_TIMEZONE } from '../utils/timezone';
 
-/**
- * Launch Monitor Jobs
- *
- * Polls bootstrap-static every minute year-round to detect season transitions:
- * - warning:   events list is empty → new season not yet published
- * - happening: events list present AND first event deadline is in the current year → season is live
- */
+export const LAUNCH_MONITOR_CRON_PATTERN = '*/5 * * * *';
+const NOTIFICATION_LOCK_TTL_MS = 10 * 60_000;
 
-async function shouldSendLaunchNotification(key: string): Promise<boolean> {
-  const redis = await redisSingleton.getClient();
-  const result = await redis.set(key, new Date().toISOString(), 'NX');
-  return result === 'OK';
+type LaunchRedisClient = {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, ...args: Array<string | number>) => Promise<string | null>;
+  eval: (script: string, numberOfKeys: number, ...args: string[]) => Promise<unknown>;
+};
+
+export interface LaunchMonitorDependencies {
+  getBootstrap: () => Promise<FPLBootstrapResponse>;
+  getRedis: () => Promise<LaunchRedisClient>;
+  sendNotification: (message: string) => Promise<void>;
+  now: () => Date;
+  createLockToken: () => string;
 }
 
-export async function runLaunchWarning() {
-  const bootstrap = await fplClient.getBootstrap();
-  if (bootstrap.events.length === 0) {
-    // Year-suffixed so the warning can re-arm each pre-season (season string is
-    // unknowable while the events list is still empty).
-    const year = new Date().getFullYear();
-    const shouldSend = await shouldSendLaunchNotification(`LaunchNotification:warning:${year}`);
-    if (!shouldSend) {
-      return;
-    }
+export interface LaunchMonitorResult {
+  outcome: 'ready' | 'noop';
+  notification: 'warning' | 'happening' | 'none';
+  delivery: 'sent' | 'already_sent' | 'locked' | 'not_applicable';
+  requiredUnits: number;
+  reusedUnits: number;
+  succeededUnits: number;
+  failedUnits: number;
+}
 
-    const message = '【NEW SEASON】WARNING! WARNING! WARNING!';
-    logInfo('Pre-season warning: FPL events list is empty');
-    await sendTelegramMessage(message);
+const defaultDependencies: LaunchMonitorDependencies = {
+  getBootstrap: () => fplClient.getBootstrap(),
+  getRedis: async () => (await redisSingleton.getClient()) as unknown as LaunchRedisClient,
+  sendNotification: sendTelegramMessage,
+  now: () => new Date(),
+  createLockToken: randomUUID,
+};
+
+const RELEASE_LOCK_SCRIPT = [
+  'if redis.call("get", KEYS[1]) == ARGV[1] then',
+  '  return redis.call("del", KEYS[1])',
+  'end',
+  'return 0',
+].join('\n');
+
+async function releaseNotificationLock(
+  redis: LaunchRedisClient,
+  lockKey: string,
+  token: string,
+): Promise<void> {
+  await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, token);
+}
+
+async function sendLaunchNotificationOnce(
+  redis: LaunchRedisClient,
+  doneKey: string,
+  message: string,
+  dependencies: LaunchMonitorDependencies,
+): Promise<LaunchMonitorResult['delivery']> {
+  if (await redis.get(doneKey)) return 'already_sent';
+
+  const lockKey = `${doneKey}:lock`;
+  const token = dependencies.createLockToken();
+  const acquired = await redis.set(lockKey, token, 'PX', NOTIFICATION_LOCK_TTL_MS, 'NX');
+  if (acquired !== 'OK') return 'locked';
+
+  let deliveryError: unknown;
+  try {
+    if (await redis.get(doneKey)) return 'already_sent';
+    await dependencies.sendNotification(message);
+    await redis.set(doneKey, dependencies.now().toISOString());
+    return 'sent';
+  } catch (error) {
+    deliveryError = error;
+    throw error;
+  } finally {
+    try {
+      await releaseNotificationLock(redis, lockKey, token);
+    } catch (error) {
+      logError('Failed to release launch notification lock', error);
+      if (deliveryError === undefined) throw error;
+    }
   }
 }
 
-export async function runLaunchHappening() {
-  const bootstrap = await fplClient.getBootstrap();
-  if (bootstrap.events.length === 0) return;
+function result(
+  notification: LaunchMonitorResult['notification'],
+  delivery: LaunchMonitorResult['delivery'],
+): LaunchMonitorResult {
+  const sent = delivery === 'sent';
+  return {
+    outcome: sent ? 'ready' : 'noop',
+    notification,
+    delivery,
+    requiredUnits: 1,
+    reusedUnits: sent ? 0 : 1,
+    succeededUnits: sent ? 1 : 0,
+    failedUnits: 0,
+  };
+}
+
+export async function evaluateLaunchMonitor(
+  dependencies: LaunchMonitorDependencies = defaultDependencies,
+): Promise<LaunchMonitorResult> {
+  const bootstrap = await dependencies.getBootstrap();
+  const redis = await dependencies.getRedis();
+  const now = dependencies.now();
+
+  if (bootstrap.events.length === 0) {
+    const delivery = await sendLaunchNotificationOnce(
+      redis,
+      `LaunchNotification:warning:${now.getFullYear()}`,
+      '【NEW SEASON】WARNING! WARNING! WARNING!',
+      dependencies,
+    );
+    if (delivery === 'sent') {
+      logInfo('Pre-season warning: FPL events list is empty');
+    }
+    return result('warning', delivery);
+  }
 
   const firstEvent = bootstrap.events[0];
   const publishedSeason = deriveSeasonFromEvents(bootstrap.events);
-  const currentYear = new Date().getFullYear().toString();
+  if (!publishedSeason || !firstEvent.deadline_time?.startsWith(now.getFullYear().toString())) {
+    return result('none', 'not_applicable');
+  }
 
-  if (publishedSeason && firstEvent.deadline_time?.startsWith(currentYear)) {
-    const shouldSend = await shouldSendLaunchNotification(
-      `LaunchNotification:happening:${publishedSeason}`,
-    );
-    if (!shouldSend) {
-      return;
-    }
-
-    const message = '【NEW SEASON】ITS HAPPENING!!!';
+  const delivery = await sendLaunchNotificationOnce(
+    redis,
+    `LaunchNotification:happening:${publishedSeason}`,
+    '【NEW SEASON】ITS HAPPENING!!!',
+    dependencies,
+  );
+  if (delivery === 'sent') {
     logInfo('New season detected: first event deadline is published', {
       deadlineTime: firstEvent.deadline_time,
       publishedSeason,
     });
-    await sendTelegramMessage(message);
   }
+  return result('happening', delivery);
+}
+
+export async function runLaunchMonitor(options?: {
+  source?: 'cron' | 'manual';
+  runId?: string;
+  dependencies?: LaunchMonitorDependencies;
+}): Promise<LaunchMonitorResult> {
+  const source = options?.source ?? 'manual';
+  const now = options?.dependencies?.now() ?? new Date();
+  return runDataSyncAttempt(
+    {
+      queue: 'cron',
+      jobName: 'launch-monitor',
+      runId: options?.runId ?? `launch-monitor-${now.getTime()}`,
+      source,
+    },
+    () => evaluateLaunchMonitor(options?.dependencies),
+  );
 }
 
 export function registerLaunchJobs(app: Elysia) {
-  return app
-    .use(
-      cron({
-        name: 'launch-warning',
-        pattern: '* * * * *',
-        timezone: CRON_TIMEZONE,
-        async run() {
-          try {
-            await executeTrackedCron('launch-warning', runLaunchWarning);
-          } catch {
-            // Failure details are already emitted by runTrackedJob.
-          }
-        },
-      }),
-    )
-    .use(
-      cron({
-        name: 'launch-happening',
-        pattern: '* * * * *',
-        timezone: CRON_TIMEZONE,
-        async run() {
-          try {
-            await executeTrackedCron('launch-happening', runLaunchHappening);
-          } catch {
-            // Failure details are already emitted by runTrackedJob.
-          }
-        },
-      }),
-    );
+  return app.use(
+    cron({
+      name: 'launch-monitor',
+      pattern: LAUNCH_MONITOR_CRON_PATTERN,
+      timezone: CRON_TIMEZONE,
+      async run() {
+        try {
+          await executeTrackedCron('launch-monitor', async () => {
+            await runLaunchMonitor({ source: 'cron' });
+          });
+        } catch {
+          // Failure details are already emitted by runTrackedJob and the attempt report.
+        }
+      },
+    }),
+  );
 }

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -171,10 +171,10 @@ export async function evaluateLaunchMonitor(
   dependencies: LaunchMonitorDependencies = defaultDependencies,
 ): Promise<LaunchMonitorResult> {
   const bootstrap = await dependencies.getBootstrap();
-  const redis = await dependencies.getRedis();
   const now = dependencies.now();
 
   if (bootstrap.events.length === 0) {
+    const redis = await dependencies.getRedis();
     const delivery = await sendLaunchNotificationOnce(
       redis,
       `LaunchNotification:warning:${now.getFullYear()}`,
@@ -193,6 +193,7 @@ export async function evaluateLaunchMonitor(
     return result('none', 'not_applicable');
   }
 
+  const redis = await dependencies.getRedis();
   const delivery = await sendLaunchNotificationOnce(
     redis,
     `LaunchNotification:happening:${publishedSeason}`,

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -139,6 +139,17 @@ async function sendLaunchNotificationOnce(
     deliveryError = error;
     throw error;
   } finally {
+    if (deliverySkipped) {
+      // Telegram-disabled delivery is a definite no-op, not an ambiguous
+      // send. The lock was made persistent before the request so an actual
+      // send cannot be duplicated; restore a short lease before best-effort
+      // cleanup so a failed DEL cannot block every later tick forever.
+      try {
+        await redis.set(lockKey, token, 'PX', NOTIFICATION_PRE_DELIVERY_LEASE_MS, 'XX');
+      } catch (error) {
+        logError('Failed to restore skipped launch notification lock lease', error);
+      }
+    }
     if (deliveryAttempted && !deliverySkipped && !markerPersisted) {
       logError(
         notificationDelivered

--- a/src/jobs/launch.jobs.ts
+++ b/src/jobs/launch.jobs.ts
@@ -96,17 +96,18 @@ async function sendLaunchNotificationOnce(
   const lockKey = `${doneKey}:lock`;
   const token = dependencies.createLockToken();
   // This once-per-transition side effect spans Telegram and Redis, so there is
-  // no atomic commit. Keep the lock without an expiry: confirmed pre-delivery
-  // failures release it, while an ambiguous delivered-without-marker state
-  // remains at-most-once until an operator reconciles it.
+  // no atomic commit. Keep the lock without an expiry once delivery is attempted:
+  // a thrown transport error can still mean Telegram accepted the request.
   const acquired = await redis.set(lockKey, token, 'NX');
   if (acquired !== 'OK') return 'locked';
 
   let deliveryError: unknown;
+  let deliveryAttempted = false;
   let notificationDelivered = false;
   let markerPersisted = false;
   try {
     if (await redis.get(doneKey)) return 'already_sent';
+    deliveryAttempted = true;
     await dependencies.sendNotification(message);
     notificationDelivered = true;
     await persistNotificationMarker(redis, doneKey, dependencies.now().toISOString(), dependencies);
@@ -116,9 +117,11 @@ async function sendLaunchNotificationOnce(
     deliveryError = error;
     throw error;
   } finally {
-    if (notificationDelivered && !markerPersisted) {
+    if (deliveryAttempted && !markerPersisted) {
       logError(
-        'Launch notification was delivered but its marker was not persisted; retaining lock',
+        notificationDelivered
+          ? 'Launch notification was delivered but its marker was not persisted; retaining lock'
+          : 'Launch notification delivery outcome is ambiguous; retaining lock',
         deliveryError,
       );
     } else {

--- a/src/jobs/league-sync.jobs.ts
+++ b/src/jobs/league-sync.jobs.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import {
   getLeagueSyncQueue,
   LEAGUE_JOBS,
@@ -13,6 +15,7 @@ export type LeagueSyncEnqueueOptions = {
   tournamentId?: number;
   delay?: number;
   jobId?: string;
+  runId?: string;
 };
 
 async function enqueueLeagueSyncJob(
@@ -24,19 +27,21 @@ async function enqueueLeagueSyncJob(
   try {
     const tier = getLeagueSyncJobPriority(jobName as LeagueSyncPriorityJobName);
     const queue = getLeagueSyncQueue(tier);
+    const runId = options.runId ?? randomUUID();
     const jobData: LeagueSyncJobData = {
       eventId,
       tournamentId: options.tournamentId,
       source,
       triggeredAt: new Date().toISOString(),
+      runId,
     };
 
     // Callers may provide a deterministic ID for bounded recurring slots.
     // Other cron, manual, and cascade runs retain unique IDs.
-    const runId = Date.now();
+    const jobNonce = Date.now();
     const generatedJobId = options.tournamentId
-      ? `${jobName}-e${eventId}-t${options.tournamentId}-${runId}`
-      : `${jobName}-e${eventId}-coordinator-${runId}`;
+      ? `${jobName}-e${eventId}-t${options.tournamentId}-${jobNonce}`
+      : `${jobName}-e${eventId}-coordinator-${jobNonce}`;
     const jobId = options.jobId ?? generatedJobId;
 
     const job = await queue.add(jobName, jobData, {
@@ -53,6 +58,7 @@ async function enqueueLeagueSyncJob(
     logInfo('League sync job enqueued', {
       jobId: job.id,
       jobName,
+      runId: job.data?.runId ?? runId,
       eventId,
       tournamentId: options.tournamentId,
       source,

--- a/src/queues/data-sync.queue.ts
+++ b/src/queues/data-sync.queue.ts
@@ -17,6 +17,8 @@ export type DataSyncJobName =
 export interface DataSyncJobData {
   source?: 'cron' | 'manual' | 'api' | 'event-transition' | 'cascade';
   triggeredAt: string;
+  /** Correlates one logical execution across BullMQ retries; independent of queue dedupe ID. */
+  runId?: string;
   /** Optional event filter (fixtures, player-stats); absent = current/all behavior */
   eventId?: number;
   /** Price-history date in the configured cron timezone (YYYYMMDD). */

--- a/src/queues/entry-sync.queue.ts
+++ b/src/queues/entry-sync.queue.ts
@@ -41,6 +41,7 @@ export interface EntrySyncJobData {
   throttleMs?: number;
   eventId?: number;
   runId?: string;
+  queueKey?: string;
 }
 
 const tieredQueueSet = createTieredQueueSet<EntrySyncJobData>(entrySyncQueueName, {

--- a/src/queues/league-sync.queue.ts
+++ b/src/queues/league-sync.queue.ts
@@ -15,6 +15,8 @@ export interface LeagueSyncJobData {
   tournamentId?: number; // If specified, process only this tournament; if not, coordinator job
   source: 'cron' | 'manual' | 'cascade';
   triggeredAt: string;
+  /** Correlates a coordinator and all of its per-tournament child attempts. */
+  runId?: string;
 }
 
 const tieredQueueSet = createTieredQueueSet<LeagueSyncJobData>(leagueSyncQueueName, {

--- a/src/services/fixtures.service.ts
+++ b/src/services/fixtures.service.ts
@@ -163,8 +163,9 @@ export async function syncFixtures(eventId?: number): Promise<{ count: number; e
               });
             }
             const repository = createFixtureRepository(tx);
+            let markedUnscheduled = 0;
             if (unscheduledFixtures.length > 0) {
-              const markedUnscheduled = await repository.markUnscheduled(
+              markedUnscheduled = await repository.markUnscheduled(
                 unscheduledFixtures.map((fixture) => fixture.id),
               );
               logInfo('Persisted unscheduled fixture ownership', {
@@ -172,7 +173,8 @@ export async function syncFixtures(eventId?: number): Promise<{ count: number; e
                 updated: markedUnscheduled,
               });
             }
-            return repository.upsertBatch(schedulableFixtures);
+            const savedFixtures = await repository.upsertBatch(schedulableFixtures);
+            return { savedFixtures, markedUnscheduled };
           },
         );
         if (!durable.accepted || !durable.value) {
@@ -180,8 +182,13 @@ export async function syncFixtures(eventId?: number): Promise<{ count: number; e
             `Fixture sync for ${eventId ? `event ${eventId}` : 'all events'} was superseded by live snapshot event ${durable.rejectedEventId ?? 'unknown'} at ${durable.winnerCheckedAt.toISOString()}; retry`,
           );
         }
-        const savedFixtures = durable.value;
-        logInfo('Fixtures upserted to database', { count: savedFixtures.length, ...logContext });
+        const { savedFixtures, markedUnscheduled } = durable.value;
+        logInfo('Fixtures persisted to database', {
+          count: savedFixtures.length + markedUnscheduled,
+          scheduledCount: savedFixtures.length,
+          unscheduledCount: markedUnscheduled,
+          ...logContext,
+        });
 
         let snapshotOwnedEventIds: ReadonlySet<number> = new Set();
         if (eventId && !recoveredFullFixtureFeed) {
@@ -239,7 +246,7 @@ export async function syncFixtures(eventId?: number): Promise<{ count: number; e
         logInfo('Fixtures cache updated', logContext);
 
         return {
-          count: savedFixtures.length,
+          count: savedFixtures.length + markedUnscheduled,
           errors: rawFixtures.length - fixtures.length,
         };
       },

--- a/src/services/job-trigger.service.ts
+++ b/src/services/job-trigger.service.ts
@@ -17,7 +17,7 @@ import {
 import { runManualEventCurrentRefresh } from '../jobs/event-current-refresh.job';
 import { runLeagueEventPicksSync } from '../jobs/league-event-picks.jobs';
 import { runLeagueEventResultsSync } from '../jobs/league-event-results.jobs';
-import { runLaunchHappening, runLaunchWarning } from '../jobs/launch.jobs';
+import { runLaunchMonitor } from '../jobs/launch.jobs';
 import {
   enqueueEventLiveExplain,
   enqueueEventLiveSummary,
@@ -248,14 +248,9 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
     schedule: '06:00, 08:00, 10:00 UTC+8 inside the 24-hour post-match window',
   },
   {
-    name: 'launch-warning',
-    description: 'Pre-season monitor message when FPL events are absent',
-    schedule: 'Every minute year-round (deduplicated once per year)',
-  },
-  {
-    name: 'launch-happening',
-    description: 'Season-start monitor message when new deadline appears',
-    schedule: 'Every minute year-round (deduplicated once per season)',
+    name: 'launch-monitor',
+    description: 'Detect pre-season and season-start transitions with one bootstrap request',
+    schedule: 'Every five minutes year-round (deduplicated by transition)',
   },
 ];
 
@@ -399,8 +394,7 @@ function buildJobMap(input?: unknown): Record<string, () => Promise<unknown>> {
       return enqueueLiveScoresSync(currentEvent.id, 'manual');
     },
     'post-match-consolidation': runPostMatchConsolidation,
-    'launch-warning': runLaunchWarning,
-    'launch-happening': runLaunchHappening,
+    'launch-monitor': () => runLaunchMonitor({ source: 'manual' }),
   };
 }
 

--- a/src/services/job-trigger.service.ts
+++ b/src/services/job-trigger.service.ts
@@ -297,7 +297,13 @@ function buildJobMap(input?: unknown): Record<string, () => Promise<unknown>> {
       }
       return enqueueEntryTransfersSyncJob('manual', { eventId: currentEvent.id });
     },
-    'entry-event-results-daily': () => enqueueEntryResultsSyncJob('manual'),
+    'entry-event-results-daily': async () => {
+      const currentEvent = await getCurrentEvent();
+      if (!currentEvent) {
+        throw new Error('No current event found');
+      }
+      return enqueueEntryResultsSyncJob('manual', { eventId: currentEvent.id });
+    },
     'league-event-picks-sync': async () => {
       await runLeagueEventPicksSync();
     },

--- a/src/services/league-event-results.service.ts
+++ b/src/services/league-event-results.service.ts
@@ -446,6 +446,12 @@ export async function syncLeagueEventResultsByTournament(
     skipped,
   });
 
+  // The repository fences rows by the entry's current season. A rollover can
+  // therefore reject rows after we built them; those rows are required units,
+  // not successful no-ops, and must remain visible to the retry/reporting
+  // layer instead of producing a false ready result.
+  const unpersisted = Math.max(0, inserts.length - updated);
+
   return {
     tournamentId,
     eventId,
@@ -455,6 +461,6 @@ export async function syncLeagueEventResultsByTournament(
     requiredUnits: totalEntries,
     reusedUnits: 0,
     succeededUnits: updated,
-    failedUnits: skipped,
+    failedUnits: skipped + unpersisted,
   };
 }

--- a/src/services/league-event-results.service.ts
+++ b/src/services/league-event-results.service.ts
@@ -298,6 +298,10 @@ export async function syncLeagueEventResultsByTournament(
   totalEntries: number;
   updated: number;
   skipped: number;
+  requiredUnits: number;
+  reusedUnits: number;
+  succeededUnits: number;
+  failedUnits: number;
 }> {
   logInfo('Starting league event results sync for tournament', { tournamentId, eventId });
 
@@ -423,5 +427,15 @@ export async function syncLeagueEventResultsByTournament(
     skipped,
   });
 
-  return { tournamentId, eventId, totalEntries, updated, skipped };
+  return {
+    tournamentId,
+    eventId,
+    totalEntries,
+    updated,
+    skipped,
+    requiredUnits: totalEntries,
+    reusedUnits: 0,
+    succeededUnits: updated,
+    failedUnits: skipped,
+  };
 }

--- a/src/services/league-event-results.service.ts
+++ b/src/services/league-event-results.service.ts
@@ -341,7 +341,12 @@ export async function syncLeagueEventResultsByTournament(
   );
   if (eventLives.length === 0) {
     logInfo('No event live data found for league event results', { eventId, tournamentId });
-    return summarizeMissingLeagueEventLiveData(tournamentId, eventId, entryIds.length);
+    // This is a prerequisite failure, not a successful partial result. Throw
+    // so the BullMQ child remains retryable and final-failure alerting can
+    // surface a missing live snapshot instead of silently losing the run.
+    throw new Error(
+      `Event live data unavailable for league event results (tournamentId=${tournamentId}, eventId=${eventId})`,
+    );
   }
   const eventLiveMap = new Map(eventLives.map((live) => [live.elementId, live]));
   const playerIds = uniqueNumbers(eventLives.map((live) => live.elementId));

--- a/src/services/league-event-results.service.ts
+++ b/src/services/league-event-results.service.ts
@@ -288,11 +288,7 @@ function buildEntryResultData(
   };
 }
 
-export async function syncLeagueEventResultsByTournament(
-  tournamentId: number,
-  eventId: number,
-  options?: { concurrency?: number; season?: string },
-): Promise<{
+export type LeagueEventResultsSyncSummary = {
   tournamentId: number;
   eventId: number;
   totalEntries: number;
@@ -302,7 +298,31 @@ export async function syncLeagueEventResultsByTournament(
   reusedUnits: number;
   succeededUnits: number;
   failedUnits: number;
-}> {
+};
+
+export function summarizeMissingLeagueEventLiveData(
+  tournamentId: number,
+  eventId: number,
+  entryCount: number,
+): LeagueEventResultsSyncSummary {
+  return {
+    tournamentId,
+    eventId,
+    totalEntries: entryCount,
+    updated: 0,
+    skipped: entryCount,
+    requiredUnits: entryCount,
+    reusedUnits: 0,
+    succeededUnits: 0,
+    failedUnits: entryCount,
+  };
+}
+
+export async function syncLeagueEventResultsByTournament(
+  tournamentId: number,
+  eventId: number,
+  options?: { concurrency?: number; season?: string },
+): Promise<LeagueEventResultsSyncSummary> {
   logInfo('Starting league event results sync for tournament', { tournamentId, eventId });
 
   const tournament = await tournamentInfoRepository.findById(tournamentId);
@@ -320,9 +340,8 @@ export async function syncLeagueEventResultsByTournament(
     checkpointSeason,
   );
   if (eventLives.length === 0) {
-    throw new Error(
-      `Finalized event live data is unavailable for league event results: event ${eventId}`,
-    );
+    logInfo('No event live data found for league event results', { eventId, tournamentId });
+    return summarizeMissingLeagueEventLiveData(tournamentId, eventId, entryIds.length);
   }
   const eventLiveMap = new Map(eventLives.map((live) => [live.elementId, live]));
   const playerIds = uniqueNumbers(eventLives.map((live) => live.elementId));

--- a/src/services/league-sync.service.ts
+++ b/src/services/league-sync.service.ts
@@ -7,8 +7,8 @@ import { syncLeagueEventResultsByTournament } from './league-event-results.servi
 /**
  * Enqueue per-tournament jobs for league event picks (coordinator fan-out).
  */
-export async function enqueuePicksPerTournament(eventId: number) {
-  logInfo('Enqueueing per-tournament picks jobs', { eventId });
+export async function enqueuePicksPerTournament(eventId: number, runId?: string) {
+  logInfo('Enqueueing per-tournament picks jobs', { eventId, runId });
 
   const tournaments = await tournamentInfoRepository.findActive();
   if (tournaments.length === 0) {
@@ -18,7 +18,7 @@ export async function enqueuePicksPerTournament(eventId: number) {
 
   const results = await Promise.allSettled(
     tournaments.map((tournament) =>
-      enqueueLeagueEventPicks(eventId, 'cascade', { tournamentId: tournament.id }),
+      enqueueLeagueEventPicks(eventId, 'cascade', { tournamentId: tournament.id, runId }),
     ),
   );
 
@@ -57,8 +57,8 @@ export async function enqueuePicksPerTournament(eventId: number) {
 /**
  * Enqueue per-tournament jobs for league event results (coordinator fan-out).
  */
-export async function enqueueResultsPerTournament(eventId: number) {
-  logInfo('Enqueueing per-tournament results jobs', { eventId });
+export async function enqueueResultsPerTournament(eventId: number, runId?: string) {
+  logInfo('Enqueueing per-tournament results jobs', { eventId, runId });
 
   const tournaments = await tournamentInfoRepository.findActive();
   if (tournaments.length === 0) {
@@ -68,7 +68,7 @@ export async function enqueueResultsPerTournament(eventId: number) {
 
   const results = await Promise.allSettled(
     tournaments.map((tournament) =>
-      enqueueLeagueEventResults(eventId, 'cascade', { tournamentId: tournament.id }),
+      enqueueLeagueEventResults(eventId, 'cascade', { tournamentId: tournament.id, runId }),
     ),
   );
 
@@ -104,16 +104,24 @@ export async function enqueueResultsPerTournament(eventId: number) {
   return { enqueued: successful };
 }
 
-export async function processLeagueEventPicksJob(eventId: number, tournamentId?: number) {
+export async function processLeagueEventPicksJob(
+  eventId: number,
+  tournamentId?: number,
+  runId?: string,
+) {
   if (tournamentId) {
     return syncLeagueEventPicksByTournament(tournamentId, eventId);
   }
-  return enqueuePicksPerTournament(eventId);
+  return enqueuePicksPerTournament(eventId, runId);
 }
 
-export async function processLeagueEventResultsJob(eventId: number, tournamentId?: number) {
+export async function processLeagueEventResultsJob(
+  eventId: number,
+  tournamentId?: number,
+  runId?: string,
+) {
   if (tournamentId) {
     return syncLeagueEventResultsByTournament(tournamentId, eventId);
   }
-  return enqueueResultsPerTournament(eventId);
+  return enqueueResultsPerTournament(eventId, runId);
 }

--- a/src/services/player-stats.service.ts
+++ b/src/services/player-stats.service.ts
@@ -16,7 +16,9 @@ import { loadTeamsBasicInfo } from '../utils/teams';
 import { getCurrentEvent, getNextEvent } from './events.service';
 import { resolvePlayerSyncEvent } from './player-sync-event.service';
 
-export async function syncCurrentPlayerStats(): Promise<{
+export async function syncCurrentPlayerStats(options?: {
+  onTargetEventResolved?: (eventId: EventId) => void;
+}): Promise<{
   count: number;
   eventId: EventId;
   errors: number;
@@ -35,6 +37,7 @@ export async function syncCurrentPlayerStats(): Promise<{
   if (!syncEvent) {
     throw new Error('No current or next event found for player stats');
   }
+  options?.onTargetEventResolved?.(syncEvent.event.id);
 
   if (fplData.elements.length === 0) {
     throw new Error('No player stats returned from FPL API');

--- a/src/services/player-stats.service.ts
+++ b/src/services/player-stats.service.ts
@@ -16,9 +16,22 @@ import { loadTeamsBasicInfo } from '../utils/teams';
 import { getCurrentEvent, getNextEvent } from './events.service';
 import { resolvePlayerSyncEvent } from './player-sync-event.service';
 
-export async function syncCurrentPlayerStats(options?: {
-  onTargetEventResolved?: (eventId: EventId) => void;
-}): Promise<{
+export type PlayerStatsSyncDependencies = {
+  getBootstrap: () => ReturnType<typeof fplClient.getBootstrap>;
+  resolvePlayerSyncEvent: typeof resolvePlayerSyncEvent;
+};
+
+const defaultDependencies: PlayerStatsSyncDependencies = {
+  getBootstrap: () => fplClient.getBootstrap(),
+  resolvePlayerSyncEvent,
+};
+
+export async function syncCurrentPlayerStats(
+  options?: {
+    onTargetEventResolved?: (eventId: EventId) => void;
+  },
+  dependencies: PlayerStatsSyncDependencies = defaultDependencies,
+): Promise<{
   count: number;
   eventId: EventId;
   errors: number;
@@ -27,17 +40,19 @@ export async function syncCurrentPlayerStats(options?: {
 }> {
   logInfo('Starting player stats sync for current gameweek');
 
-  const fplData = await fplClient.getBootstrap();
-
-  if (!Array.isArray(fplData.elements)) {
-    throw new Error('Invalid player elements data from FPL API');
-  }
-
-  const syncEvent = await resolvePlayerSyncEvent();
+  // Resolve and publish the target before the fallible upstream request. This
+  // keeps failed unscoped attempts traceable to the affected gameweek.
+  const syncEvent = await dependencies.resolvePlayerSyncEvent();
   if (!syncEvent) {
     throw new Error('No current or next event found for player stats');
   }
   options?.onTargetEventResolved?.(syncEvent.event.id);
+
+  const fplData = await dependencies.getBootstrap();
+
+  if (!Array.isArray(fplData.elements)) {
+    throw new Error('Invalid player elements data from FPL API');
+  }
 
   if (fplData.elements.length === 0) {
     throw new Error('No player stats returned from FPL API');

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -158,6 +158,7 @@ function enrichStoredRows(
 export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencies) {
   return async function syncForDate(
     changeDate: string = formatCronDateKey(),
+    options?: { onTargetEventResolved?: (eventId: number) => void },
   ): Promise<{ count: number; eventId?: number }> {
     logInfo('Starting daily player values sync');
 
@@ -181,6 +182,7 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
     if (!syncEvent) {
       throw new Error('No current or next event found for player values');
     }
+    options?.onTargetEventResolved?.(syncEvent.event.id);
 
     if (!Array.isArray(bootstrapData.elements) || bootstrapData.elements.length === 0) {
       throw new Error('No player values returned from FPL API');

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -159,7 +159,7 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
   return async function syncForDate(
     changeDate: string = formatCronDateKey(),
     options?: { onTargetEventResolved?: (eventId: number) => void },
-  ): Promise<{ count: number; eventId?: number }> {
+  ): Promise<{ count: number; eventId?: number; outcome?: 'noop' }> {
     logInfo('Starting daily player values sync');
 
     if (!/^\d{8}$/.test(changeDate)) {
@@ -172,7 +172,7 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
         changeDate,
         currentChangeDate,
       });
-      return { count: 0 };
+      return { count: 0, outcome: 'noop' };
     }
 
     const [bootstrapData, syncEvent] = await Promise.all([

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -158,7 +158,7 @@ function enrichStoredRows(
 export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencies) {
   return async function syncForDate(
     changeDate: string = formatCronDateKey(),
-  ): Promise<{ count: number }> {
+  ): Promise<{ count: number; eventId?: number }> {
     logInfo('Starting daily player values sync');
 
     if (!/^\d{8}$/.test(changeDate)) {
@@ -206,7 +206,7 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
 
     if (playersWithChanges.length === 0 && todaysRecords.length === 0) {
       logInfo('No player price changes detected; preserving database and cache', { changeDate });
-      return { count: 0 };
+      return { count: 0, eventId: syncEvent.event.id };
     }
 
     const teams = await dependencies.loadTeamsBasicInfo();
@@ -321,7 +321,7 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
       recordsInserted: result.count,
     });
 
-    return { count: result.count };
+    return { count: result.count, eventId: syncEvent.event.id };
   };
 }
 

--- a/src/services/player-values.service.ts
+++ b/src/services/player-values.service.ts
@@ -175,14 +175,16 @@ export function createPlayerValuesSync(dependencies: PlayerValuesSyncDependencie
       return { count: 0, outcome: 'noop' };
     }
 
-    const [bootstrapData, syncEvent] = await Promise.all([
-      dependencies.getBootstrap(),
-      dependencies.resolvePlayerSyncEvent(),
-    ]);
+    // Resolve and report the target before the fallible bootstrap request. A
+    // bootstrap outage must still leave the attempt correlated to the event
+    // that was selected for this date.
+    const syncEvent = await dependencies.resolvePlayerSyncEvent();
     if (!syncEvent) {
       throw new Error('No current or next event found for player values');
     }
     options?.onTargetEventResolved?.(syncEvent.event.id);
+
+    const bootstrapData = await dependencies.getBootstrap();
 
     if (!Array.isArray(bootstrapData.elements) || bootstrapData.elements.length === 0) {
       throw new Error('No player values returned from FPL API');

--- a/src/utils/data-sync-attempt.ts
+++ b/src/utils/data-sync-attempt.ts
@@ -10,7 +10,13 @@ import { logInfo } from './logger';
 export const DATA_SYNC_ATTEMPT_OUTCOMES = ['ready', 'partial', 'failed', 'noop'] as const;
 export type DataSyncAttemptOutcome = (typeof DATA_SYNC_ATTEMPT_OUTCOMES)[number];
 
-export type DataSyncAttemptSource = 'cron' | 'manual' | 'retry' | 'watchdog' | 'coordinator';
+export type DataSyncAttemptSource =
+  | 'cron'
+  | 'manual'
+  | 'api'
+  | 'retry'
+  | 'watchdog'
+  | 'coordinator';
 
 export interface DataSyncAttemptContext {
   queue: string;
@@ -159,6 +165,7 @@ export function inferDataSyncWorkSummary(result: unknown): DataSyncWorkSummary {
 function normalizeSource(context: DataSyncAttemptContext): DataSyncAttemptSource {
   if ((context.attempt ?? 1) > 1 || context.source === 'retry') return 'retry';
   if (context.source === 'cron') return 'cron';
+  if (context.source === 'api') return 'api';
   if (context.source === 'watchdog') return 'watchdog';
   if (context.source === 'cascade' || context.source === 'event-transition') return 'coordinator';
   if (context.source === 'coordinator') return 'coordinator';
@@ -188,9 +195,13 @@ export async function runDataSyncAttempt<T>(
     const startedAt = performance.now();
     let summary: DataSyncWorkSummary = {};
     let outcome: DataSyncAttemptOutcome = 'failed';
+    let targetEventId = context.targetEventId;
 
     try {
       const result = await runner();
+      if (targetEventId === undefined && isRecord(result)) {
+        targetEventId = firstBoundedUnit(result.eventId);
+      }
       summary = options.summarize?.(result) ?? inferDataSyncWorkSummary(result);
       outcome = resolveOutcome(summary);
       return result;
@@ -202,7 +213,7 @@ export async function runDataSyncAttempt<T>(
         jobName: context.jobName,
         runId: context.runId,
         source: normalizeSource(context),
-        ...(context.targetEventId !== undefined ? { targetEventId: context.targetEventId } : {}),
+        ...(targetEventId !== undefined ? { targetEventId } : {}),
         outcome,
         queueWaitMs: Math.max(0, Math.floor(context.queueWaitMs ?? 0)),
         durationMs: Math.max(0, Math.round(performance.now() - startedAt)),

--- a/src/utils/data-sync-attempt.ts
+++ b/src/utils/data-sync-attempt.ts
@@ -43,6 +43,21 @@ export function resolveDataSyncAttempt(
   };
 }
 
+export function resolveBullMqAttemptQueueWaitMs(
+  timing: { timestamp: number; processedOn?: number; attemptsMade: number },
+  now = Date.now(),
+): number {
+  const processedOn = timing.processedOn ?? now;
+  if (timing.attemptsMade === 0) {
+    return Math.max(0, Math.floor(processedOn - timing.timestamp));
+  }
+
+  // BullMQ retains the original job timestamp across automatic retries and
+  // does not expose a new queued-at timestamp. Use this attempt's activation
+  // time so retry reports never include earlier execution and backoff time.
+  return Math.max(0, Math.floor(now - processedOn));
+}
+
 export interface DataSyncAttemptReport {
   event: 'data_sync_attempt';
   schemaVersion: 1;
@@ -101,6 +116,7 @@ export function inferDataSyncWorkSummary(result: unknown): DataSyncWorkSummary {
   );
   const explicitSucceededUnits = firstBoundedUnit(
     result.succeededUnits,
+    result.enqueued,
     result.synced,
     result.updated,
     result.upserted,

--- a/src/utils/data-sync-attempt.ts
+++ b/src/utils/data-sync-attempt.ts
@@ -44,12 +44,13 @@ export function resolveDataSyncAttempt(
 }
 
 export function resolveBullMqAttemptQueueWaitMs(
-  timing: { timestamp: number; processedOn?: number; attemptsMade: number },
+  timing: { timestamp: number; processedOn?: number; attemptsMade: number; delay?: number },
   now = Date.now(),
 ): number {
   const processedOn = timing.processedOn ?? now;
   if (timing.attemptsMade === 0) {
-    return Math.max(0, Math.floor(processedOn - timing.timestamp));
+    const scheduledDelay = Math.max(0, Math.floor(timing.delay ?? 0));
+    return Math.max(0, Math.floor(processedOn - timing.timestamp - scheduledDelay));
   }
 
   // BullMQ retains the original job timestamp across automatic retries and

--- a/src/utils/data-sync-attempt.ts
+++ b/src/utils/data-sync-attempt.ts
@@ -199,6 +199,10 @@ export async function runDataSyncAttempt<T>(
 
     try {
       const result = await runner();
+      // Some unscoped workers resolve their canonical event inside the runner
+      // immediately before taking mutation locks. The context is shared by
+      // reference, so adopt that resolution before falling back to the result.
+      targetEventId ??= context.targetEventId;
       if (targetEventId === undefined && isRecord(result)) {
         targetEventId = firstBoundedUnit(result.eventId);
       }
@@ -206,6 +210,9 @@ export async function runDataSyncAttempt<T>(
       outcome = resolveOutcome(summary);
       return result;
     } finally {
+      // Preserve the resolved target even when the runner fails after lookup;
+      // the failure report still needs to identify the bounded event unit.
+      targetEventId ??= context.targetEventId;
       const report: DataSyncAttemptReport = {
         event: 'data_sync_attempt',
         schemaVersion: 1,

--- a/src/utils/data-sync-attempt.ts
+++ b/src/utils/data-sync-attempt.ts
@@ -1,0 +1,149 @@
+import { performance } from 'node:perf_hooks';
+
+import {
+  getFplRequestMetricsSnapshot,
+  runWithFplRequestMetrics,
+  type FplRequestMetricsSnapshot,
+} from './fpl-request-metrics';
+import { logInfo } from './logger';
+
+export const DATA_SYNC_ATTEMPT_OUTCOMES = ['ready', 'partial', 'failed', 'noop'] as const;
+export type DataSyncAttemptOutcome = (typeof DATA_SYNC_ATTEMPT_OUTCOMES)[number];
+
+export type DataSyncAttemptSource = 'cron' | 'manual' | 'retry' | 'watchdog' | 'coordinator';
+
+export interface DataSyncAttemptContext {
+  queue: string;
+  jobName: string;
+  runId: string;
+  source?: string;
+  attempt?: number;
+  targetEventId?: number;
+  queueWaitMs?: number | null;
+}
+
+export interface DataSyncWorkSummary {
+  outcome?: DataSyncAttemptOutcome;
+  requiredUnits?: number;
+  reusedUnits?: number;
+  succeededUnits?: number;
+  failedUnits?: number;
+}
+
+export interface DataSyncAttemptReport {
+  event: 'data_sync_attempt';
+  schemaVersion: 1;
+  queue: string;
+  jobName: string;
+  runId: string;
+  source: DataSyncAttemptSource;
+  targetEventId?: number;
+  outcome: DataSyncAttemptOutcome;
+  queueWaitMs: number;
+  durationMs: number;
+  requiredUnits: number;
+  reusedUnits: number;
+  succeededUnits: number;
+  failedUnits: number;
+  fpl: FplRequestMetricsSnapshot;
+}
+
+type ReportOptions<T> = {
+  summarize?: (result: T) => DataSyncWorkSummary;
+  enabled?: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function boundedUnit(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function readOutcome(value: unknown): DataSyncAttemptOutcome | undefined {
+  return typeof value === 'string' &&
+    DATA_SYNC_ATTEMPT_OUTCOMES.includes(value as DataSyncAttemptOutcome)
+    ? (value as DataSyncAttemptOutcome)
+    : undefined;
+}
+
+export function inferDataSyncWorkSummary(result: unknown): DataSyncWorkSummary {
+  if (!isRecord(result)) return {};
+
+  const failedUnits = boundedUnit(result.failedUnits ?? result.failed ?? result.errors);
+  const requiredUnits = boundedUnit(result.requiredUnits ?? result.total);
+  const succeededUnits = boundedUnit(result.succeededUnits ?? result.success);
+  const reusedUnits = boundedUnit(result.reusedUnits);
+  const explicitOutcome = readOutcome(result.outcome);
+
+  return {
+    ...(explicitOutcome ? { outcome: explicitOutcome } : {}),
+    requiredUnits,
+    reusedUnits,
+    succeededUnits,
+    failedUnits,
+  };
+}
+
+function normalizeSource(context: DataSyncAttemptContext): DataSyncAttemptSource {
+  if ((context.attempt ?? 1) > 1 || context.source === 'retry') return 'retry';
+  if (context.source === 'cron') return 'cron';
+  if (context.source === 'watchdog') return 'watchdog';
+  if (context.source === 'cascade' || context.source === 'event-transition') return 'coordinator';
+  if (context.source === 'coordinator') return 'coordinator';
+  return 'manual';
+}
+
+function reportingEnabled(): boolean {
+  const value = process.env.DATA_SYNC_ATTEMPT_REPORTING_ENABLED;
+  return value === undefined || !['false', '0', 'off', 'no'].includes(value.toLowerCase());
+}
+
+function resolveOutcome(summary: DataSyncWorkSummary): DataSyncAttemptOutcome {
+  if (summary.outcome) return summary.outcome;
+  return boundedUnit(summary.failedUnits) > 0 ? 'partial' : 'ready';
+}
+
+export async function runDataSyncAttempt<T>(
+  context: DataSyncAttemptContext,
+  runner: () => Promise<T>,
+  options: ReportOptions<T> = {},
+): Promise<T> {
+  if (options.enabled === false || !reportingEnabled()) {
+    return runner();
+  }
+
+  return runWithFplRequestMetrics(async () => {
+    const startedAt = performance.now();
+    let summary: DataSyncWorkSummary = {};
+    let outcome: DataSyncAttemptOutcome = 'failed';
+
+    try {
+      const result = await runner();
+      summary = options.summarize?.(result) ?? inferDataSyncWorkSummary(result);
+      outcome = resolveOutcome(summary);
+      return result;
+    } finally {
+      const report: DataSyncAttemptReport = {
+        event: 'data_sync_attempt',
+        schemaVersion: 1,
+        queue: context.queue,
+        jobName: context.jobName,
+        runId: context.runId,
+        source: normalizeSource(context),
+        ...(context.targetEventId !== undefined ? { targetEventId: context.targetEventId } : {}),
+        outcome,
+        queueWaitMs: Math.max(0, Math.floor(context.queueWaitMs ?? 0)),
+        durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
+        requiredUnits: boundedUnit(summary.requiredUnits),
+        reusedUnits: boundedUnit(summary.reusedUnits),
+        succeededUnits: boundedUnit(summary.succeededUnits),
+        failedUnits: boundedUnit(summary.failedUnits),
+        fpl: getFplRequestMetricsSnapshot(),
+      };
+
+      logInfo('Data sync attempt', report);
+    }
+  });
+}

--- a/src/utils/data-sync-attempt.ts
+++ b/src/utils/data-sync-attempt.ts
@@ -43,9 +43,10 @@ export function resolveDataSyncAttempt(
 ): { attempt: number; source: string | undefined } {
   const boundedAttemptsMade = Math.max(0, Math.floor(attemptsMade));
   const boundedRetryCount = Math.max(0, Math.floor(retryCount));
+  const attempt = boundedRetryCount + boundedAttemptsMade + 1;
   return {
-    attempt: Math.max(boundedAttemptsMade + 1, boundedRetryCount + 1),
-    source: boundedRetryCount > 0 ? 'retry' : source,
+    attempt,
+    source: attempt > 1 ? 'retry' : source,
   };
 }
 
@@ -72,6 +73,7 @@ export interface DataSyncAttemptReport {
   jobName: string;
   runId: string;
   source: DataSyncAttemptSource;
+  attempt: number;
   targetEventId?: number;
   outcome: DataSyncAttemptOutcome;
   queueWaitMs: number;
@@ -94,6 +96,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function boundedUnit(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function boundedAttempt(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 1 ? Math.floor(value) : 1;
 }
 
 function firstBoundedUnit(...values: unknown[]): number | undefined {
@@ -163,7 +169,7 @@ export function inferDataSyncWorkSummary(result: unknown): DataSyncWorkSummary {
 }
 
 function normalizeSource(context: DataSyncAttemptContext): DataSyncAttemptSource {
-  if ((context.attempt ?? 1) > 1 || context.source === 'retry') return 'retry';
+  if (boundedAttempt(context.attempt) > 1 || context.source === 'retry') return 'retry';
   if (context.source === 'cron') return 'cron';
   if (context.source === 'api') return 'api';
   if (context.source === 'watchdog') return 'watchdog';
@@ -220,6 +226,7 @@ export async function runDataSyncAttempt<T>(
         jobName: context.jobName,
         runId: context.runId,
         source: normalizeSource(context),
+        attempt: boundedAttempt(context.attempt),
         ...(targetEventId !== undefined ? { targetEventId } : {}),
         outcome,
         queueWaitMs: Math.max(0, Math.floor(context.queueWaitMs ?? 0)),

--- a/src/utils/data-sync-attempt.ts
+++ b/src/utils/data-sync-attempt.ts
@@ -30,6 +30,19 @@ export interface DataSyncWorkSummary {
   failedUnits?: number;
 }
 
+export function resolveDataSyncAttempt(
+  source: string | undefined,
+  attemptsMade: number,
+  retryCount = 0,
+): { attempt: number; source: string | undefined } {
+  const boundedAttemptsMade = Math.max(0, Math.floor(attemptsMade));
+  const boundedRetryCount = Math.max(0, Math.floor(retryCount));
+  return {
+    attempt: Math.max(boundedAttemptsMade + 1, boundedRetryCount + 1),
+    source: boundedRetryCount > 0 ? 'retry' : source,
+  };
+}
+
 export interface DataSyncAttemptReport {
   event: 'data_sync_attempt';
   schemaVersion: 1;
@@ -61,6 +74,15 @@ function boundedUnit(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
 
+function firstBoundedUnit(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      return Math.floor(value);
+    }
+  }
+  return undefined;
+}
+
 function readOutcome(value: unknown): DataSyncAttemptOutcome | undefined {
   return typeof value === 'string' &&
     DATA_SYNC_ATTEMPT_OUTCOMES.includes(value as DataSyncAttemptOutcome)
@@ -71,10 +93,41 @@ function readOutcome(value: unknown): DataSyncAttemptOutcome | undefined {
 export function inferDataSyncWorkSummary(result: unknown): DataSyncWorkSummary {
   if (!isRecord(result)) return {};
 
-  const failedUnits = boundedUnit(result.failedUnits ?? result.failed ?? result.errors);
-  const requiredUnits = boundedUnit(result.requiredUnits ?? result.total);
-  const succeededUnits = boundedUnit(result.succeededUnits ?? result.success);
-  const reusedUnits = boundedUnit(result.reusedUnits);
+  const explicitRequiredUnits = firstBoundedUnit(
+    result.requiredUnits,
+    result.totalEntries,
+    result.sourceEntries,
+    result.total,
+  );
+  const explicitSucceededUnits = firstBoundedUnit(
+    result.succeededUnits,
+    result.synced,
+    result.updated,
+    result.upserted,
+    result.inserted,
+    result.success,
+    result.count,
+    result.totalCount,
+  );
+  const explicitFailedUnits = firstBoundedUnit(
+    result.failedUnits,
+    result.failed,
+    result.errors,
+    result.totalErrors,
+  );
+  const reusedUnits = firstBoundedUnit(result.reusedUnits, result.skipped) ?? 0;
+  const failedUnits =
+    explicitFailedUnits ??
+    (explicitRequiredUnits !== undefined && explicitSucceededUnits !== undefined
+      ? Math.max(0, explicitRequiredUnits - explicitSucceededUnits - reusedUnits)
+      : 0);
+  const succeededUnits =
+    explicitSucceededUnits ??
+    (explicitRequiredUnits !== undefined
+      ? Math.max(0, explicitRequiredUnits - reusedUnits - failedUnits)
+      : 0);
+  const requiredUnits =
+    explicitRequiredUnits ?? Math.max(0, succeededUnits + reusedUnits + failedUnits);
   const explicitOutcome = readOutcome(result.outcome);
 
   return {

--- a/src/utils/fpl-request-metrics.ts
+++ b/src/utils/fpl-request-metrics.ts
@@ -66,6 +66,10 @@ function cloneMetrics(metrics: MutableFplRequestMetrics): FplRequestMetricsSnaps
 }
 
 export async function runWithFplRequestMetrics<T>(runner: () => Promise<T>): Promise<T> {
+  if (requestMetricsStore.getStore()) {
+    return runner();
+  }
+
   const metrics = createEmptyFplRequestMetrics();
   return requestMetricsStore.run(metrics, runner);
 }

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -2,14 +2,16 @@ import type { Job } from 'bullmq';
 import { getConfig } from './config';
 import { logError, logInfo, logWarn } from './logger';
 
-export async function sendTelegramMessage(message: string): Promise<void> {
+export type NotificationDeliveryResult = 'sent' | 'skipped';
+
+export async function sendTelegramMessage(message: string): Promise<NotificationDeliveryResult> {
   const config = getConfig();
   const token = config.TELEGRAM_BOT_TOKEN;
   const chatId = config.TELEGRAM_CHAT_ID;
 
   if (!token || !chatId) {
     logWarn('Telegram not configured — skipping notification', { message });
-    return;
+    return 'skipped';
   }
 
   const url = `https://api.telegram.org/bot${token}/sendMessage`;
@@ -26,6 +28,7 @@ export async function sendTelegramMessage(message: string): Promise<void> {
     }
 
     logInfo('Telegram notification sent', { messageLength: message.length });
+    return 'sent';
   } catch (error) {
     logError('Failed to send Telegram notification', error, { messageLength: message.length });
     throw error;

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -4,6 +4,17 @@ import { logError, logInfo, logWarn } from './logger';
 
 export type NotificationDeliveryResult = 'sent' | 'skipped';
 
+/** The provider answered with a definite rejection; no message was accepted. */
+export class NotificationDeliveryRejectedError extends Error {
+  readonly status: number;
+
+  constructor(status: number, statusText: string) {
+    super(`Telegram API error: ${status} ${statusText}`);
+    this.name = 'NotificationDeliveryRejectedError';
+    this.status = status;
+  }
+}
+
 export async function sendTelegramMessage(message: string): Promise<NotificationDeliveryResult> {
   const config = getConfig();
   const token = config.TELEGRAM_BOT_TOKEN;
@@ -24,7 +35,7 @@ export async function sendTelegramMessage(message: string): Promise<Notification
     });
 
     if (!response.ok) {
-      throw new Error(`Telegram API error: ${response.status} ${response.statusText}`);
+      throw new NotificationDeliveryRejectedError(response.status, response.statusText);
     }
 
     logInfo('Telegram notification sent', { messageLength: message.length });

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -14,6 +14,7 @@ import { syncPlayers } from '../services/players.service';
 import { syncPlayerPricesForDate } from '../services/player-prices.service';
 import { syncCurrentPlayerStats, syncPlayerStatsForEvent } from '../services/player-stats.service';
 import { syncCurrentPlayerValues } from '../services/player-values.service';
+import { runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { syncTeams } from '../services/teams.service';
 import { getQueueConnection } from '../utils/queue';
@@ -32,49 +33,62 @@ const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
     jobName: job.name,
     source: job.data?.source as string | undefined,
     attempt: job.attemptsMade + 1,
+    queueWaitMs: Math.max(0, Date.now() - job.timestamp),
   };
 
   logJobTriggered(context);
 
-  return withMutationConflictGuard(
+  return runDataSyncAttempt(
     {
-      queueName: job.queueName,
+      queue: job.queueName,
       jobName: job.name,
-      jobId: String(job.id),
+      runId: String(job.id ?? `${job.name}-${job.timestamp}`),
+      source: job.data?.source,
+      attempt: job.attemptsMade + 1,
+      targetEventId: job.data?.eventId,
+      queueWaitMs: context.queueWaitMs,
     },
     () =>
-      runTrackedJob(context, async () => {
-        switch (job.name) {
-          case 'events':
-            return syncEvents();
-          case 'fixtures':
-            return syncFixtures(job.data.eventId);
-          case 'fixtures-all-gameweeks':
-            // Per-GW loop with isolated errors — not the same as syncFixtures(undefined).
-            return syncAllGameweeks();
-          case 'teams':
-            return syncTeams();
-          case 'players':
-            return syncPlayers();
-          case 'player-prices':
-            if (!job.data.changeDate) {
-              throw new Error('player-prices job requires changeDate');
+      withMutationConflictGuard(
+        {
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId: String(job.id),
+        },
+        () =>
+          runTrackedJob(context, async () => {
+            switch (job.name) {
+              case 'events':
+                return syncEvents();
+              case 'fixtures':
+                return syncFixtures(job.data.eventId);
+              case 'fixtures-all-gameweeks':
+                // Per-GW loop with isolated errors — not the same as syncFixtures(undefined).
+                return syncAllGameweeks();
+              case 'teams':
+                return syncTeams();
+              case 'players':
+                return syncPlayers();
+              case 'player-prices':
+                if (!job.data.changeDate) {
+                  throw new Error('player-prices job requires changeDate');
+                }
+                return syncPlayerPricesForDate(job.data.changeDate);
+              case 'player-stats':
+                return job.data.eventId !== undefined
+                  ? syncPlayerStatsForEvent(job.data.eventId)
+                  : syncCurrentPlayerStats();
+              case 'phases':
+                return syncPhases();
+              case 'player-values':
+                return syncCurrentPlayerValues(
+                  job.data.changeDate ?? formatCronDateKey(new Date(job.data.triggeredAt)),
+                );
+              default:
+                throw new Error(`Unknown data-sync job: ${job.name}`);
             }
-            return syncPlayerPricesForDate(job.data.changeDate);
-          case 'player-stats':
-            return job.data.eventId !== undefined
-              ? syncPlayerStatsForEvent(job.data.eventId)
-              : syncCurrentPlayerStats();
-          case 'phases':
-            return syncPhases();
-          case 'player-values':
-            return syncCurrentPlayerValues(
-              job.data.changeDate ?? formatCronDateKey(new Date(job.data.triggeredAt)),
-            );
-          default:
-            throw new Error(`Unknown data-sync job: ${job.name}`);
-        }
-      }),
+          }),
+      ),
   );
 };
 
@@ -99,7 +113,7 @@ export function createDataSyncWorker(): WorkerRuntime {
       logInfo('Data sync job completed', { jobId: job.id, name: job.name, tier });
     });
 
-    worker.on('failed', async (job, error) => {
+    worker.on('failed', (job, error) => {
       logError('Data sync job failed', error, {
         jobId: job?.id,
         name: job?.name,
@@ -108,16 +122,6 @@ export function createDataSyncWorker(): WorkerRuntime {
       });
       if (job) {
         void alertOnFinalFailure(job, error);
-      }
-
-      // Same-day player-values ticks should not be blocked by a transient failure.
-      if (job && job.name === 'player-values' && job.attemptsMade < 3) {
-        try {
-          await job.retry();
-          logInfo('Retried failed player-values job', { jobId: job.id, attempt: job.attemptsMade });
-        } catch (retryError) {
-          logError('Failed to retry player-values job', retryError, { jobId: job.id });
-        }
       }
     });
 

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -42,7 +42,7 @@ const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
     {
       queue: job.queueName,
       jobName: job.name,
-      runId: String(job.id ?? `${job.name}-${job.timestamp}`),
+      runId: job.data?.runId ?? String(job.id ?? `${job.name}-${job.timestamp}`),
       source: job.data?.source,
       attempt: job.attemptsMade + 1,
       targetEventId: job.data?.eventId,

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -14,7 +14,11 @@ import { syncPlayers } from '../services/players.service';
 import { syncPlayerPricesForDate } from '../services/player-prices.service';
 import { syncCurrentPlayerStats, syncPlayerStatsForEvent } from '../services/player-stats.service';
 import { syncCurrentPlayerValues } from '../services/player-values.service';
-import { resolveBullMqAttemptQueueWaitMs, runDataSyncAttempt } from '../utils/data-sync-attempt';
+import {
+  resolveBullMqAttemptQueueWaitMs,
+  runDataSyncAttempt,
+  type DataSyncAttemptContext,
+} from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { syncTeams } from '../services/teams.service';
 import { getQueueConnection } from '../utils/queue';
@@ -35,60 +39,63 @@ const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
     attempt: job.attemptsMade + 1,
     queueWaitMs: resolveBullMqAttemptQueueWaitMs(job),
   };
+  const attemptContext: DataSyncAttemptContext = {
+    queue: job.queueName,
+    jobName: job.name,
+    runId: job.data?.runId ?? String(job.id ?? `${job.name}-${job.timestamp}`),
+    source: job.data?.source,
+    attempt: job.attemptsMade + 1,
+    targetEventId: job.data?.eventId,
+    queueWaitMs: context.queueWaitMs,
+  };
+  const recordResolvedTarget = (eventId: number) => {
+    attemptContext.targetEventId = eventId;
+  };
 
   logJobTriggered(context);
 
-  return runDataSyncAttempt(
-    {
-      queue: job.queueName,
-      jobName: job.name,
-      runId: job.data?.runId ?? String(job.id ?? `${job.name}-${job.timestamp}`),
-      source: job.data?.source,
-      attempt: job.attemptsMade + 1,
-      targetEventId: job.data?.eventId,
-      queueWaitMs: context.queueWaitMs,
-    },
-    () =>
-      withMutationConflictGuard(
-        {
-          queueName: job.queueName,
-          jobName: job.name,
-          jobId: String(job.id),
-        },
-        () =>
-          runTrackedJob(context, async () => {
-            switch (job.name) {
-              case 'events':
-                return syncEvents();
-              case 'fixtures':
-                return syncFixtures(job.data.eventId);
-              case 'fixtures-all-gameweeks':
-                // Per-GW loop with isolated errors — not the same as syncFixtures(undefined).
-                return syncAllGameweeks();
-              case 'teams':
-                return syncTeams();
-              case 'players':
-                return syncPlayers();
-              case 'player-prices':
-                if (!job.data.changeDate) {
-                  throw new Error('player-prices job requires changeDate');
-                }
-                return syncPlayerPricesForDate(job.data.changeDate);
-              case 'player-stats':
-                return job.data.eventId !== undefined
-                  ? syncPlayerStatsForEvent(job.data.eventId)
-                  : syncCurrentPlayerStats();
-              case 'phases':
-                return syncPhases();
-              case 'player-values':
-                return syncCurrentPlayerValues(
-                  job.data.changeDate ?? formatCronDateKey(new Date(job.data.triggeredAt)),
-                );
-              default:
-                throw new Error(`Unknown data-sync job: ${job.name}`);
-            }
-          }),
-      ),
+  return runDataSyncAttempt(attemptContext, () =>
+    withMutationConflictGuard(
+      {
+        queueName: job.queueName,
+        jobName: job.name,
+        jobId: String(job.id),
+      },
+      () =>
+        runTrackedJob(context, async () => {
+          switch (job.name) {
+            case 'events':
+              return syncEvents();
+            case 'fixtures':
+              return syncFixtures(job.data.eventId);
+            case 'fixtures-all-gameweeks':
+              // Per-GW loop with isolated errors — not the same as syncFixtures(undefined).
+              return syncAllGameweeks();
+            case 'teams':
+              return syncTeams();
+            case 'players':
+              return syncPlayers();
+            case 'player-prices':
+              if (!job.data.changeDate) {
+                throw new Error('player-prices job requires changeDate');
+              }
+              return syncPlayerPricesForDate(job.data.changeDate);
+            case 'player-stats':
+              return job.data.eventId !== undefined
+                ? syncPlayerStatsForEvent(job.data.eventId)
+                : syncCurrentPlayerStats({ onTargetEventResolved: recordResolvedTarget });
+            case 'phases':
+              return syncPhases();
+            case 'player-values':
+              return syncCurrentPlayerValues(
+                job.data.changeDate ?? formatCronDateKey(new Date(job.data.triggeredAt)),
+                { onTargetEventResolved: recordResolvedTarget },
+              );
+            default:
+              throw new Error(`Unknown data-sync job: ${job.name}`);
+          }
+        }),
+    ),
   );
 };
 

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -14,7 +14,7 @@ import { syncPlayers } from '../services/players.service';
 import { syncPlayerPricesForDate } from '../services/player-prices.service';
 import { syncCurrentPlayerStats, syncPlayerStatsForEvent } from '../services/player-stats.service';
 import { syncCurrentPlayerValues } from '../services/player-values.service';
-import { runDataSyncAttempt } from '../utils/data-sync-attempt';
+import { resolveBullMqAttemptQueueWaitMs, runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { syncTeams } from '../services/teams.service';
 import { getQueueConnection } from '../utils/queue';
@@ -33,7 +33,7 @@ const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
     jobName: job.name,
     source: job.data?.source as string | undefined,
     attempt: job.attemptsMade + 1,
-    queueWaitMs: Math.max(0, Date.now() - job.timestamp),
+    queueWaitMs: resolveBullMqAttemptQueueWaitMs(job),
   };
 
   logJobTriggered(context);

--- a/src/workers/entry-sync.worker.ts
+++ b/src/workers/entry-sync.worker.ts
@@ -32,6 +32,7 @@ import {
   markEntryInfoSyncedToday,
   shouldMarkEntryInfoSynced,
 } from '../jobs/entry-info-sync-marker';
+import { runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
 import { alertOnFinalFailure } from '../utils/notify';
@@ -259,59 +260,72 @@ export function createEntrySyncWorker(): WorkerRuntime {
       source: job.data?.source as string | undefined,
       eventId: job.data?.eventId,
       attempt: job.attemptsMade + 1,
+      queueWaitMs: Math.max(0, Date.now() - job.timestamp),
     };
 
     logJobTriggered(context);
 
-    return withMutationConflictGuard(
+    return runDataSyncAttempt(
       {
-        queueName: job.queueName,
+        queue: job.queueName,
         jobName: job.name,
-        jobId,
-        eventId: job.data?.eventId,
+        runId: job.data?.runId ?? String(jobId),
+        source: job.data?.source,
+        attempt: job.attemptsMade + 1,
+        targetEventId: job.data?.eventId,
+        queueWaitMs: context.queueWaitMs,
       },
       () =>
-        runTrackedJob(context, async () => {
-          switch (job.name) {
-            case 'entry-info': {
-              const result = await handleEntryJob(
-                'entry-info',
-                'entry info sync',
-                syncEntryInfo,
-                job.data,
-              );
-              // Mark only after the final chunk succeeds with zero failures so
-              // mid-chunk crashes and pending retries can still re-run same day.
-              if (shouldMarkEntryInfoSynced(result.hasMore, result.failed)) {
-                await markEntryInfoSyncedToday(new Date(), job.id);
+        withMutationConflictGuard(
+          {
+            queueName: job.queueName,
+            jobName: job.name,
+            jobId,
+            eventId: job.data?.eventId,
+          },
+          () =>
+            runTrackedJob(context, async () => {
+              switch (job.name) {
+                case 'entry-info': {
+                  const result = await handleEntryJob(
+                    'entry-info',
+                    'entry info sync',
+                    syncEntryInfo,
+                    job.data,
+                  );
+                  // Mark only after the final chunk succeeds with zero failures so
+                  // mid-chunk crashes and pending retries can still re-run same day.
+                  if (shouldMarkEntryInfoSynced(result.hasMore, result.failed)) {
+                    await markEntryInfoSyncedToday(new Date(), job.id);
+                  }
+                  return result;
+                }
+                case 'entry-picks':
+                  return handleEntryJob(
+                    'entry-picks',
+                    'entry picks sync',
+                    (entryId) => syncEntryEventPicks(entryId, job.data?.eventId),
+                    job.data,
+                  );
+                case 'entry-transfers':
+                  return handleEntryJob(
+                    'entry-transfers',
+                    'entry transfers sync',
+                    (entryId) => syncEntryEventTransfers(entryId, job.data?.eventId),
+                    job.data,
+                  );
+                case 'entry-results':
+                  return handleEntryJob(
+                    'entry-results',
+                    'entry results sync',
+                    (entryId) => syncEntryEventResults(entryId, job.data?.eventId),
+                    job.data,
+                  );
+                default:
+                  throw new Error(`Unknown entry-sync job: ${job.name}`);
               }
-              return result;
-            }
-            case 'entry-picks':
-              return handleEntryJob(
-                'entry-picks',
-                'entry picks sync',
-                (entryId) => syncEntryEventPicks(entryId, job.data?.eventId),
-                job.data,
-              );
-            case 'entry-transfers':
-              return handleEntryJob(
-                'entry-transfers',
-                'entry transfers sync',
-                (entryId) => syncEntryEventTransfers(entryId, job.data?.eventId),
-                job.data,
-              );
-            case 'entry-results':
-              return handleEntryJob(
-                'entry-results',
-                'entry results sync',
-                (entryId) => syncEntryEventResults(entryId, job.data?.eventId),
-                job.data,
-              );
-            default:
-              throw new Error(`Unknown entry-sync job: ${job.name}`);
-          }
-        }),
+            }),
+        ),
     );
   };
 

--- a/src/workers/entry-sync.worker.ts
+++ b/src/workers/entry-sync.worker.ts
@@ -32,7 +32,11 @@ import {
   markEntryInfoSyncedToday,
   shouldMarkEntryInfoSynced,
 } from '../jobs/entry-info-sync-marker';
-import { resolveDataSyncAttempt, runDataSyncAttempt } from '../utils/data-sync-attempt';
+import {
+  resolveBullMqAttemptQueueWaitMs,
+  resolveDataSyncAttempt,
+  runDataSyncAttempt,
+} from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
 import { alertOnFinalFailure } from '../utils/notify';
@@ -193,7 +197,14 @@ async function handleEntryJob(
       jobName,
       chunkOffset: loaded.chunkOffset,
     });
-    return { total: 0, success: 0, failed: 0, failedIds: [] as number[], hasMore: false };
+    return {
+      total: 0,
+      success: 0,
+      failed: 0,
+      failedIds: [] as number[],
+      hasMore: false,
+      fetchedFromDb: loaded.fetchedFromDb,
+    };
   }
 
   const concurrency = jobData?.concurrency ?? ENTRY_SYNC_DEFAULT_CONCURRENCY;
@@ -240,7 +251,7 @@ async function handleEntryJob(
     }
   }
 
-  return { ...result, hasMore: loaded.hasMore };
+  return { ...result, hasMore: loaded.hasMore, fetchedFromDb: loaded.fetchedFromDb };
 }
 
 export function createEntrySyncWorker(): WorkerRuntime {
@@ -265,7 +276,7 @@ export function createEntrySyncWorker(): WorkerRuntime {
       source: attempt.source as string | undefined,
       eventId: job.data?.eventId,
       attempt: attempt.attempt,
-      queueWaitMs: Math.max(0, Date.now() - job.timestamp),
+      queueWaitMs: resolveBullMqAttemptQueueWaitMs(job),
     };
 
     logJobTriggered(context);
@@ -298,9 +309,11 @@ export function createEntrySyncWorker(): WorkerRuntime {
                     syncEntryInfo,
                     job.data,
                   );
-                  // Mark only after the final chunk succeeds with zero failures so
-                  // mid-chunk crashes and pending retries can still re-run same day.
-                  if (shouldMarkEntryInfoSynced(result.hasMore, result.failed)) {
+                  // Only a complete database scan can satisfy the daily marker;
+                  // targeted API and retry jobs must leave the full scan eligible.
+                  if (
+                    shouldMarkEntryInfoSynced(result.fetchedFromDb, result.hasMore, result.failed)
+                  ) {
                     await markEntryInfoSyncedToday(new Date(), job.id);
                   }
                   return result;

--- a/src/workers/entry-sync.worker.ts
+++ b/src/workers/entry-sync.worker.ts
@@ -2,6 +2,7 @@ import { QueueEvents, Worker, type Job } from 'bullmq';
 import { asc } from 'drizzle-orm';
 
 import { MUTATION_PRIORITY_ORDER, type MutationPriorityTier } from '../domain/job-priority';
+import { resolveEntrySyncTargetEventId } from '../domain/entry-sync';
 import { entryInfos } from '../db/schemas/index.schema';
 import { getDb } from '../db/singleton';
 import {
@@ -23,6 +24,7 @@ import {
   type EntrySyncJobOptions,
 } from '../jobs/entry-sync-enqueue';
 import { syncEntryInfo } from '../services/entry-info.service';
+import { getCurrentEvent } from '../services/events.service';
 import {
   syncEntryEventPicks,
   syncEntryEventResults,
@@ -36,6 +38,7 @@ import {
   resolveBullMqAttemptQueueWaitMs,
   resolveDataSyncAttempt,
   runDataSyncAttempt,
+  type DataSyncAttemptContext,
 } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
@@ -281,70 +284,80 @@ export function createEntrySyncWorker(): WorkerRuntime {
 
     logJobTriggered(context);
 
-    return runDataSyncAttempt(
-      {
-        queue: job.queueName,
-        jobName: job.name,
-        runId: job.data?.runId ?? String(jobId),
-        source: attempt.source,
-        attempt: attempt.attempt,
-        targetEventId: job.data?.eventId,
-        queueWaitMs: context.queueWaitMs,
-      },
-      () =>
-        withMutationConflictGuard(
-          {
-            queueName: job.queueName,
-            jobName: job.name,
-            jobId,
-            eventId: job.data?.eventId,
-          },
-          () =>
-            runTrackedJob(context, async () => {
-              switch (job.name) {
-                case 'entry-info': {
-                  const result = await handleEntryJob(
-                    'entry-info',
-                    'entry info sync',
-                    syncEntryInfo,
-                    job.data,
-                  );
-                  // Only a complete database scan can satisfy the daily marker;
-                  // targeted API and retry jobs must leave the full scan eligible.
-                  if (
-                    shouldMarkEntryInfoSynced(result.fetchedFromDb, result.hasMore, result.failed)
-                  ) {
-                    await markEntryInfoSyncedToday(new Date(), job.id);
-                  }
-                  return result;
+    const attemptContext: DataSyncAttemptContext = {
+      queue: job.queueName,
+      jobName: job.name,
+      runId: job.data?.runId ?? String(jobId),
+      source: attempt.source,
+      attempt: attempt.attempt,
+      targetEventId: job.data?.eventId,
+      queueWaitMs: context.queueWaitMs,
+    };
+
+    return runDataSyncAttempt(attemptContext, async () => {
+      const targetEventId = await resolveEntrySyncTargetEventId(
+        job.name as EntrySyncJobName,
+        job.data?.eventId,
+        async () => (await getCurrentEvent())?.id ?? null,
+      );
+      const effectiveJobData =
+        targetEventId !== undefined ? { ...job.data, eventId: targetEventId } : job.data;
+      context.eventId = targetEventId;
+      attemptContext.targetEventId = targetEventId;
+
+      return withMutationConflictGuard(
+        {
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId,
+          eventId: targetEventId,
+        },
+        () =>
+          runTrackedJob(context, async () => {
+            switch (job.name) {
+              case 'entry-info': {
+                const result = await handleEntryJob(
+                  'entry-info',
+                  'entry info sync',
+                  syncEntryInfo,
+                  effectiveJobData,
+                );
+                // Only a complete database scan can satisfy the daily marker;
+                // targeted API and retry jobs must leave the full scan eligible.
+                if (
+                  shouldMarkEntryInfoSynced(result.fetchedFromDb, result.hasMore, result.failed)
+                ) {
+                  await markEntryInfoSyncedToday(new Date(), job.id);
                 }
-                case 'entry-picks':
-                  return handleEntryJob(
-                    'entry-picks',
-                    'entry picks sync',
-                    (entryId) => syncEntryEventPicks(entryId, job.data?.eventId),
-                    job.data,
-                  );
-                case 'entry-transfers':
-                  return handleEntryJob(
-                    'entry-transfers',
-                    'entry transfers sync',
-                    (entryId) => syncEntryEventTransfers(entryId, job.data?.eventId),
-                    job.data,
-                  );
-                case 'entry-results':
-                  return handleEntryJob(
-                    'entry-results',
-                    'entry results sync',
-                    (entryId) => syncEntryEventResults(entryId, job.data?.eventId),
-                    job.data,
-                  );
-                default:
-                  throw new Error(`Unknown entry-sync job: ${job.name}`);
+                return result;
               }
-            }),
-        ),
-    );
+              case 'entry-picks':
+                return handleEntryJob(
+                  'entry-picks',
+                  'entry picks sync',
+                  (entryId) => syncEntryEventPicks(entryId, targetEventId),
+                  effectiveJobData,
+                );
+              case 'entry-transfers':
+                return handleEntryJob(
+                  'entry-transfers',
+                  'entry transfers sync',
+                  (entryId) => syncEntryEventTransfers(entryId, targetEventId),
+                  effectiveJobData,
+                );
+              case 'entry-results':
+                return handleEntryJob(
+                  'entry-results',
+                  'entry results sync',
+                  (entryId) => syncEntryEventResults(entryId, targetEventId),
+                  effectiveJobData,
+                );
+              default:
+                throw new Error(`Unknown entry-sync job: ${job.name}`);
+            }
+          }),
+      );
+    });
   };
 
   for (const tier of activeTiers) {

--- a/src/workers/entry-sync.worker.ts
+++ b/src/workers/entry-sync.worker.ts
@@ -32,7 +32,7 @@ import {
   markEntryInfoSyncedToday,
   shouldMarkEntryInfoSynced,
 } from '../jobs/entry-info-sync-marker';
-import { runDataSyncAttempt } from '../utils/data-sync-attempt';
+import { resolveDataSyncAttempt, runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { logError, logInfo } from '../utils/logger';
 import { alertOnFinalFailure } from '../utils/notify';
@@ -252,14 +252,19 @@ export function createEntrySyncWorker(): WorkerRuntime {
 
   const processor = async (job: Job<EntrySyncJobData>) => {
     const jobId = job.id ?? `${job.name}-${job.timestamp}`;
+    const attempt = resolveDataSyncAttempt(
+      job.data?.source,
+      job.attemptsMade,
+      job.data?.retryCount,
+    );
     const context = {
       jobType: 'queue' as const,
       queueName: job.queueName,
       jobId,
       jobName: job.name,
-      source: job.data?.source as string | undefined,
+      source: attempt.source as string | undefined,
       eventId: job.data?.eventId,
-      attempt: job.attemptsMade + 1,
+      attempt: attempt.attempt,
       queueWaitMs: Math.max(0, Date.now() - job.timestamp),
     };
 
@@ -270,8 +275,8 @@ export function createEntrySyncWorker(): WorkerRuntime {
         queue: job.queueName,
         jobName: job.name,
         runId: job.data?.runId ?? String(jobId),
-        source: job.data?.source,
-        attempt: job.attemptsMade + 1,
+        source: attempt.source,
+        attempt: attempt.attempt,
         targetEventId: job.data?.eventId,
         queueWaitMs: context.queueWaitMs,
       },

--- a/src/workers/entry-sync.worker.ts
+++ b/src/workers/entry-sync.worker.ts
@@ -185,6 +185,7 @@ async function scheduleRetry(
     delayMs,
     eventId: jobData?.eventId,
     runId: jobData?.runId,
+    queueKey: jobData?.queueKey,
   });
 }
 
@@ -227,6 +228,7 @@ async function handleEntryJob(
       throttleMs,
       eventId: jobData?.eventId,
       runId: jobData?.runId,
+      queueKey: jobData?.queueKey,
     });
     logInfo('Entry sync next chunk enqueued', {
       jobName,

--- a/src/workers/league-sync.worker.ts
+++ b/src/workers/league-sync.worker.ts
@@ -30,6 +30,7 @@ import type { WorkerRuntime } from './worker-runtime';
  */
 async function processLeagueSyncJob(job: Job<LeagueSyncJobData>) {
   const { eventId, tournamentId, source } = job.data;
+  const runId = job.data.runId ?? String(job.id ?? `${job.name}-${job.timestamp}`);
   const context = {
     jobType: 'queue' as const,
     queueName: job.queueName,
@@ -48,7 +49,7 @@ async function processLeagueSyncJob(job: Job<LeagueSyncJobData>) {
     {
       queue: job.queueName,
       jobName: job.name,
-      runId: String(job.id ?? `${job.name}-${job.timestamp}`),
+      runId,
       source: tournamentId === undefined ? 'coordinator' : source,
       attempt: job.attemptsMade + 1,
       targetEventId: eventId,
@@ -67,10 +68,10 @@ async function processLeagueSyncJob(job: Job<LeagueSyncJobData>) {
           runTrackedJob(context, async () => {
             switch (job.name) {
               case LEAGUE_JOBS.LEAGUE_EVENT_PICKS:
-                return processLeagueEventPicksJob(eventId, tournamentId);
+                return processLeagueEventPicksJob(eventId, tournamentId, runId);
 
               case LEAGUE_JOBS.LEAGUE_EVENT_RESULTS:
-                return processLeagueEventResultsJob(eventId, tournamentId);
+                return processLeagueEventResultsJob(eventId, tournamentId, runId);
 
               default:
                 throw new Error(`Unknown job name: ${job.name}`);

--- a/src/workers/league-sync.worker.ts
+++ b/src/workers/league-sync.worker.ts
@@ -12,7 +12,7 @@ import {
   processLeagueEventPicksJob,
   processLeagueEventResultsJob,
 } from '../services/league-sync.service';
-import { runDataSyncAttempt } from '../utils/data-sync-attempt';
+import { resolveBullMqAttemptQueueWaitMs, runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
@@ -39,7 +39,7 @@ async function processLeagueSyncJob(job: Job<LeagueSyncJobData>) {
     source,
     attempt: job.attemptsMade + 1,
     tournamentId,
-    queueWaitMs: Math.max(0, Date.now() - job.timestamp),
+    queueWaitMs: resolveBullMqAttemptQueueWaitMs(job),
   };
 
   logJobTriggered(context);

--- a/src/workers/league-sync.worker.ts
+++ b/src/workers/league-sync.worker.ts
@@ -12,6 +12,7 @@ import {
   processLeagueEventPicksJob,
   processLeagueEventResultsJob,
 } from '../services/league-sync.service';
+import { runDataSyncAttempt } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
@@ -38,31 +39,44 @@ async function processLeagueSyncJob(job: Job<LeagueSyncJobData>) {
     source,
     attempt: job.attemptsMade + 1,
     tournamentId,
+    queueWaitMs: Math.max(0, Date.now() - job.timestamp),
   };
 
   logJobTriggered(context);
 
-  return withMutationConflictGuard(
+  return runDataSyncAttempt(
     {
-      queueName: job.queueName,
+      queue: job.queueName,
       jobName: job.name,
-      jobId: String(job.id),
-      eventId,
-      tournamentId,
+      runId: String(job.id ?? `${job.name}-${job.timestamp}`),
+      source: tournamentId === undefined ? 'coordinator' : source,
+      attempt: job.attemptsMade + 1,
+      targetEventId: eventId,
+      queueWaitMs: context.queueWaitMs,
     },
     () =>
-      runTrackedJob(context, async () => {
-        switch (job.name) {
-          case LEAGUE_JOBS.LEAGUE_EVENT_PICKS:
-            return processLeagueEventPicksJob(eventId, tournamentId);
+      withMutationConflictGuard(
+        {
+          queueName: job.queueName,
+          jobName: job.name,
+          jobId: String(job.id),
+          eventId,
+          tournamentId,
+        },
+        () =>
+          runTrackedJob(context, async () => {
+            switch (job.name) {
+              case LEAGUE_JOBS.LEAGUE_EVENT_PICKS:
+                return processLeagueEventPicksJob(eventId, tournamentId);
 
-          case LEAGUE_JOBS.LEAGUE_EVENT_RESULTS:
-            return processLeagueEventResultsJob(eventId, tournamentId);
+              case LEAGUE_JOBS.LEAGUE_EVENT_RESULTS:
+                return processLeagueEventResultsJob(eventId, tournamentId);
 
-          default:
-            throw new Error(`Unknown job name: ${job.name}`);
-        }
-      }),
+              default:
+                throw new Error(`Unknown job name: ${job.name}`);
+            }
+          }),
+      ),
   );
 }
 

--- a/src/workers/strict-priority-gate.ts
+++ b/src/workers/strict-priority-gate.ts
@@ -9,8 +9,8 @@ const DEFAULT_POLL_MS = 5_000;
 type GateWorkerSet<T> = Record<MutationPriorityTier, { queue: Queue<T>; worker: Worker<T> }>;
 
 async function getBacklogCount<T>(queue: Queue<T>): Promise<number> {
-  const counts = await queue.getJobCounts('waiting', 'delayed');
-  return (counts.waiting ?? 0) + (counts.delayed ?? 0);
+  const counts = await queue.getJobCounts('waiting', 'prioritized');
+  return (counts.waiting ?? 0) + (counts.prioritized ?? 0);
 }
 
 export function startStrictPriorityGate<T>(

--- a/tests/integration/fixtures.test.ts
+++ b/tests/integration/fixtures.test.ts
@@ -32,6 +32,40 @@ describe('Fixtures Integration Tests', () => {
     expect(rows.length).toBeGreaterThan(0);
   });
 
+  test('counts fixtures whose existing ownership is successfully cleared', async () => {
+    const originalGetFixtures = fplClient.getFixtures;
+    const fetchFixtures = originalGetFixtures.bind(fplClient);
+    const fullFixtureFeed = await fetchFixtures();
+    const assignedFixture = fullFixtureFeed.find((fixture) => fixture.event !== null);
+    if (!assignedFixture) throw new Error('FPL fixture feed contains no assigned fixture');
+
+    const correctedFeed = fullFixtureFeed.map((fixture) =>
+      fixture.id === assignedFixture.id ? { ...fixture, event: null } : fixture,
+    );
+    const correctedFixtures = correctedFeed.map(transformFixture);
+    const unscheduledIds = correctedFixtures
+      .filter((fixture) => fixture.event === null)
+      .map((fixture) => fixture.id);
+    const persistedUnscheduled = await fixtureRepository.findEventIdsByFixtureIds(unscheduledIds);
+    const expectedCount =
+      correctedFixtures.filter((fixture) => fixture.event !== null).length +
+      persistedUnscheduled.size;
+
+    try {
+      fplClient.getFixtures = async () => correctedFeed;
+
+      const result = await syncFixtures();
+
+      expect(result.count).toBe(expectedCount);
+      expect(result.count).toBeGreaterThan(
+        correctedFixtures.filter((fixture) => fixture.event !== null).length,
+      );
+    } finally {
+      fplClient.getFixtures = originalGetFixtures;
+      await syncFixtures();
+    }
+  }, 30000);
+
   test('should have valid fixture structure', async () => {
     const db = await getDb();
     const fixtures = await db.select().from(eventFixtures).limit(1);

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -46,6 +46,8 @@ const enqueueFixturesAllGameweeksSyncJob = mock(async () => ({ id: 'fixtures-all
 const enqueuePlayersSyncJob = mock(async () => ({ id: 'players-job-1' }));
 const enqueuePlayerValuesSyncJob = mock(async () => ({ id: 'player-values-job-1' }));
 const enqueuePlayerStatsSyncJob = mock(async () => ({ id: 'player-stats-job-1' }));
+const enqueueTeamsSyncJob = mock(async () => ({ id: 'teams-job-1' }));
+const enqueuePhasesSyncJob = mock(async () => ({ id: 'phases-job-1' }));
 mock.module('../../src/jobs/data-sync-enqueue', () => ({
   enqueueEventsSyncJob,
   enqueueFixturesSyncJob,
@@ -53,6 +55,8 @@ mock.module('../../src/jobs/data-sync-enqueue', () => ({
   enqueuePlayersSyncJob,
   enqueuePlayerValuesSyncJob,
   enqueuePlayerStatsSyncJob,
+  enqueueTeamsSyncJob,
+  enqueuePhasesSyncJob,
 }));
 
 // Mock the entry-sync queue (not entry-sync-enqueue) so real enqueue helpers run.
@@ -161,11 +165,6 @@ const deleteTournament = spyOn(
   'deleteTournament',
 ).mockImplementation(async () => managedTournament);
 
-const syncEntryInfo = mock(async (entryId: number) => ({ id: entryId, name: 'Test' }));
-mock.module('../../src/services/entry-info.service', () => ({
-  syncEntryInfo,
-}));
-
 const { eventsAPI } = await import('../../src/api/events.api');
 const { jobsAPI } = await import('../../src/api/jobs.api');
 const { entrySyncAPI } = await import('../../src/api/entry-sync.api');
@@ -176,6 +175,8 @@ const { playerStatsAPI } = await import('../../src/api/player-stats.api');
 const { eventLivesAPI } = await import('../../src/api/event-lives.api');
 const { tournamentsAPI } = await import('../../src/api/tournaments.api');
 const { entryInfoAPI } = await import('../../src/api/entry-info.api');
+const { teamsAPI } = await import('../../src/api/teams.api');
+const { phasesAPI } = await import('../../src/api/phases.api');
 
 describe('eventsAPI handlers', () => {
   beforeEach(() => {
@@ -609,18 +610,24 @@ describe('tournamentsAPI handlers', () => {
 
 describe('entryInfoAPI handlers', () => {
   beforeEach(() => {
-    syncEntryInfo.mockClear();
+    entrySyncAddCalls.length = 0;
   });
 
-  test('POST /entry-info/:entryId/sync syncs a numeric entry id', async () => {
+  test('POST /entry-info/:entryId/sync queues a numeric entry id', async () => {
     const response = await entryInfoAPI.handle(
       new Request('http://localhost/entry-info/42/sync', { method: 'POST' }),
     );
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as { success: boolean; data: { id: number } };
-    expect(body.success).toBe(true);
-    expect(body.data.id).toBe(42);
-    expect(syncEntryInfo).toHaveBeenCalledWith(42);
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      status: 'queued',
+      jobId: expect.any(String),
+    });
+    expect(entrySyncAddCalls).toHaveLength(1);
+    expect(entrySyncAddCalls[0]).toMatchObject({
+      name: 'entry-info',
+      data: { source: 'api', entryIds: [42] },
+    });
   });
 
   test('rejects non-numeric entryId params', async () => {
@@ -628,6 +635,41 @@ describe('entryInfoAPI handlers', () => {
       new Request('http://localhost/entry-info/abc/sync', { method: 'POST' }),
     );
     expect(response.status).toBe(422);
-    expect(syncEntryInfo).not.toHaveBeenCalled();
+    expect(entrySyncAddCalls).toHaveLength(0);
+  });
+});
+
+describe('queued core repair APIs', () => {
+  beforeEach(() => {
+    enqueueTeamsSyncJob.mockClear();
+    enqueuePhasesSyncJob.mockClear();
+  });
+
+  test('POST /teams/sync returns the queued job contract', async () => {
+    const response = await teamsAPI.handle(
+      new Request('http://localhost/teams/sync', { method: 'POST' }),
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      success: true,
+      status: 'queued',
+      jobId: 'teams-job-1',
+      message: 'Teams sync queued',
+    });
+    expect(enqueueTeamsSyncJob).toHaveBeenCalledWith('api');
+  });
+
+  test('POST /phases/sync returns the queued job contract', async () => {
+    const response = await phasesAPI.handle(
+      new Request('http://localhost/phases/sync', { method: 'POST' }),
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      success: true,
+      status: 'queued',
+      jobId: 'phases-job-1',
+      message: 'Phases sync queued',
+    });
+    expect(enqueuePhasesSyncJob).toHaveBeenCalledWith('api');
   });
 });

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -74,9 +74,10 @@ mock.module('../../src/queues/entry-sync.queue', () => ({
   ENTRY_SYNC_DEFAULT_THROTTLE_MS: 150,
   getEntrySyncQueue: () => ({
     name: 'entry-sync-p2',
+    getJobs: async () => [],
     add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
       entrySyncAddCalls.push({ name, data, opts });
-      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id', name, data };
     },
   }),
 }));

--- a/tests/unit/data-sync-attempt.test.ts
+++ b/tests/unit/data-sync-attempt.test.ts
@@ -25,6 +25,8 @@ function reportsFrom(spy: { mock: { calls: unknown[][] } }): DataSyncAttemptRepo
 describe('data sync attempt reporting', () => {
   test('accounts for delayed retries that reset BullMQ attemptsMade', () => {
     expect(resolveDataSyncAttempt('cron', 0, 2)).toEqual({ attempt: 3, source: 'retry' });
+    expect(resolveDataSyncAttempt('cron', 2, 2)).toEqual({ attempt: 5, source: 'retry' });
+    expect(resolveDataSyncAttempt('cron', 1)).toEqual({ attempt: 2, source: 'retry' });
     expect(resolveDataSyncAttempt('cron', 0)).toEqual({ attempt: 1, source: 'cron' });
   });
 
@@ -83,6 +85,13 @@ describe('data sync attempt reporting', () => {
       succeededUnits: 12,
       failedUnits: 0,
     });
+    expect(inferDataSyncWorkSummary({ count: 0, outcome: 'noop' })).toEqual({
+      outcome: 'noop',
+      requiredUnits: 0,
+      reusedUnits: 0,
+      succeededUnits: 0,
+      failedUnits: 0,
+    });
     expect(
       inferDataSyncWorkSummary({
         totalEntries: 75,
@@ -133,6 +142,7 @@ describe('data sync attempt reporting', () => {
       jobName: 'entry-picks',
       runId: 'run-1',
       source: 'cron',
+      attempt: 1,
       targetEventId: 7,
       outcome: 'partial',
       queueWaitMs: 15,
@@ -176,6 +186,7 @@ describe('data sync attempt reporting', () => {
     expect(reports[0]).toMatchObject({
       runId: 'run-failed',
       source: 'retry',
+      attempt: 2,
       outcome: 'failed',
       failedUnits: 0,
     });

--- a/tests/unit/data-sync-attempt.test.ts
+++ b/tests/unit/data-sync-attempt.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
-import { runDataSyncAttempt, type DataSyncAttemptReport } from '../../src/utils/data-sync-attempt';
+import {
+  inferDataSyncWorkSummary,
+  resolveDataSyncAttempt,
+  runDataSyncAttempt,
+  type DataSyncAttemptReport,
+} from '../../src/utils/data-sync-attempt';
 import { beginFplLogicalRequest } from '../../src/utils/fpl-request-metrics';
 import { logger } from '../../src/utils/logger';
 
@@ -16,6 +21,38 @@ function reportsFrom(spy: { mock: { calls: unknown[][] } }): DataSyncAttemptRepo
 }
 
 describe('data sync attempt reporting', () => {
+  test('accounts for delayed retries that reset BullMQ attemptsMade', () => {
+    expect(resolveDataSyncAttempt('cron', 0, 2)).toEqual({ attempt: 3, source: 'retry' });
+    expect(resolveDataSyncAttempt('cron', 0)).toEqual({ attempt: 1, source: 'cron' });
+  });
+
+  test('normalizes the result shapes returned by core and entry sync services', () => {
+    expect(inferDataSyncWorkSummary({ count: 20, errors: 2 })).toEqual({
+      requiredUnits: 22,
+      reusedUnits: 0,
+      succeededUnits: 20,
+      failedUnits: 2,
+    });
+    expect(inferDataSyncWorkSummary({ totalCount: 38, totalErrors: 2 })).toEqual({
+      requiredUnits: 40,
+      reusedUnits: 0,
+      succeededUnits: 38,
+      failedUnits: 2,
+    });
+    expect(inferDataSyncWorkSummary({ totalEntries: 75, synced: 70, errors: 5 })).toEqual({
+      requiredUnits: 75,
+      reusedUnits: 0,
+      succeededUnits: 70,
+      failedUnits: 5,
+    });
+    expect(inferDataSyncWorkSummary({ totalEntries: 75, updated: 70, skipped: 5 })).toEqual({
+      requiredUnits: 75,
+      reusedUnits: 5,
+      succeededUnits: 70,
+      failedUnits: 0,
+    });
+  });
+
   test('emits one bounded report with inferred work and FPL metrics', async () => {
     const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
 

--- a/tests/unit/data-sync-attempt.test.ts
+++ b/tests/unit/data-sync-attempt.test.ts
@@ -5,6 +5,7 @@ import {
   resolveBullMqAttemptQueueWaitMs,
   resolveDataSyncAttempt,
   runDataSyncAttempt,
+  type DataSyncAttemptContext,
   type DataSyncAttemptReport,
 } from '../../src/utils/data-sync-attempt';
 import { beginFplLogicalRequest } from '../../src/utils/fpl-request-metrics';
@@ -213,6 +214,29 @@ describe('data sync attempt reporting', () => {
     expect(reportsFrom(infoSpy)[0]).toMatchObject({
       jobName: 'player-stats',
       targetEventId: 12,
+    });
+  });
+
+  test('records a target resolved inside an unscoped attempt, including failures', async () => {
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
+    const context: DataSyncAttemptContext = {
+      queue: 'entry-sync',
+      jobName: 'entry-results',
+      runId: 'current-entry-results',
+      source: 'cron' as const,
+    };
+
+    await expect(
+      runDataSyncAttempt(context, async () => {
+        context.targetEventId = 13;
+        throw new Error('entry result failed after event resolution');
+      }),
+    ).rejects.toThrow('entry result failed after event resolution');
+
+    expect(reportsFrom(infoSpy)[0]).toMatchObject({
+      jobName: 'entry-results',
+      targetEventId: 13,
+      outcome: 'failed',
     });
   });
 

--- a/tests/unit/data-sync-attempt.test.ts
+++ b/tests/unit/data-sync-attempt.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import {
   inferDataSyncWorkSummary,
+  resolveBullMqAttemptQueueWaitMs,
   resolveDataSyncAttempt,
   runDataSyncAttempt,
   type DataSyncAttemptReport,
@@ -24,6 +25,21 @@ describe('data sync attempt reporting', () => {
   test('accounts for delayed retries that reset BullMQ attemptsMade', () => {
     expect(resolveDataSyncAttempt('cron', 0, 2)).toEqual({ attempt: 3, source: 'retry' });
     expect(resolveDataSyncAttempt('cron', 0)).toEqual({ attempt: 1, source: 'cron' });
+  });
+
+  test('does not include earlier attempts in BullMQ retry queue wait', () => {
+    expect(
+      resolveBullMqAttemptQueueWaitMs(
+        { timestamp: 1_000, processedOn: 1_250, attemptsMade: 0 },
+        1_251,
+      ),
+    ).toBe(250);
+    expect(
+      resolveBullMqAttemptQueueWaitMs(
+        { timestamp: 1_000, processedOn: 8_000, attemptsMade: 2 },
+        8_004,
+      ),
+    ).toBe(4);
   });
 
   test('normalizes the result shapes returned by core and entry sync services', () => {
@@ -50,6 +66,28 @@ describe('data sync attempt reporting', () => {
       reusedUnits: 5,
       succeededUnits: 70,
       failedUnits: 0,
+    });
+    expect(inferDataSyncWorkSummary({ enqueued: 12 })).toEqual({
+      requiredUnits: 12,
+      reusedUnits: 0,
+      succeededUnits: 12,
+      failedUnits: 0,
+    });
+    expect(
+      inferDataSyncWorkSummary({
+        totalEntries: 75,
+        updated: 70,
+        skipped: 5,
+        requiredUnits: 75,
+        reusedUnits: 0,
+        succeededUnits: 70,
+        failedUnits: 5,
+      }),
+    ).toEqual({
+      requiredUnits: 75,
+      reusedUnits: 0,
+      succeededUnits: 70,
+      failedUnits: 5,
     });
   });
 

--- a/tests/unit/data-sync-attempt.test.ts
+++ b/tests/unit/data-sync-attempt.test.ts
@@ -181,6 +181,41 @@ describe('data sync attempt reporting', () => {
     expect(JSON.stringify(reports[0])).not.toContain('private name');
   });
 
+  test('keeps first-attempt API traffic distinct from operator manual traffic', async () => {
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
+
+    await runDataSyncAttempt(
+      {
+        queue: 'data-sync',
+        jobName: 'teams',
+        runId: 'api-run',
+        source: 'api',
+      },
+      async () => ({ count: 20, errors: 0 }),
+    );
+
+    expect(reportsFrom(infoSpy)[0]?.source).toBe('api');
+  });
+
+  test('records a target event resolved by an unscoped sync result', async () => {
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
+
+    await runDataSyncAttempt(
+      {
+        queue: 'data-sync',
+        jobName: 'player-stats',
+        runId: 'current-player-stats',
+        source: 'cron',
+      },
+      async () => ({ count: 700, errors: 0, eventId: 12 }),
+    );
+
+    expect(reportsFrom(infoSpy)[0]).toMatchObject({
+      jobName: 'player-stats',
+      targetEventId: 12,
+    });
+  });
+
   test('isolates concurrent top-level attempt metrics', async () => {
     const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
 

--- a/tests/unit/data-sync-attempt.test.ts
+++ b/tests/unit/data-sync-attempt.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+
+import { runDataSyncAttempt, type DataSyncAttemptReport } from '../../src/utils/data-sync-attempt';
+import { beginFplLogicalRequest } from '../../src/utils/fpl-request-metrics';
+import { logger } from '../../src/utils/logger';
+
+afterEach(() => {
+  mock.restore();
+  delete process.env.DATA_SYNC_ATTEMPT_REPORTING_ENABLED;
+});
+
+function reportsFrom(spy: { mock: { calls: unknown[][] } }): DataSyncAttemptReport[] {
+  return spy.mock.calls
+    .map((call) => call[0] as DataSyncAttemptReport)
+    .filter((payload) => payload?.event === 'data_sync_attempt');
+}
+
+describe('data sync attempt reporting', () => {
+  test('emits one bounded report with inferred work and FPL metrics', async () => {
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
+
+    await runDataSyncAttempt(
+      {
+        queue: 'entry-sync',
+        jobName: 'entry-picks',
+        runId: 'run-1',
+        source: 'cron',
+        targetEventId: 7,
+        queueWaitMs: 15.9,
+      },
+      async () => {
+        const request = beginFplLogicalRequest(
+          'https://fantasy.premierleague.com/api/entry/123/event/7/picks/',
+        );
+        request.recordAttempt('429');
+        request.recordAttempt('2xx');
+        request.finish();
+        return { total: 2, success: 1, failed: 1, reusedUnits: 3 };
+      },
+    );
+
+    const reports = reportsFrom(infoSpy);
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      event: 'data_sync_attempt',
+      schemaVersion: 1,
+      queue: 'entry-sync',
+      jobName: 'entry-picks',
+      runId: 'run-1',
+      source: 'cron',
+      targetEventId: 7,
+      outcome: 'partial',
+      queueWaitMs: 15,
+      requiredUnits: 2,
+      reusedUnits: 3,
+      succeededUnits: 1,
+      failedUnits: 1,
+      fpl: {
+        logicalRequests: 1,
+        attempts: 2,
+        retries: 1,
+        byEndpoint: { entry_picks: 1 },
+        attemptsByOutcome: { '429': 1, '2xx': 1 },
+        finalOutcomes: { '2xx': 1 },
+      },
+    });
+    expect(JSON.stringify(reports[0])).not.toContain('fantasy.premierleague.com');
+    expect(JSON.stringify(reports[0])).not.toContain('/entry/123/');
+  });
+
+  test('emits once on failure and rethrows the original error', async () => {
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
+
+    await expect(
+      runDataSyncAttempt(
+        {
+          queue: 'data-sync',
+          jobName: 'teams',
+          runId: 'run-failed',
+          source: 'api',
+          attempt: 2,
+        },
+        async () => {
+          throw new Error('upstream payload contained a private name');
+        },
+      ),
+    ).rejects.toThrow('upstream payload contained a private name');
+
+    const reports = reportsFrom(infoSpy);
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      runId: 'run-failed',
+      source: 'retry',
+      outcome: 'failed',
+      failedUnits: 0,
+    });
+    expect(JSON.stringify(reports[0])).not.toContain('private name');
+  });
+
+  test('isolates concurrent top-level attempt metrics', async () => {
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
+
+    await Promise.all([
+      runDataSyncAttempt(
+        { queue: 'data-sync', jobName: 'fixtures', runId: 'fixtures-run', source: 'cron' },
+        async () => {
+          const request = beginFplLogicalRequest('https://fantasy.premierleague.com/api/fixtures/');
+          await Promise.resolve();
+          request.recordAttempt('2xx');
+          request.finish();
+          return { total: 1, success: 1 };
+        },
+      ),
+      runDataSyncAttempt(
+        {
+          queue: 'entry-sync',
+          jobName: 'entry-transfers',
+          runId: 'transfers-run',
+          source: 'manual',
+        },
+        async () => {
+          const request = beginFplLogicalRequest(
+            'https://fantasy.premierleague.com/api/entry/456/transfers/',
+          );
+          request.recordAttempt('5xx');
+          request.finish();
+          return { total: 1, failed: 1 };
+        },
+      ),
+    ]);
+
+    const reports = reportsFrom(infoSpy);
+    expect(reports).toHaveLength(2);
+    const fixtures = reports.find((report) => report.runId === 'fixtures-run');
+    const transfers = reports.find((report) => report.runId === 'transfers-run');
+    expect(fixtures?.fpl.byEndpoint.fixtures).toBe(1);
+    expect(fixtures?.fpl.byEndpoint.entry_transfers).toBe(0);
+    expect(transfers?.fpl.byEndpoint.fixtures).toBe(0);
+    expect(transfers?.fpl.byEndpoint.entry_transfers).toBe(1);
+  });
+
+  test('can be disabled without creating a metrics context or report', async () => {
+    process.env.DATA_SYNC_ATTEMPT_REPORTING_ENABLED = 'false';
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined as never);
+
+    const value = await runDataSyncAttempt(
+      { queue: 'data-sync', jobName: 'events', runId: 'disabled', source: 'cron' },
+      async () => 'ok',
+    );
+
+    expect(value).toBe('ok');
+    expect(reportsFrom(infoSpy)).toHaveLength(0);
+  });
+});

--- a/tests/unit/data-sync-attempt.test.ts
+++ b/tests/unit/data-sync-attempt.test.ts
@@ -42,6 +42,15 @@ describe('data sync attempt reporting', () => {
     ).toBe(4);
   });
 
+  test('excludes an explicitly scheduled retry delay from queue wait', () => {
+    expect(
+      resolveBullMqAttemptQueueWaitMs(
+        { timestamp: 1_000, processedOn: 601_250, attemptsMade: 0, delay: 600_000 },
+        601_251,
+      ),
+    ).toBe(250);
+  });
+
   test('normalizes the result shapes returned by core and entry sync services', () => {
     expect(inferDataSyncWorkSummary({ count: 20, errors: 2 })).toEqual({
       requiredUnits: 22,

--- a/tests/unit/data-sync-enqueue.test.ts
+++ b/tests/unit/data-sync-enqueue.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type AddCall = { name: string; data: Record<string, unknown>; opts: Record<string, unknown> };
+
+const addCalls: AddCall[] = [];
+
+mock.module('../../src/queues/data-sync.queue', () => ({
+  getDataSyncQueue: () => ({
+    name: 'data-sync-p1',
+    add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
+      addCalls.push({ name, data, opts });
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+    },
+  }),
+}));
+
+const { enqueueTeamsSyncJob } = await import('../../src/jobs/data-sync-enqueue');
+
+describe('data-sync enqueue correlation', () => {
+  beforeEach(() => {
+    addCalls.length = 0;
+  });
+
+  test('keeps a deterministic queue ID but gives settled executions distinct run IDs', async () => {
+    await enqueueTeamsSyncJob('api');
+    await enqueueTeamsSyncJob('api');
+
+    expect(addCalls).toHaveLength(2);
+    expect(addCalls[0]?.opts.jobId).toBe('teams-api');
+    expect(addCalls[1]?.opts.jobId).toBe('teams-api');
+    expect(addCalls[0]?.data.runId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(addCalls[1]?.data.runId).not.toBe(addCalls[0]?.data.runId);
+  });
+});

--- a/tests/unit/data-sync-enqueue.test.ts
+++ b/tests/unit/data-sync-enqueue.test.ts
@@ -1,34 +1,17 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
-type AddCall = { name: string; data: Record<string, unknown>; opts: Record<string, unknown> };
-
-const addCalls: AddCall[] = [];
-
-mock.module('../../src/queues/data-sync.queue', () => ({
-  getDataSyncQueue: () => ({
-    name: 'data-sync-p1',
-    add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
-      addCalls.push({ name, data, opts });
-      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
-    },
-  }),
-}));
-
-const { enqueueTeamsSyncJob } = await import('../../src/jobs/data-sync-enqueue');
+import {
+  createDataSyncJobData,
+  defaultDataSyncJobId,
+} from '../../src/jobs/data-sync-job-definition';
 
 describe('data-sync enqueue correlation', () => {
-  beforeEach(() => {
-    addCalls.length = 0;
-  });
+  test('keeps a deterministic queue ID but gives settled executions distinct run IDs', () => {
+    const first = createDataSyncJobData('api', {});
+    const second = createDataSyncJobData('api', {});
 
-  test('keeps a deterministic queue ID but gives settled executions distinct run IDs', async () => {
-    await enqueueTeamsSyncJob('api');
-    await enqueueTeamsSyncJob('api');
-
-    expect(addCalls).toHaveLength(2);
-    expect(addCalls[0]?.opts.jobId).toBe('teams-api');
-    expect(addCalls[1]?.opts.jobId).toBe('teams-api');
-    expect(addCalls[0]?.data.runId).toMatch(/^[0-9a-f-]{36}$/);
-    expect(addCalls[1]?.data.runId).not.toBe(addCalls[0]?.data.runId);
+    expect(defaultDataSyncJobId('teams', 'api', {})).toBe('teams-api');
+    expect(first.runId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(second.runId).not.toBe(first.runId);
   });
 });

--- a/tests/unit/entry-info-sync-marker.test.ts
+++ b/tests/unit/entry-info-sync-marker.test.ts
@@ -4,18 +4,22 @@ import { shouldMarkEntryInfoSynced } from '../../src/jobs/entry-info-sync-marker
 
 describe('shouldMarkEntryInfoSynced', () => {
   test('marks only the final chunk with zero failures', () => {
-    expect(shouldMarkEntryInfoSynced(false, 0)).toBe(true);
+    expect(shouldMarkEntryInfoSynced(true, false, 0)).toBe(true);
   });
 
   test('does not mark mid-chunk success', () => {
-    expect(shouldMarkEntryInfoSynced(true, 0)).toBe(false);
+    expect(shouldMarkEntryInfoSynced(true, true, 0)).toBe(false);
   });
 
   test('does not mark the final chunk while failures remain', () => {
-    expect(shouldMarkEntryInfoSynced(false, 3)).toBe(false);
+    expect(shouldMarkEntryInfoSynced(true, false, 3)).toBe(false);
   });
 
   test('does not mark a mid-chunk that also has failures', () => {
-    expect(shouldMarkEntryInfoSynced(true, 1)).toBe(false);
+    expect(shouldMarkEntryInfoSynced(true, true, 1)).toBe(false);
+  });
+
+  test('does not let a targeted API or retry job complete the daily scan', () => {
+    expect(shouldMarkEntryInfoSynced(false, false, 0)).toBe(false);
   });
 });

--- a/tests/unit/entry-sync-enqueue.test.ts
+++ b/tests/unit/entry-sync-enqueue.test.ts
@@ -1,8 +1,14 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 type AddCall = { name: string; data: Record<string, unknown>; opts: Record<string, unknown> };
 
 const addCalls: AddCall[] = [];
+const pendingJobs: Array<{
+  id: string;
+  name: string;
+  data: Record<string, unknown>;
+}> = [];
+let returnedJobData: Record<string, unknown> | undefined;
 
 mock.module('../../src/queues/entry-sync.queue', () => ({
   ENTRY_SYNC_DEFAULT_CHUNK_SIZE: 100,
@@ -10,18 +16,26 @@ mock.module('../../src/queues/entry-sync.queue', () => ({
   ENTRY_SYNC_DEFAULT_THROTTLE_MS: 150,
   getEntrySyncQueue: () => ({
     name: 'entry-sync-p2',
+    getJobs: async () => pendingJobs,
     add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
       addCalls.push({ name, data, opts });
-      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+      return {
+        id: (opts.jobId as string | undefined) ?? 'generated-id',
+        name,
+        data: returnedJobData ?? data,
+      };
     },
   }),
 }));
 
+const { logger } = await import('../../src/utils/logger');
 const { enqueueEntryPicksSyncJob } = await import('../../src/jobs/entry-sync-enqueue');
 
 describe('entry-sync enqueue runId propagation', () => {
   beforeEach(() => {
     addCalls.length = 0;
+    pendingJobs.length = 0;
+    returnedJobData = undefined;
   });
 
   test('uses provided runId in chunk job ID', async () => {
@@ -60,5 +74,31 @@ describe('entry-sync enqueue runId propagation', () => {
     expect(continuation!.id).toBe('entry-picks-manual-chunk-100');
     expect(addCalls[1].data.runId).toBe(rootData.runId);
     expect(addCalls[1].data.queueKey).toBe('manual');
+  });
+
+  test('reuses an active continuation for a repeated manual root trigger', async () => {
+    pendingJobs.push({
+      id: 'entry-picks-manual-chunk-500',
+      name: 'entry-picks',
+      data: { source: 'manual', queueKey: 'manual', runId: 'existing-run' },
+    });
+
+    const job = await enqueueEntryPicksSyncJob('manual', { chunkOffset: 0 });
+
+    expect(job!.id).toBe('entry-picks-manual-chunk-500');
+    expect(addCalls).toHaveLength(0);
+  });
+
+  test('logs the stored run id when BullMQ deduplicates an add', async () => {
+    const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined);
+    returnedJobData = { runId: 'stored-run' };
+
+    await enqueueEntryPicksSyncJob('cron', { chunkOffset: 0, runId: 'new-run' });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: 'stored-run' }),
+      'Entry sync job enqueued',
+    );
+    infoSpy.mockRestore();
   });
 });

--- a/tests/unit/entry-sync-enqueue.test.ts
+++ b/tests/unit/entry-sync-enqueue.test.ts
@@ -9,6 +9,7 @@ const pendingJobs: Array<{
   data: Record<string, unknown>;
 }> = [];
 let returnedJobData: Record<string, unknown> | undefined;
+let currentEventId = 12;
 
 mock.module('../../src/queues/entry-sync.queue', () => ({
   ENTRY_SYNC_DEFAULT_CHUNK_SIZE: 100,
@@ -28,6 +29,10 @@ mock.module('../../src/queues/entry-sync.queue', () => ({
   }),
 }));
 
+mock.module('../../src/services/events.service', () => ({
+  getCurrentEvent: async () => ({ id: currentEventId }),
+}));
+
 const { logger } = await import('../../src/utils/logger');
 const { enqueueEntryPicksSyncJob } = await import('../../src/jobs/entry-sync-enqueue');
 
@@ -36,6 +41,7 @@ describe('entry-sync enqueue runId propagation', () => {
     addCalls.length = 0;
     pendingJobs.length = 0;
     returnedJobData = undefined;
+    currentEventId = 12;
   });
 
   test('uses provided runId in chunk job ID', async () => {
@@ -114,6 +120,21 @@ describe('entry-sync enqueue runId propagation', () => {
 
     expect(job!.id).toBe('entry-picks-manual-chunk-500');
     expect(addCalls).toHaveLength(0);
+  });
+
+  test('does not reuse a resolved continuation after the current event advances', async () => {
+    pendingJobs.push({
+      id: 'entry-picks-manual-chunk-500-event-12',
+      name: 'entry-picks',
+      data: { source: 'manual', queueKey: 'manual', eventId: 12, runId: 'existing-run' },
+    });
+    currentEventId = 13;
+
+    const job = await enqueueEntryPicksSyncJob('manual');
+
+    expect(job!.id).toBe('entry-picks-manual-chunk-0');
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0].data.eventId).toBeUndefined();
   });
 
   test('reuses a legacy manual continuation that predates queue keys', async () => {

--- a/tests/unit/entry-sync-enqueue.test.ts
+++ b/tests/unit/entry-sync-enqueue.test.ts
@@ -45,4 +45,20 @@ describe('entry-sync enqueue runId propagation', () => {
     expect(job).not.toBeNull();
     expect(job!.id).toBe('entry-picks-chain-abc-chunk-100-event-20');
   });
+
+  test('keeps the manual queue key stable across correlated continuation chunks', async () => {
+    const root = await enqueueEntryPicksSyncJob('manual', { chunkOffset: 0 });
+    const rootData = addCalls[0].data;
+    const continuation = await enqueueEntryPicksSyncJob('manual', {
+      chunkOffset: 100,
+      runId: rootData.runId as string,
+      queueKey: rootData.queueKey as string,
+    });
+
+    expect(root!.id).toBe('entry-picks-manual-chunk-0');
+    expect(rootData.queueKey).toBe('manual');
+    expect(continuation!.id).toBe('entry-picks-manual-chunk-100');
+    expect(addCalls[1].data.runId).toBe(rootData.runId);
+    expect(addCalls[1].data.queueKey).toBe('manual');
+  });
 });

--- a/tests/unit/entry-sync-enqueue.test.ts
+++ b/tests/unit/entry-sync-enqueue.test.ts
@@ -103,6 +103,19 @@ describe('entry-sync enqueue runId propagation', () => {
     expect(addCalls[0].data.eventId).toBe(13);
   });
 
+  test('reuses an unscoped root trigger for a resolved continuation', async () => {
+    pendingJobs.push({
+      id: 'entry-picks-manual-chunk-500',
+      name: 'entry-picks',
+      data: { source: 'manual', queueKey: 'manual', eventId: 12, runId: 'existing-run' },
+    });
+
+    const job = await enqueueEntryPicksSyncJob('manual');
+
+    expect(job!.id).toBe('entry-picks-manual-chunk-500');
+    expect(addCalls).toHaveLength(0);
+  });
+
   test('reuses a legacy manual continuation that predates queue keys', async () => {
     pendingJobs.push({
       id: 'entry-picks-manual-chunk-500',

--- a/tests/unit/entry-sync-enqueue.test.ts
+++ b/tests/unit/entry-sync-enqueue.test.ts
@@ -89,6 +89,19 @@ describe('entry-sync enqueue runId propagation', () => {
     expect(addCalls).toHaveLength(0);
   });
 
+  test('reuses a legacy manual continuation that predates queue keys', async () => {
+    pendingJobs.push({
+      id: 'entry-picks-manual-chunk-500',
+      name: 'entry-picks',
+      data: { source: 'manual', runId: 'manual' },
+    });
+
+    const job = await enqueueEntryPicksSyncJob('manual', { chunkOffset: 0 });
+
+    expect(job!.id).toBe('entry-picks-manual-chunk-500');
+    expect(addCalls).toHaveLength(0);
+  });
+
   test('logs the stored run id when BullMQ deduplicates an add', async () => {
     const infoSpy = spyOn(logger, 'info').mockImplementation(() => undefined);
     returnedJobData = { runId: 'stored-run' };

--- a/tests/unit/entry-sync-enqueue.test.ts
+++ b/tests/unit/entry-sync-enqueue.test.ts
@@ -89,6 +89,20 @@ describe('entry-sync enqueue runId propagation', () => {
     expect(addCalls).toHaveLength(0);
   });
 
+  test('does not reuse a manual scan rooted for a different event', async () => {
+    pendingJobs.push({
+      id: 'entry-picks-manual-chunk-0-event-12',
+      name: 'entry-picks',
+      data: { source: 'manual', queueKey: 'manual', eventId: 12, runId: 'existing-run' },
+    });
+
+    const job = await enqueueEntryPicksSyncJob('manual', { eventId: 13 });
+
+    expect(job!.id).toBe('entry-picks-manual-chunk-0-event-13');
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0].data.eventId).toBe(13);
+  });
+
   test('reuses a legacy manual continuation that predates queue keys', async () => {
     pendingJobs.push({
       id: 'entry-picks-manual-chunk-500',

--- a/tests/unit/entry-sync-target.test.ts
+++ b/tests/unit/entry-sync-target.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveEntrySyncTargetEventId } from '../../src/domain/entry-sync';
+
+describe('entry sync target event resolution', () => {
+  test('preserves explicit event IDs without a lookup', async () => {
+    let lookups = 0;
+    const eventId = await resolveEntrySyncTargetEventId('entry-results', 7, async () => {
+      lookups += 1;
+      return 8;
+    });
+
+    expect(eventId).toBe(7);
+    expect(lookups).toBe(0);
+  });
+
+  test('resolves one current event for event-scoped jobs without a target', async () => {
+    expect(await resolveEntrySyncTargetEventId('entry-picks', undefined, async () => 9)).toBe(9);
+    expect(await resolveEntrySyncTargetEventId('entry-transfers', undefined, async () => 9)).toBe(
+      9,
+    );
+    expect(await resolveEntrySyncTargetEventId('entry-results', undefined, async () => 9)).toBe(9);
+  });
+
+  test('leaves entry-info unscoped and fails when no current event exists', async () => {
+    expect(
+      await resolveEntrySyncTargetEventId('entry-info', undefined, async () => 9),
+    ).toBeUndefined();
+    await expect(
+      resolveEntrySyncTargetEventId('entry-results', undefined, async () => null),
+    ).rejects.toThrow('No current event found');
+  });
+});

--- a/tests/unit/fpl-request-metrics.test.ts
+++ b/tests/unit/fpl-request-metrics.test.ts
@@ -84,6 +84,30 @@ describe('FPL request metrics', () => {
     expect(transferMetrics.finalOutcomes.network_error).toBe(1);
   });
 
+  test('reuses a parent collector for nested reporting scopes', async () => {
+    const metrics = await runWithFplRequestMetrics(async () => {
+      const outer = beginFplLogicalRequest(
+        'https://fantasy.premierleague.com/api/entry/101/history/',
+      );
+      outer.recordAttempt('2xx');
+      outer.finish();
+
+      await runWithFplRequestMetrics(async () => {
+        const inner = beginFplLogicalRequest(
+          'https://fantasy.premierleague.com/api/entry/101/transfers/',
+        );
+        inner.recordAttempt('2xx');
+        inner.finish();
+      });
+
+      return getFplRequestMetricsSnapshot();
+    });
+
+    expect(metrics.logicalRequests).toBe(2);
+    expect(metrics.byEndpoint.entry_history).toBe(1);
+    expect(metrics.byEndpoint.entry_transfers).toBe(1);
+  });
+
   test('records a repeated 5xx sequence as one failed logical request', async () => {
     process.env.FPL_RETRY_BASE_DELAY_MS = '0';
     process.env.FPL_RETRY_MAX_DELAY_MS = '0';

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -9,6 +9,11 @@ import {
 
 class FakeRedis {
   readonly values = new Map<string, string>();
+  private markerFailuresRemaining: number;
+
+  constructor(markerFailures = 0) {
+    this.markerFailuresRemaining = markerFailures;
+  }
 
   async get(key: string): Promise<string | null> {
     return this.values.get(key) ?? null;
@@ -16,6 +21,10 @@ class FakeRedis {
 
   async set(key: string, value: string, ...args: Array<string | number>): Promise<string | null> {
     if (args.includes('NX') && this.values.has(key)) return null;
+    if (!key.endsWith(':lock') && this.markerFailuresRemaining > 0) {
+      this.markerFailuresRemaining -= 1;
+      throw new Error('marker storage unavailable');
+    }
     this.values.set(key, value);
     return 'OK';
   }
@@ -46,6 +55,7 @@ function dependencies(options?: {
     sendNotification: options?.send ?? (async () => undefined),
     now: () => new Date('2026-08-04T00:00:00.000Z'),
     createLockToken: () => 'lock-token',
+    wait: async () => undefined,
   };
 }
 
@@ -93,6 +103,23 @@ describe('launch monitor', () => {
     });
     expect(messages).toEqual(['【NEW SEASON】ITS HAPPENING!!!']);
     expect(redis.values.has('LaunchNotification:happening:2627')).toBe(true);
+  });
+
+  test('reports ordinary monitor no-ops as zero synchronization work', async () => {
+    const result = await evaluateLaunchMonitor(
+      dependencies({
+        events: [{ id: 1, deadline_time: '2025-08-15T10:00:00Z' }],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'noop',
+      delivery: 'not_applicable',
+      requiredUnits: 0,
+      reusedUnits: 0,
+      succeededUnits: 0,
+      failedUnits: 0,
+    });
   });
 
   test('serializes concurrent ticks so only one notification is delivered', async () => {
@@ -144,5 +171,43 @@ describe('launch monitor', () => {
     const retry = await evaluateLaunchMonitor(deps);
     expect(retry.delivery).toBe('sent');
     expect(redis.values.has('LaunchNotification:warning:2026')).toBe(true);
+  });
+
+  test('retries the delivered marker before releasing the notification lock', async () => {
+    const redis = new FakeRedis(1);
+    let sends = 0;
+
+    const result = await evaluateLaunchMonitor(
+      dependencies({
+        redis,
+        send: async () => {
+          sends += 1;
+        },
+      }),
+    );
+
+    expect(result.delivery).toBe('sent');
+    expect(sends).toBe(1);
+    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(true);
+    expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(false);
+  });
+
+  test('retains the lock when delivery succeeds but every marker write fails', async () => {
+    const redis = new FakeRedis(3);
+    let sends = 0;
+    const deps = dependencies({
+      redis,
+      send: async () => {
+        sends += 1;
+      },
+    });
+
+    await expect(evaluateLaunchMonitor(deps)).rejects.toThrow('marker storage unavailable');
+    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(false);
+    expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(true);
+
+    const nextTick = await evaluateLaunchMonitor(deps);
+    expect(nextTick.delivery).toBe('locked');
+    expect(sends).toBe(1);
   });
 });

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -9,6 +9,7 @@ import {
 
 class FakeRedis {
   readonly values = new Map<string, string>();
+  readonly setCalls: Array<{ key: string; args: Array<string | number> }> = [];
   private markerFailuresRemaining: number;
 
   constructor(markerFailures = 0) {
@@ -20,6 +21,7 @@ class FakeRedis {
   }
 
   async set(key: string, value: string, ...args: Array<string | number>): Promise<string | null> {
+    this.setCalls.push({ key, args });
     if (args.includes('NX') && this.values.has(key)) return null;
     if (!key.endsWith(':lock') && this.markerFailuresRemaining > 0) {
       this.markerFailuresRemaining -= 1;
@@ -205,6 +207,9 @@ describe('launch monitor', () => {
     await expect(evaluateLaunchMonitor(deps)).rejects.toThrow('marker storage unavailable');
     expect(redis.values.has('LaunchNotification:warning:2026')).toBe(false);
     expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(true);
+    expect(
+      redis.setCalls.find((call) => call.key === 'LaunchNotification:warning:2026:lock')?.args,
+    ).toEqual(['NX']);
 
     const nextTick = await evaluateLaunchMonitor(deps);
     expect(nextTick.delivery).toBe('locked');

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -155,24 +155,24 @@ describe('launch monitor', () => {
     expect(sends).toBe(1);
   });
 
-  test('releases the lock after delivery failure so the next tick can retry', async () => {
+  test('retains the lock after an ambiguous delivery failure', async () => {
     const redis = new FakeRedis();
-    let shouldFail = true;
+    let sends = 0;
     const deps = dependencies({
       redis,
       send: async () => {
-        if (shouldFail) throw new Error('notification unavailable');
+        sends += 1;
+        throw new Error('notification response lost');
       },
     });
 
-    await expect(evaluateLaunchMonitor(deps)).rejects.toThrow('notification unavailable');
-    expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(false);
+    await expect(evaluateLaunchMonitor(deps)).rejects.toThrow('notification response lost');
+    expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(true);
     expect(redis.values.has('LaunchNotification:warning:2026')).toBe(false);
 
-    shouldFail = false;
     const retry = await evaluateLaunchMonitor(deps);
-    expect(retry.delivery).toBe('sent');
-    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(true);
+    expect(retry.delivery).toBe('locked');
+    expect(sends).toBe(1);
   });
 
   test('retries the delivered marker before releasing the notification lock', async () => {

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -6,6 +6,7 @@ import {
   LAUNCH_MONITOR_CRON_PATTERN,
   type LaunchMonitorDependencies,
 } from '../../src/jobs/launch.jobs';
+import { NotificationDeliveryRejectedError } from '../../src/utils/notify';
 
 class FakeRedis {
   readonly values = new Map<string, string>();
@@ -239,6 +240,33 @@ describe('launch monitor', () => {
     const retry = await evaluateLaunchMonitor(deps);
     expect(retry.delivery).toBe('locked');
     expect(sends).toBe(1);
+  });
+
+  test('releases the lock after a definite Telegram rejection so the next tick can retry', async () => {
+    const redis = new FakeRedis();
+    let sends = 0;
+    const deps = dependencies({
+      redis,
+      send: async () => {
+        sends += 1;
+        throw new NotificationDeliveryRejectedError(429, 'Too Many Requests');
+      },
+    });
+
+    await expect(evaluateLaunchMonitor(deps)).rejects.toThrow('Telegram API error: 429');
+    expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(false);
+
+    const retry = await evaluateLaunchMonitor(
+      dependencies({
+        redis,
+        send: async () => {
+          sends += 1;
+        },
+      }),
+    );
+
+    expect(retry.delivery).toBe('sent');
+    expect(sends).toBe(2);
   });
 
   test('retries the delivered marker before releasing the notification lock', async () => {

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -55,6 +55,7 @@ function dependencies(options?: {
   events?: Array<{ id: number; deadline_time: string | null }>;
   redis?: FakeRedis;
   send?: (message: string) => Promise<void>;
+  delivery?: 'sent' | 'skipped';
   onBootstrap?: () => void;
 }): LaunchMonitorDependencies {
   return {
@@ -63,7 +64,10 @@ function dependencies(options?: {
       return bootstrap(options?.events ?? []);
     },
     getRedis: async () => options?.redis ?? new FakeRedis(),
-    sendNotification: options?.send ?? (async () => undefined),
+    sendNotification: async (message) => {
+      await options?.send?.(message);
+      return options?.delivery ?? 'sent';
+    },
     now: () => new Date('2026-08-04T00:00:00.000Z'),
     createLockToken: () => 'lock-token',
     wait: async () => undefined,
@@ -114,6 +118,29 @@ describe('launch monitor', () => {
     });
     expect(messages).toEqual(['【NEW SEASON】ITS HAPPENING!!!']);
     expect(redis.values.has('LaunchNotification:happening:2627')).toBe(true);
+  });
+
+  test('does not mark a disabled notification as delivered and can send it later', async () => {
+    const redis = new FakeRedis();
+    const skipped = await evaluateLaunchMonitor(dependencies({ redis, delivery: 'skipped' }));
+
+    expect(skipped).toMatchObject({ outcome: 'noop', delivery: 'skipped', requiredUnits: 0 });
+    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(false);
+    expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(false);
+
+    let sends = 0;
+    const delivered = await evaluateLaunchMonitor(
+      dependencies({
+        redis,
+        send: async () => {
+          sends += 1;
+        },
+      }),
+    );
+
+    expect(delivered.delivery).toBe('sent');
+    expect(sends).toBe(1);
+    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(true);
   });
 
   test('reports ordinary monitor no-ops as zero synchronization work', async () => {

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { FPLBootstrapResponse } from '../../src/clients/fpl';
+import {
+  evaluateLaunchMonitor,
+  LAUNCH_MONITOR_CRON_PATTERN,
+  type LaunchMonitorDependencies,
+} from '../../src/jobs/launch.jobs';
+
+class FakeRedis {
+  readonly values = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async set(key: string, value: string, ...args: Array<string | number>): Promise<string | null> {
+    if (args.includes('NX') && this.values.has(key)) return null;
+    this.values.set(key, value);
+    return 'OK';
+  }
+
+  async eval(_script: string, _numberOfKeys: number, key: string, token: string) {
+    if (this.values.get(key) !== token) return 0;
+    this.values.delete(key);
+    return 1;
+  }
+}
+
+function bootstrap(events: Array<{ id: number; deadline_time: string | null }>) {
+  return { events } as unknown as FPLBootstrapResponse;
+}
+
+function dependencies(options?: {
+  events?: Array<{ id: number; deadline_time: string | null }>;
+  redis?: FakeRedis;
+  send?: (message: string) => Promise<void>;
+  onBootstrap?: () => void;
+}): LaunchMonitorDependencies {
+  return {
+    getBootstrap: async () => {
+      options?.onBootstrap?.();
+      return bootstrap(options?.events ?? []);
+    },
+    getRedis: async () => options?.redis ?? new FakeRedis(),
+    sendNotification: options?.send ?? (async () => undefined),
+    now: () => new Date('2026-08-04T00:00:00.000Z'),
+    createLockToken: () => 'lock-token',
+  };
+}
+
+describe('launch monitor', () => {
+  test('uses one five-minute schedule and one bootstrap request per tick', async () => {
+    expect(LAUNCH_MONITOR_CRON_PATTERN).toBe('*/5 * * * *');
+    const redis = new FakeRedis();
+    let bootstrapCalls = 0;
+    let sends = 0;
+    const deps = dependencies({
+      redis,
+      onBootstrap: () => {
+        bootstrapCalls += 1;
+      },
+      send: async () => {
+        sends += 1;
+      },
+    });
+
+    for (let tick = 0; tick < 24 * 12; tick += 1) {
+      await evaluateLaunchMonitor(deps);
+    }
+
+    expect(bootstrapCalls).toBe(288);
+    expect(sends).toBe(1);
+  });
+
+  test('detects the happening transition from the same bootstrap response', async () => {
+    const redis = new FakeRedis();
+    const messages: string[] = [];
+    const result = await evaluateLaunchMonitor(
+      dependencies({
+        redis,
+        events: [{ id: 1, deadline_time: '2026-08-15T10:00:00Z' }],
+        send: async (message) => {
+          messages.push(message);
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'ready',
+      notification: 'happening',
+      delivery: 'sent',
+    });
+    expect(messages).toEqual(['【NEW SEASON】ITS HAPPENING!!!']);
+    expect(redis.values.has('LaunchNotification:happening:2627')).toBe(true);
+  });
+
+  test('serializes concurrent ticks so only one notification is delivered', async () => {
+    const redis = new FakeRedis();
+    let sends = 0;
+    let releaseSend: () => void = () => undefined;
+    let markSendStarted: () => void = () => undefined;
+    const sendStarted = new Promise<void>((resolve) => {
+      markSendStarted = resolve;
+    });
+    const sendReleased = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    const deps = dependencies({
+      redis,
+      send: async () => {
+        sends += 1;
+        markSendStarted();
+        await sendReleased;
+      },
+    });
+
+    const first = evaluateLaunchMonitor(deps);
+    await sendStarted;
+    const second = await evaluateLaunchMonitor(deps);
+    releaseSend();
+    const firstResult = await first;
+
+    expect(firstResult.delivery).toBe('sent');
+    expect(second.delivery).toBe('locked');
+    expect(sends).toBe(1);
+  });
+
+  test('releases the lock after delivery failure so the next tick can retry', async () => {
+    const redis = new FakeRedis();
+    let shouldFail = true;
+    const deps = dependencies({
+      redis,
+      send: async () => {
+        if (shouldFail) throw new Error('notification unavailable');
+      },
+    });
+
+    await expect(evaluateLaunchMonitor(deps)).rejects.toThrow('notification unavailable');
+    expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(false);
+    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(false);
+
+    shouldFail = false;
+    const retry = await evaluateLaunchMonitor(deps);
+    expect(retry.delivery).toBe('sent');
+    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(true);
+  });
+});

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -11,9 +11,13 @@ class FakeRedis {
   readonly values = new Map<string, string>();
   readonly setCalls: Array<{ key: string; args: Array<string | number> }> = [];
   private markerFailuresRemaining: number;
+  private releaseFailuresRemaining: number;
+  private readonly persistResult: number | null;
 
-  constructor(markerFailures = 0) {
+  constructor(markerFailures = 0, options?: { releaseFailures?: number; persistResult?: number }) {
     this.markerFailuresRemaining = markerFailures;
+    this.releaseFailuresRemaining = options?.releaseFailures ?? 0;
+    this.persistResult = options?.persistResult ?? null;
   }
 
   async get(key: string): Promise<string | null> {
@@ -31,8 +35,13 @@ class FakeRedis {
     return 'OK';
   }
 
-  async eval(_script: string, _numberOfKeys: number, key: string, token: string) {
+  async eval(script: string, _numberOfKeys: number, key: string, token: string) {
     if (this.values.get(key) !== token) return 0;
+    if (script.includes('persist')) return this.persistResult ?? 1;
+    if (this.releaseFailuresRemaining > 0) {
+      this.releaseFailuresRemaining -= 1;
+      throw new Error('lock cleanup unavailable');
+    }
     this.values.delete(key);
     return 1;
   }
@@ -155,6 +164,26 @@ describe('launch monitor', () => {
     expect(sends).toBe(1);
   });
 
+  test('uses a recoverable lease until notification delivery begins', async () => {
+    const redis = new FakeRedis(0, { persistResult: 0 });
+    let sends = 0;
+
+    const result = await evaluateLaunchMonitor(
+      dependencies({
+        redis,
+        send: async () => {
+          sends += 1;
+        },
+      }),
+    );
+
+    expect(result.delivery).toBe('locked');
+    expect(sends).toBe(0);
+    expect(
+      redis.setCalls.find((call) => call.key === 'LaunchNotification:warning:2026:lock')?.args,
+    ).toEqual(['PX', 60_000, 'NX']);
+  });
+
   test('retains the lock after an ambiguous delivery failure', async () => {
     const redis = new FakeRedis();
     let sends = 0;
@@ -194,6 +223,24 @@ describe('launch monitor', () => {
     expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(false);
   });
 
+  test('reports sent after marker persistence even when lock cleanup fails', async () => {
+    const redis = new FakeRedis(0, { releaseFailures: 1 });
+    let sends = 0;
+
+    const result = await evaluateLaunchMonitor(
+      dependencies({
+        redis,
+        send: async () => {
+          sends += 1;
+        },
+      }),
+    );
+
+    expect(result.delivery).toBe('sent');
+    expect(sends).toBe(1);
+    expect(redis.values.has('LaunchNotification:warning:2026')).toBe(true);
+  });
+
   test('retains the lock when delivery succeeds but every marker write fails', async () => {
     const redis = new FakeRedis(3);
     let sends = 0;
@@ -209,7 +256,7 @@ describe('launch monitor', () => {
     expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(true);
     expect(
       redis.setCalls.find((call) => call.key === 'LaunchNotification:warning:2026:lock')?.args,
-    ).toEqual(['NX']);
+    ).toEqual(['PX', 60_000, 'NX']);
 
     const nextTick = await evaluateLaunchMonitor(deps);
     expect(nextTick.delivery).toBe('locked');

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -127,6 +127,11 @@ describe('launch monitor', () => {
     expect(skipped).toMatchObject({ outcome: 'noop', delivery: 'skipped', requiredUnits: 0 });
     expect(redis.values.has('LaunchNotification:warning:2026')).toBe(false);
     expect(redis.values.has('LaunchNotification:warning:2026:lock')).toBe(false);
+    expect(
+      redis.setCalls.find(
+        (call) => call.key === 'LaunchNotification:warning:2026:lock' && call.args.includes('XX'),
+      )?.args,
+    ).toEqual(['PX', 60_000, 'XX']);
 
     let sends = 0;
     const delivered = await evaluateLaunchMonitor(

--- a/tests/unit/launch-monitor.test.ts
+++ b/tests/unit/launch-monitor.test.ts
@@ -117,11 +117,15 @@ describe('launch monitor', () => {
   });
 
   test('reports ordinary monitor no-ops as zero synchronization work', async () => {
-    const result = await evaluateLaunchMonitor(
-      dependencies({
-        events: [{ id: 1, deadline_time: '2025-08-15T10:00:00Z' }],
-      }),
-    );
+    let redisCalls = 0;
+    const deps = dependencies({
+      events: [{ id: 1, deadline_time: '2025-08-15T10:00:00Z' }],
+    });
+    deps.getRedis = async () => {
+      redisCalls += 1;
+      throw new Error('Redis should not be needed for an ordinary no-op');
+    };
+    const result = await evaluateLaunchMonitor(deps);
 
     expect(result).toMatchObject({
       outcome: 'noop',
@@ -131,6 +135,7 @@ describe('launch monitor', () => {
       succeededUnits: 0,
       failedUnits: 0,
     });
+    expect(redisCalls).toBe(0);
   });
 
   test('serializes concurrent ticks so only one notification is delivered', async () => {

--- a/tests/unit/league-event-results-summary.test.ts
+++ b/tests/unit/league-event-results-summary.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+
+import { summarizeMissingLeagueEventLiveData } from '../../src/services/league-event-results.service';
+import { inferDataSyncWorkSummary } from '../../src/utils/data-sync-attempt';
+
+describe('league event results prerequisites', () => {
+  test('reports every loaded entry as failed when event-live data is missing', () => {
+    const summary = summarizeMissingLeagueEventLiveData(42, 7, 75);
+
+    expect(summary).toEqual({
+      tournamentId: 42,
+      eventId: 7,
+      totalEntries: 75,
+      updated: 0,
+      skipped: 75,
+      requiredUnits: 75,
+      reusedUnits: 0,
+      succeededUnits: 0,
+      failedUnits: 75,
+    });
+    expect(inferDataSyncWorkSummary(summary)).toMatchObject({
+      requiredUnits: 75,
+      reusedUnits: 0,
+      succeededUnits: 0,
+      failedUnits: 75,
+    });
+  });
+});

--- a/tests/unit/manual-job-ids.test.ts
+++ b/tests/unit/manual-job-ids.test.ts
@@ -205,6 +205,8 @@ describe('entry-sync entry-list job IDs', () => {
     expect(second).not.toBeNull();
     expect(first!.id).toBe('entry-picks-manual-chunk-0');
     expect(second!.id).toBe(first!.id as string);
+    expect(entrySyncAddCalls[0].data.runId).not.toBe('manual');
+    expect(entrySyncAddCalls[1].data.runId).not.toBe(entrySyncAddCalls[0].data.runId);
     expect(entrySyncAddCalls[0].opts.removeOnComplete).toBe(true);
     expect(entrySyncAddCalls[0].opts.removeOnFail).toBe(true);
   });

--- a/tests/unit/manual-job-ids.test.ts
+++ b/tests/unit/manual-job-ids.test.ts
@@ -35,9 +35,10 @@ mock.module('../../src/queues/entry-sync.queue', () => ({
   ENTRY_SYNC_DEFAULT_THROTTLE_MS: 150,
   getEntrySyncQueue: () => ({
     name: 'entry-sync-p2',
+    getJobs: async () => [],
     add: async (name: string, data: Record<string, unknown>, opts: Record<string, unknown>) => {
       entrySyncAddCalls.push({ name, data, opts });
-      return { id: (opts.jobId as string | undefined) ?? 'generated-id' };
+      return { id: (opts.jobId as string | undefined) ?? 'generated-id', name, data };
     },
   }),
 }));

--- a/tests/unit/manual-job-ids.test.ts
+++ b/tests/unit/manual-job-ids.test.ts
@@ -231,6 +231,15 @@ describe('deterministic result job retention', () => {
       expect(call.opts.removeOnFail).toBe(true);
     }
   });
+
+  test('preserves a coordinator correlation ID in league child job data', async () => {
+    await enqueueLeagueEventResults(12, 'cascade', {
+      tournamentId: 42,
+      runId: 'league-run-42',
+    });
+
+    expect(leagueSyncAddCalls[0].data.runId).toBe('league-run-42');
+  });
 });
 
 describe('stableHash', () => {

--- a/tests/unit/player-stats-sync.test.ts
+++ b/tests/unit/player-stats-sync.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+const { syncCurrentPlayerStats } = await import('../../src/services/player-stats.service');
+
+describe('player stats synchronization reporting', () => {
+  test('publishes the target before bootstrap failures', async () => {
+    const resolvedEvents: number[] = [];
+    const getBootstrap = mock(async () => {
+      throw new Error('bootstrap unavailable');
+    });
+
+    await expect(
+      syncCurrentPlayerStats(
+        {
+          onTargetEventResolved: (eventId) => resolvedEvents.push(eventId),
+        },
+        {
+          getBootstrap,
+          resolvePlayerSyncEvent: async () =>
+            ({
+              event: { id: 12 },
+              phase: 'current',
+            }) as never,
+        },
+      ),
+    ).rejects.toThrow('bootstrap unavailable');
+
+    expect(resolvedEvents).toEqual([12]);
+    expect(getBootstrap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -59,6 +59,24 @@ function buildDependencies(
 }
 
 describe('player-values synchronization orchestration', () => {
+  test('reports the resolved target before later synchronization work fails', async () => {
+    const resolvedEvents: number[] = [];
+    const sync = createPlayerValuesSync(
+      buildDependencies({
+        findLatestForAllPlayers: async () => {
+          throw new Error('database unavailable after target resolution');
+        },
+      }),
+    );
+
+    await expect(
+      sync(changeDate, {
+        onTargetEventResolved: (eventId) => resolvedEvents.push(eventId),
+      }),
+    ).rejects.toThrow('database unavailable after target resolution');
+    expect(resolvedEvents).toEqual([1]);
+  });
+
   test('keeps the same season floor after the calendar year changes', () => {
     expect(getPlayerValueSeasonFloor('2026-08-15T17:30:00Z')).toBe('20260601');
     expect(getPlayerValueSeasonFloor('2027-01-02T11:00:00Z')).toBe('20260601');

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -123,7 +123,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 1 });
+    expect(await sync(changeDate)).toEqual({ count: 1, eventId: 1 });
     expect(persisted[0]).toMatchObject({ changeType: 'Start', lastValue: 0 });
     // Start rows seed the DB baseline but must never be published to Redis.
     expect(mergeCachedValues).not.toHaveBeenCalled();
@@ -158,7 +158,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(await sync(changeDate)).toEqual({ count: 0, eventId: 1 });
     expect(insertBatch).not.toHaveBeenCalled();
     expect(loadTeamsBasicInfo).not.toHaveBeenCalled();
     expect(inspectCachedValues).not.toHaveBeenCalled();
@@ -202,7 +202,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 1 });
+    expect(await sync(changeDate)).toEqual({ count: 1, eventId: 1 });
     expect(operations).toEqual(['persist', 'cache', 'enqueue', 'notify']);
   });
 
@@ -236,7 +236,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(await sync(changeDate)).toEqual({ count: 0, eventId: 1 });
     expect(mergeCachedValues).toHaveBeenCalledTimes(1);
     expect(mergeCachedValues).toHaveBeenCalledWith(changeDate, [cachedValue]);
   });
@@ -278,7 +278,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(await sync(changeDate)).toEqual({ count: 0, eventId: 1 });
     expect(operations).toEqual(['hset', 'hdel']);
   });
 
@@ -316,7 +316,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(await sync(changeDate)).toEqual({ count: 0, eventId: 1 });
     expect(mergeCachedValues).toHaveBeenCalledTimes(1);
     expect(deleteCachedFields).not.toHaveBeenCalled();
   });
@@ -352,7 +352,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(await sync(changeDate)).toEqual({ count: 0, eventId: 1 });
     expect(mergeCachedValues).not.toHaveBeenCalled();
     expect(deleteCachedFields).toHaveBeenCalledTimes(1);
   });
@@ -403,7 +403,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(await sync(changeDate)).toEqual({ count: 0, eventId: 1 });
     expect(findPlayersByIds).toHaveBeenCalledTimes(1);
     expect(mergeCachedValues).toHaveBeenCalledTimes(1);
     expect(enqueuePlayerPrices).toHaveBeenCalledTimes(1);
@@ -426,6 +426,6 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 1 });
+    expect(await sync(changeDate)).toEqual({ count: 1, eventId: 1 });
   });
 });

--- a/tests/unit/player-values-sync.test.ts
+++ b/tests/unit/player-values-sync.test.ts
@@ -95,7 +95,7 @@ describe('player-values synchronization orchestration', () => {
       }),
     );
 
-    expect(await sync(changeDate)).toEqual({ count: 0 });
+    expect(await sync(changeDate)).toEqual({ count: 0, outcome: 'noop' });
     expect(getBootstrap).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/strict-priority-gate.test.ts
+++ b/tests/unit/strict-priority-gate.test.ts
@@ -3,7 +3,7 @@ import type { Queue, Worker } from 'bullmq';
 
 import { startStrictPriorityGate } from '../../src/workers/strict-priority-gate';
 
-type MutableCounts = { waiting: number; active: number; delayed: number };
+type MutableCounts = { waiting: number; prioritized: number; active: number; delayed: number };
 
 class FakeQueue {
   constructor(private readonly counts: MutableCounts) {}
@@ -33,10 +33,10 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe('strict priority gate', () => {
   it('pauses lower tiers when higher tiers have backlog, then resumes', async () => {
-    const p0Counts: MutableCounts = { waiting: 2, active: 0, delayed: 0 };
-    const p1Counts: MutableCounts = { waiting: 1, active: 0, delayed: 0 };
-    const p2Counts: MutableCounts = { waiting: 1, active: 0, delayed: 0 };
-    const p3Counts: MutableCounts = { waiting: 1, active: 0, delayed: 0 };
+    const p0Counts: MutableCounts = { waiting: 2, prioritized: 0, active: 0, delayed: 0 };
+    const p1Counts: MutableCounts = { waiting: 1, prioritized: 0, active: 0, delayed: 0 };
+    const p2Counts: MutableCounts = { waiting: 1, prioritized: 0, active: 0, delayed: 0 };
+    const p3Counts: MutableCounts = { waiting: 1, prioritized: 0, active: 0, delayed: 0 };
 
     const p0Worker = new FakeWorker();
     const p1Worker = new FakeWorker();
@@ -86,6 +86,58 @@ describe('strict priority gate', () => {
     expect(p2Worker.resumeCount).toBeGreaterThan(0);
     expect(p3Worker.resumeCount).toBeGreaterThan(0);
 
+    gate.stop();
+  });
+
+  it('does not pause lower tiers for a future delayed retry', async () => {
+    const counts = {
+      p0: { waiting: 0, prioritized: 0, active: 0, delayed: 1 },
+      p1: { waiting: 0, prioritized: 0, active: 0, delayed: 0 },
+      p2: { waiting: 0, prioritized: 0, active: 0, delayed: 0 },
+      p3: { waiting: 0, prioritized: 0, active: 0, delayed: 0 },
+    } satisfies Record<string, MutableCounts>;
+    const workers = {
+      p0: new FakeWorker(),
+      p1: new FakeWorker(),
+      p2: new FakeWorker(),
+      p3: new FakeWorker(),
+    };
+
+    const gate = startStrictPriorityGate(
+      'test-domain',
+      {
+        p0: {
+          queue: new FakeQueue(counts.p0) as unknown as Queue<unknown>,
+          worker: workers.p0 as unknown as Worker<unknown>,
+        },
+        p1: {
+          queue: new FakeQueue(counts.p1) as unknown as Queue<unknown>,
+          worker: workers.p1 as unknown as Worker<unknown>,
+        },
+        p2: {
+          queue: new FakeQueue(counts.p2) as unknown as Queue<unknown>,
+          worker: workers.p2 as unknown as Worker<unknown>,
+        },
+        p3: {
+          queue: new FakeQueue(counts.p3) as unknown as Queue<unknown>,
+          worker: workers.p3 as unknown as Worker<unknown>,
+        },
+      },
+      { enabled: true, pollMs: 10 },
+    );
+
+    await sleep(40);
+
+    expect(workers.p1.paused).toBe(false);
+    expect(workers.p2.paused).toBe(false);
+    expect(workers.p3.paused).toBe(false);
+
+    counts.p0.prioritized = 1;
+    await sleep(40);
+
+    expect(workers.p1.paused).toBe(true);
+    expect(workers.p2.paused).toBe(true);
+    expect(workers.p3.paused).toBe(true);
     gate.stop();
   });
 });


### PR DESCRIPTION
## Purpose

Establish the non-live synchronization foundation without changing the Live pipeline:

- emit isolated, privacy-bounded data_sync_attempt reports;
- queue core repair APIs and return a durable 202 contract;
- combine launch polling into one five-minute, retry-safe monitor;
- ignore future delayed jobs in strict-priority backlog decisions;
- rely on BullMQ retry policy instead of manually retrying player values;
- document operational tracing and aggregation.

## Dependency

Stacked on #46. The Live pipeline PR #45 must land first; this branch will then be rebased with the tournament lifecycle branch before final review and merge.

## Validation

- bun run typecheck
- bun run lint (pre-existing warnings only)
- LOG_LEVEL=fatal bun test tests/unit: 562 pass
- bun run test:integration: 111 pass, 6 skip
- bun run build
- DATABASE_URL=... bun run db:check

No production mutation or Live pipeline behavior is included.