### PR TITLE
feat(sync): publish atomic core snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,22 @@ and staged update matrix in the
 ## Season rollover guarantees
 
 - Empty core arrays preserve existing database and cache state.
-- `Season:active` advances only to a newer, valid four-digit season derived
-  from FPL metadata.
+- Same-season core snapshots reserve a durable database revision before their
+  two upstream reads; an older delayed attempt cannot overwrite a newer one.
+- Legacy event, team, player, phase, and fixture refresh entry points all queue
+  that same complete snapshot; no partial core writer competes with it.
+- `Season:active` changes only with a matching committed
+  `core_snapshot_authority` record. A crash between PostgreSQL and Redis is
+  recovered by finalizing or rolling back the pending publication receipt.
+- Destructive database season rollover remains a separately approved runbook.
+  A newer candidate fails with `CORE_SNAPSHOT_MANUAL_ROLLOVER_REQUIRED` before
+  any canonical row or cache key changes until that runbook has completed.
 - When that key advances through a core write, all documented season-scoped
   Data cache families are scanned and prior-season keys are removed. This does
   not flush Redis, BullMQ state, price history, or consumer-owned keys.
-- PostgreSQL intentionally stores one FPL season at a time. IDs reused by FPL
-  overwrite the prior season's canonical rows.
+- PostgreSQL intentionally stores one FPL season at a time. Identity
+  reassignment is rejected rather than silently repointing historical foreign
+  keys; replacement belongs to the gated rollover procedure.
 - Player stats/values and live/selection jobs require both the fixture-derived
   season window and a current event. Core discovery jobs do not; bounded
   post-match result jobs intentionally remain eligible after the GW38 date.

--- a/docs/cache-ttl-summary.md
+++ b/docs/cache-ttl-summary.md
@@ -37,6 +37,9 @@ it is deliberately outside automatic season rollover.
 |---|---|
 | `Season:active` | No TTL; advances only from validated FPL season metadata |
 | `event:current` | No TTL; overwritten in place from the active Event hash |
+| `CoreSnapshotStage:*` | 15 minutes; crash-safe temporary hashes |
+| `CoreSnapshotPublication:pending` | No TTL; one durable recovery receipt, removed after DB commit reconciliation |
+| `CoreSnapshotBackup:*` | No TTL only while the matching pending receipt exists; removed by finalize/rollback recovery |
 | `LaunchNotification:*` | No TTL; year/season suffix provides re-arming |
 | `letletme:entry-info-sync:daily:*` | Expires at the next UTC midnight, minimum 60 seconds |
 | `mutation-lock:*` | Millisecond TTL from `MUTATION_LOCK_TTL_MS` |
@@ -51,8 +54,9 @@ the same hourly slot can be retried.
 
 - Entity writers replace affected hashes; reads do not extend retention.
 - Empty core upstream arrays preserve the previously accepted cache.
-- The first core write that advances `Season:active` scans all fifteen
-  season-scoped families and deletes prior-season keys.
+- After the separately gated database rollover, the committed core publication
+  that advances `Season:active` scans all fifteen season-scoped families and
+  deletes prior-season keys.
 - Rollover does not delete player-value history, notification markers, locks,
   cascade coordination, BullMQ state, or consumer-owned negative markers.
 - Never use `FLUSHDB` or `FLUSHALL` for cache maintenance.

--- a/docs/redis-contract.md
+++ b/docs/redis-contract.md
@@ -271,14 +271,31 @@ entity-key retention rules above.
 
 ## 11. Season rollover
 
-### Automatic today (when `Season:active` advances)
+### Atomic core publication (when `Season:active` advances)
 
-Core entity writers call `finalizeSeasonCacheWrite(season, prefixes)`, which:
+The core-snapshot worker publishes only after complete bootstrap and fixture
+validation. It:
 
-1. Updates `Season:active` only when the validated FPL-derived season is newer.
-2. If (and only if) that value **changed**, expands the cleanup set to the full
-   `SEASON_CACHE_PREFIXES` inventory and deletes keys that are not scoped to the
-   new active season.
+1. reserves a monotonic PostgreSQL revision before fetching;
+2. stages every core hash with a 15-minute TTL;
+3. validates every staging key inside one Redis Lua publication before any key
+   is replaced;
+4. records one `CoreSnapshotPublication:pending` recovery receipt and keeps
+   bounded backups until the matching PostgreSQL authority row commits;
+5. finalizes the backups on commit, or atomically restores them on rollback or
+   the next worker recovery pass;
+6. clears stale keys across the full `SEASON_CACHE_PREFIXES` inventory only
+   after the core DB/cache publication is consistent.
+
+The Redis swap checks `LiveSnapshotMeta:{season}:{eventId}` in the same Lua
+operation. A fixture hash owned by a published Live snapshot is excluded from
+the core receipt, backup, and replacement, while the remaining non-Live core
+families still publish atomically. The separately managed Live pipeline remains
+the only writer allowed to replace that event's coordinated fixture view.
+
+A candidate for a different season stops before mutation with
+`CORE_SNAPSHOT_MANUAL_ROLLOVER_REQUIRED`. Canonical table replacement is
+destructive and remains a separately approved runbook, outside ordinary sync.
 
 The automatic rollover prefixes are:
 

--- a/migrations/0045_core_snapshot_authority.sql
+++ b/migrations/0045_core_snapshot_authority.sql
@@ -1,0 +1,48 @@
+-- Durable authority follows the tournament lifecycle migration series.
+-- It coordinates the one-at-a-time non-Live core snapshot publication.
+-- The revision is reserved before upstream reads so a slow older fetch cannot
+-- overwrite a newer snapshot after waiting for the mutation lock.
+
+CREATE SEQUENCE IF NOT EXISTS public.core_snapshot_revision_seq AS bigint START WITH 1;
+
+CREATE TABLE IF NOT EXISTS public.core_snapshot_authority (
+  singleton_id smallint PRIMARY KEY DEFAULT 1 CHECK (singleton_id = 1),
+  season text NOT NULL CHECK (season ~ '^[0-9]{4}$'),
+  revision bigint NOT NULL CHECK (revision > 0),
+  publication_id uuid NOT NULL,
+  committed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS core_snapshot_authority_publication_id_idx
+  ON public.core_snapshot_authority (publication_id);
+
+-- Generic players.updated_at is also advanced by complete core upserts. Keep
+-- price-writer source evidence separate so an older core job cannot masquerade
+-- as a newer partial price update during snapshot reconciliation.
+ALTER TABLE public.players
+  ADD COLUMN IF NOT EXISTS price_source_checked_at timestamptz;
+
+ALTER TABLE public.core_snapshot_authority ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.core_snapshot_authority FROM PUBLIC;
+REVOKE ALL ON SEQUENCE public.core_snapshot_revision_seq FROM PUBLIC;
+
+DO $$
+DECLARE
+  client_role text;
+BEGIN
+  FOREACH client_role IN ARRAY ARRAY['anon', 'authenticated']
+  LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = client_role) THEN
+      EXECUTE format(
+        'REVOKE ALL ON TABLE public.core_snapshot_authority FROM %I',
+        client_role
+      );
+      EXECUTE format(
+        'REVOKE ALL ON SEQUENCE public.core_snapshot_revision_seq FROM %I',
+        client_role
+      );
+    END IF;
+  END LOOP;
+END
+$$;

--- a/migrations/0049_core_snapshot_authority.sql
+++ b/migrations/0049_core_snapshot_authority.sql
@@ -17,8 +17,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS core_snapshot_authority_publication_id_idx
   ON public.core_snapshot_authority (publication_id);
 
 -- Generic players.updated_at is also advanced by complete core upserts. Keep
--- price-writer source evidence separate so an older core job cannot masquerade
--- as a newer partial price update during snapshot reconciliation.
+-- source-ordering evidence separate so an older core or price job cannot
+-- masquerade as a newer partial price update during snapshot reconciliation.
 ALTER TABLE public.players
   ADD COLUMN IF NOT EXISTS price_source_checked_at timestamptz;
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "env:check": "bun validate-env.ts",
     "test": "bun test tests/unit",
     "test:integration": "RUN_INTEGRATION=1 bun test tests/integration",
+    "test:core-snapshot": "LOG_LEVEL=error RUN_INTEGRATION=1 RUN_CORE_SNAPSHOT_INTEGRATION=1 bun test tests/integration/core-snapshot-atomicity.test.ts",
+    "test:core-snapshot-benchmark": "LOG_LEVEL=error RUN_INTEGRATION=1 RUN_CORE_SNAPSHOT_BENCHMARK=1 bun test tests/integration/core-snapshot-benchmark.test.ts",
     "test:tournament-benchmark": "LOG_LEVEL=error RUN_INTEGRATION=1 RUN_TOURNAMENT_BENCHMARK=1 bun test tests/integration/tournament-setup-benchmark.test.ts",
     "test:all": "bun test",
     "typecheck": "bunx tsc --noEmit",

--- a/src/api/events.api.ts
+++ b/src/api/events.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { enqueueEventsSyncJob } from '../jobs/data-sync-enqueue';
+import { enqueueCoreSnapshotJob } from '../jobs/data-sync-enqueue';
 import { getCurrentEvent, getNextEvent } from '../services/events.service';
 
 export const eventsAPI = new Elysia({ prefix: '/events' })
@@ -13,7 +13,7 @@ export const eventsAPI = new Elysia({ prefix: '/events' })
     return { success: true, data };
   })
   .post('/sync', async ({ set }) => {
-    const job = await enqueueEventsSyncJob('api');
+    const job = await enqueueCoreSnapshotJob('api');
     set.status = 202;
-    return { success: true, message: 'Events sync job enqueued', jobId: job.id };
+    return { success: true, message: 'Core snapshot job enqueued', jobId: job.id };
   });

--- a/src/api/fixtures.api.ts
+++ b/src/api/fixtures.api.ts
@@ -1,17 +1,14 @@
 import { Elysia, t } from 'elysia';
 
-import {
-  enqueueFixturesAllGameweeksSyncJob,
-  enqueueFixturesSyncJob,
-} from '../jobs/data-sync-enqueue';
+import { enqueueCoreSnapshotJob } from '../jobs/data-sync-enqueue';
 import { clearFixturesCache } from '../services/fixtures.service';
 
 /**
  * Fixtures API Routes
  *
  * Handles all fixture-related HTTP endpoints:
- * - POST /fixtures/sync - Enqueue fixtures sync (all or specific event), 202
- * - POST /fixtures/sync-all-gameweeks - Enqueue per-GW backfill (isolated errors), 202
+ * - POST /fixtures/sync - Enqueue the complete core snapshot, 202
+ * - POST /fixtures/sync-all-gameweeks - Compatibility alias for the same snapshot, 202
  * - DELETE /fixtures/cache - Clear fixtures cache
  */
 
@@ -19,16 +16,17 @@ export const fixturesAPI = new Elysia({ prefix: '/fixtures' })
   .post(
     '/sync',
     async ({ query, set }) => {
-      const job = await enqueueFixturesSyncJob('api', {
-        ...(query.event !== undefined ? { eventId: query.event } : {}),
-      });
+      const job =
+        query.event === undefined
+          ? await enqueueCoreSnapshotJob('api')
+          : await enqueueCoreSnapshotJob('api', { eventId: query.event });
       set.status = 202;
       return {
         success: true,
         message:
           query.event !== undefined
-            ? `Fixtures sync job enqueued for event ${query.event}`
-            : 'Fixtures sync job enqueued',
+            ? `Core snapshot job enqueued for fixture event ${query.event}`
+            : 'Core snapshot job enqueued',
         jobId: job.id,
       };
     },
@@ -38,13 +36,11 @@ export const fixturesAPI = new Elysia({ prefix: '/fixtures' })
   )
 
   .post('/sync-all-gameweeks', async ({ set }) => {
-    // Dedicated job → syncAllGameweeks(): per-GW try/catch so one bad week
-    // does not abort the whole 1–38 backfill (unlike syncFixtures(undefined)).
-    const job = await enqueueFixturesAllGameweeksSyncJob('api');
+    const job = await enqueueCoreSnapshotJob('api');
     set.status = 202;
     return {
       success: true,
-      message: 'Fixtures all-gameweeks backfill job enqueued',
+      message: 'Core snapshot job enqueued',
       jobId: job.id,
     };
   })

--- a/src/api/phases.api.ts
+++ b/src/api/phases.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { enqueuePhasesSyncJob } from '../jobs/data-sync-enqueue';
+import { enqueueCoreSnapshotJob } from '../jobs/data-sync-enqueue';
 
 /**
  * Phases API Routes
@@ -10,13 +10,13 @@ import { enqueuePhasesSyncJob } from '../jobs/data-sync-enqueue';
  */
 
 export const phasesAPI = new Elysia({ prefix: '/phases' }).post('/sync', async ({ set }) => {
-  const job = await enqueuePhasesSyncJob('api');
+  const job = await enqueueCoreSnapshotJob('api');
   if (job.id === undefined) throw new Error('Phases sync queue did not assign a job ID');
   set.status = 202;
   return {
     success: true,
     status: 'queued' as const,
     jobId: String(job.id),
-    message: 'Phases sync queued',
+    message: 'Core snapshot queued',
   };
 });

--- a/src/api/players.api.ts
+++ b/src/api/players.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { enqueuePlayersSyncJob } from '../jobs/data-sync-enqueue';
+import { enqueueCoreSnapshotJob } from '../jobs/data-sync-enqueue';
 
 /**
  * Players API Routes
@@ -10,7 +10,7 @@ import { enqueuePlayersSyncJob } from '../jobs/data-sync-enqueue';
  */
 
 export const playersAPI = new Elysia({ prefix: '/players' }).post('/sync', async ({ set }) => {
-  const job = await enqueuePlayersSyncJob('api');
+  const job = await enqueueCoreSnapshotJob('api');
   set.status = 202;
-  return { success: true, message: 'Players sync job enqueued', jobId: job.id };
+  return { success: true, message: 'Core snapshot job enqueued', jobId: job.id };
 });

--- a/src/api/teams.api.ts
+++ b/src/api/teams.api.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { enqueueTeamsSyncJob } from '../jobs/data-sync-enqueue';
+import { enqueueCoreSnapshotJob } from '../jobs/data-sync-enqueue';
 
 /**
  * Teams API Routes
@@ -10,13 +10,13 @@ import { enqueueTeamsSyncJob } from '../jobs/data-sync-enqueue';
  */
 
 export const teamsAPI = new Elysia({ prefix: '/teams' }).post('/sync', async ({ set }) => {
-  const job = await enqueueTeamsSyncJob('api');
+  const job = await enqueueCoreSnapshotJob('api');
   if (job.id === undefined) throw new Error('Teams sync queue did not assign a job ID');
   set.status = 202;
   return {
     success: true,
     status: 'queued' as const,
     jobId: String(job.id),
-    message: 'Teams sync queued',
+    message: 'Core snapshot queued',
   };
 });

--- a/src/cache/cache-season.ts
+++ b/src/cache/cache-season.ts
@@ -1,7 +1,7 @@
 import type { Redis } from 'ioredis';
 import { sql } from 'drizzle-orm';
 
-import { getDb, type DbOrTransaction } from '../db/singleton';
+import { getDb, type DbHandle, type DbOrTransaction } from '../db/singleton';
 import { logDebug, logError, logInfo } from '../utils/logger';
 import { redisSingleton } from './singleton';
 
@@ -40,6 +40,12 @@ function getActiveSeasonMemoTtlMs(): number {
 
 function memoizeActiveSeason(season: string): void {
   activeSeasonMemo = { season, expiresAt: Date.now() + getActiveSeasonMemoTtlMs() };
+}
+
+/** Called only after the complete core snapshot transaction publishes Season:active. */
+export function rememberCoreSnapshotActiveSeason(season: string): void {
+  if (!isValidSeason(season)) throw new Error(`Invalid active cache season: ${season}`);
+  memoizeActiveSeason(season);
 }
 
 function readActiveSeasonMemo(): string | null {
@@ -163,6 +169,17 @@ export function deriveSeasonFromFixtures(fixtures: readonly FixtureLike[]): stri
   return seasonFromStartYear(Math.min(...gw1Kickoffs));
 }
 
+export function resolveFixtureRepairSeason(
+  fixtures: readonly FixtureLike[],
+  authoritativeSeason?: string | null,
+): string | null {
+  const fixtureSeason = deriveSeasonFromFixtures(fixtures);
+  if (authoritativeSeason === undefined) return fixtureSeason;
+  if (!isValidSeason(authoritativeSeason)) return null;
+  if (fixtureSeason && fixtureSeason !== authoritativeSeason) return null;
+  return authoritativeSeason;
+}
+
 export async function getActiveCacheSeason(): Promise<string> {
   const memoized = readActiveSeasonMemo();
   if (memoized) {
@@ -207,65 +224,35 @@ export async function acquireActiveSeasonReadFence(tx: DbOrTransaction): Promise
   );
 }
 
-async function withActiveSeasonWriteFence<T>(operation: () => Promise<T>): Promise<T> {
-  const db = await getDb();
+export async function acquireActiveSeasonWriteFence(tx: DbOrTransaction): Promise<void> {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(${ACTIVE_SEASON_LOCK_NAMESPACE}, ${ACTIVE_SEASON_LOCK_ID})`,
+  );
+}
+
+export async function withActiveSeasonWriteFence<T>(
+  operation: () => Promise<T>,
+  dbInstance?: DbHandle,
+): Promise<T> {
+  const db = dbInstance ?? (await getDb());
   return db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(${ACTIVE_SEASON_LOCK_NAMESPACE}, ${ACTIVE_SEASON_LOCK_ID})`,
-    );
+    await acquireActiveSeasonWriteFence(tx);
     return operation();
   });
 }
 
-async function advanceActiveCacheSeason(
-  season: string,
-  afterAdvance?: () => Promise<void>,
-): Promise<boolean> {
-  if (!isValidSeason(season)) {
-    throw new Error(`Invalid active cache season: ${season}`);
-  }
-
-  const redis = await redisSingleton.getClient();
-  const preflight = await redis.get(ACTIVE_SEASON_KEY);
-  if (!isNewerSeason(season, preflight)) {
-    logDebug('Skipping active cache season update; candidate is not newer', {
-      candidate: season,
-      current: preflight,
-    });
-    if (isValidSeason(preflight)) memoizeActiveSeason(preflight);
-    return false;
-  }
-
-  return withActiveSeasonWriteFence(async () => {
-    // Another season publisher may have won while this process waited for
-    // live snapshot readers. Re-check under the exclusive fence.
-    const current = await redis.get(ACTIVE_SEASON_KEY);
-    if (!isNewerSeason(season, current)) {
-      logDebug('Skipping active cache season update after fenced recheck', {
-        candidate: season,
-        current,
-      });
-      if (isValidSeason(current)) memoizeActiveSeason(current);
-      return false;
-    }
-
-    await redis.set(ACTIVE_SEASON_KEY, season);
-    memoizeActiveSeason(season);
-    await afterAdvance?.();
-    logInfo('Active cache season updated', { season, previous: current });
-    return true;
-  });
-}
-
-export async function setActiveCacheSeason(season: string): Promise<boolean> {
-  return advanceActiveCacheSeason(season);
+export async function readStoredActiveCacheSeason(redisClient?: Redis): Promise<string | null> {
+  const redis = redisClient ?? (await redisSingleton.getClient());
+  const current = await redis.get(ACTIVE_SEASON_KEY);
+  return isValidSeason(current) ? current : null;
 }
 
 export async function clearStaleSeasonCache(
   activeSeason: string,
   prefixes: readonly string[] = SEASON_CACHE_PREFIXES,
+  redisClient?: Redis,
 ): Promise<void> {
-  const redis = await redisSingleton.getClient();
+  const redis = redisClient ?? (await redisSingleton.getClient());
   const staleKeys: string[] = [];
 
   for (const prefix of prefixes) {
@@ -293,8 +280,12 @@ export async function clearStaleSeasonCache(
 
 export async function finalizeSeasonCacheWrite(
   season: string,
-  prefixes: readonly string[],
+  _prefixes: readonly string[],
 ): Promise<void> {
-  const rolloverPrefixes = [...new Set([...SEASON_CACHE_PREFIXES, ...prefixes])];
-  await advanceActiveCacheSeason(season, () => clearStaleSeasonCache(season, rolloverPrefixes));
+  const activeSeason = await readStoredActiveCacheSeason();
+  if (activeSeason !== season) {
+    throw new Error(
+      `Core snapshot required before publishing season cache data (candidate=${season})`,
+    );
+  }
 }

--- a/src/cache/core-snapshot-cache.ts
+++ b/src/cache/core-snapshot-cache.ts
@@ -11,7 +11,7 @@ import {
   rememberCoreSnapshotActiveSeason,
   resetActiveSeasonMemo,
 } from './cache-season';
-import { buildFixturesByTeam } from './fixtures-cache';
+import { buildFixturesByTeam, isLiveSnapshotStagingKey } from './fixtures-cache';
 import { liveSnapshotMetaKey } from './live-snapshot-ownership';
 import { redisSingleton } from './singleton';
 
@@ -94,6 +94,7 @@ for _, item in ipairs(payload.staged) do
   local snapshotOwned = item.metaKey and redis.call('EXISTS', item.metaKey) == 1
   if not snapshotOwned then
     redis.call('RENAME', item.stageKey, item.finalKey)
+    redis.call('PERSIST', item.finalKey)
     table.insert(finalKeys, item.finalKey)
   end
 end
@@ -436,7 +437,9 @@ export async function publishCoreSnapshotCache(
     }
 
     const [existingFixtures, existingTeamFixtures] = await Promise.all([
-      scanKeys(redis, `Fixtures:${snapshot.season}:*`),
+      scanKeys(redis, `Fixtures:${snapshot.season}:*`).then((keys) =>
+        keys.filter((key) => !isLiveSnapshotStagingKey(key, snapshot.season)),
+      ),
       scanKeys(redis, `FixturesByTeam:${snapshot.season}:*`),
     ]);
     const targetKeys = [

--- a/src/cache/core-snapshot-cache.ts
+++ b/src/cache/core-snapshot-cache.ts
@@ -239,6 +239,7 @@ export function buildCoreSnapshotCachePlan(snapshot: CoreSnapshot): CoreSnapshot
     teamById,
   );
   for (const [teamId, eventMap] of fixturesByTeam) {
+    if (eventMap.size === 0) continue;
     hashes.set(
       `FixturesByTeam:${snapshot.season}:${teamId}`,
       Object.fromEntries(

--- a/src/cache/core-snapshot-cache.ts
+++ b/src/cache/core-snapshot-cache.ts
@@ -1,0 +1,572 @@
+import { randomUUID } from 'node:crypto';
+
+import type { Redis } from 'ioredis';
+
+import { selectCurrentEventByDeadline } from '../domain/events';
+import { CacheError } from '../utils/errors';
+import { logWarn } from '../utils/logger';
+import {
+  ACTIVE_SEASON_KEY,
+  isNewerSeason,
+  rememberCoreSnapshotActiveSeason,
+  resetActiveSeasonMemo,
+} from './cache-season';
+import { buildFixturesByTeam } from './fixtures-cache';
+import { liveSnapshotMetaKey } from './live-snapshot-ownership';
+import { redisSingleton } from './singleton';
+
+import type { CoreSnapshot } from '../domain/core-snapshot';
+import type { Event, Fixture, Player } from '../types';
+
+type HashFields = Record<string, string>;
+
+export interface CoreSnapshotCachePlan {
+  hashes: Map<string, HashFields>;
+  currentEvent: string | null;
+}
+
+export interface CoreSnapshotCachePublication {
+  published: boolean;
+  reason: 'published' | 'newer_active_season';
+  hashCount: number;
+  receipt?: CoreSnapshotCachePublicationReceipt;
+}
+
+export interface CoreSnapshotCachePublicationReceipt {
+  publicationId: string;
+  season: string;
+  sourceCheckedAt: string;
+  fixtureIds: number[];
+  previousActiveSeason: string | null;
+  finalKeys: string[];
+  backups: Array<{ key: string; backupKey: string }>;
+  currentEventBackupKey: string;
+}
+
+type PublishOptions = {
+  redis?: Redis;
+  publicationId?: string;
+  sourceCheckedAt?: Date;
+  afterStage?: () => Promise<void>;
+};
+
+export const CORE_SNAPSHOT_PENDING_PUBLICATION_KEY = 'CoreSnapshotPublication:pending';
+export const CORE_SNAPSHOT_STAGING_TTL_MS = 15 * 60_000;
+
+const PUBLISH_SCRIPT = `
+local payload = cjson.decode(ARGV[1])
+local active = redis.call('GET', KEYS[1])
+local normalizedActive = active or ''
+if normalizedActive ~= payload.expectedActive then
+  return {'authority_changed', normalizedActive}
+end
+if redis.call('EXISTS', KEYS[3]) == 1 then
+  return {'pending_publication'}
+end
+for _, item in ipairs(payload.staged) do
+  if redis.call('EXISTS', item.stageKey) ~= 1 then
+    return {'missing_stage', item.stageKey}
+  end
+  if redis.call('HLEN', item.stageKey) ~= item.expectedCount then
+    return {'invalid_stage', item.stageKey}
+  end
+end
+for _, item in ipairs(payload.backups) do
+  local snapshotOwned = item.metaKey and redis.call('EXISTS', item.metaKey) == 1
+  if not snapshotOwned and redis.call('EXISTS', item.key) == 1 then
+    redis.call('DEL', item.backupKey)
+    redis.call('RENAME', item.key, item.backupKey)
+  end
+end
+redis.call('DEL', payload.currentEventBackupKey)
+if redis.call('EXISTS', KEYS[2]) == 1 then
+  redis.call('RENAME', KEYS[2], payload.currentEventBackupKey)
+end
+local finalKeys = {}
+local backups = {}
+for _, item in ipairs(payload.backups) do
+  local snapshotOwned = item.metaKey and redis.call('EXISTS', item.metaKey) == 1
+  if not snapshotOwned then
+    table.insert(backups, {key = item.key, backupKey = item.backupKey})
+  end
+end
+for _, item in ipairs(payload.staged) do
+  local snapshotOwned = item.metaKey and redis.call('EXISTS', item.metaKey) == 1
+  if not snapshotOwned then
+    redis.call('RENAME', item.stageKey, item.finalKey)
+    table.insert(finalKeys, item.finalKey)
+  end
+end
+if payload.currentEvent == cjson.null then
+  redis.call('DEL', KEYS[2])
+else
+  redis.call('SET', KEYS[2], payload.currentEvent)
+end
+redis.call('SET', KEYS[1], payload.season)
+local receipt = {
+  publicationId = payload.publicationId,
+  season = payload.season,
+  sourceCheckedAt = payload.sourceCheckedAt,
+  fixtureIds = payload.fixtureIds,
+  previousActiveSeason = payload.previousActiveSeason,
+  finalKeys = finalKeys,
+  backups = backups,
+  currentEventBackupKey = payload.currentEventBackupKey
+}
+local encodedReceipt = cjson.encode(receipt)
+redis.call('SET', KEYS[3], encodedReceipt)
+return {'published', tostring(#finalKeys), encodedReceipt}
+`;
+
+const FINALIZE_SCRIPT = `
+local pending = redis.call('GET', KEYS[1])
+if not pending then return {'noop'} end
+local stored = cjson.decode(pending)
+local receipt = cjson.decode(ARGV[1])
+if stored.publicationId ~= receipt.publicationId then
+  return {'different_publication'}
+end
+for _, item in ipairs(receipt.backups) do redis.call('DEL', item.backupKey) end
+redis.call('DEL', receipt.currentEventBackupKey)
+redis.call('DEL', KEYS[1])
+return {'finalized'}
+`;
+
+const ROLLBACK_SCRIPT = `
+local pending = redis.call('GET', KEYS[3])
+if not pending then return {'noop'} end
+local stored = cjson.decode(pending)
+local receipt = cjson.decode(ARGV[1])
+if stored.publicationId ~= receipt.publicationId then
+  return {'different_publication'}
+end
+
+local fixture_prefix = 'Fixtures:' .. receipt.season .. ':'
+local function live_snapshot_owns(key)
+  if string.sub(key, 1, string.len(fixture_prefix)) ~= fixture_prefix then
+    return false
+  end
+  local event_id = string.sub(key, string.len(fixture_prefix) + 1)
+  if string.match(event_id, '^%d+$') == nil then
+    return false
+  end
+  return redis.call('EXISTS', 'LiveSnapshotMeta:' .. receipt.season .. ':' .. event_id) == 1
+end
+
+for _, key in ipairs(receipt.finalKeys) do
+  if not live_snapshot_owns(key) then redis.call('DEL', key) end
+end
+for _, item in ipairs(receipt.backups) do
+  if live_snapshot_owns(item.key) then
+    redis.call('DEL', item.backupKey)
+  elseif redis.call('EXISTS', item.backupKey) == 1 then
+    redis.call('DEL', item.key)
+    redis.call('RENAME', item.backupKey, item.key)
+  end
+end
+
+if ARGV[2] ~= '' and redis.call('EXISTS', ARGV[2]) == 1 then
+  local durable_players = cjson.decode(ARGV[3])
+  for element_id, player in pairs(durable_players) do
+    if redis.call('HEXISTS', ARGV[2], element_id) == 1 then
+      redis.call('HSET', ARGV[2], element_id, player)
+    end
+  end
+end
+
+redis.call('DEL', KEYS[2])
+if redis.call('EXISTS', receipt.currentEventBackupKey) == 1 then
+  redis.call('RENAME', receipt.currentEventBackupKey, KEYS[2])
+end
+if receipt.previousActiveSeason == cjson.null then
+  redis.call('DEL', KEYS[1])
+else
+  redis.call('SET', KEYS[1], receipt.previousActiveSeason)
+end
+redis.call('DEL', KEYS[3])
+return {'rolled_back'}
+`;
+
+function serializeEvent(event: Event): string {
+  return JSON.stringify(event);
+}
+
+function fixtureHash(fixtures: Fixture[]): HashFields {
+  return Object.fromEntries(
+    fixtures.map((fixture) => [String(fixture.id), JSON.stringify(fixture)]),
+  );
+}
+
+export function buildCoreSnapshotCachePlan(snapshot: CoreSnapshot): CoreSnapshotCachePlan {
+  const hashes = new Map<string, HashFields>();
+  hashes.set(
+    `Event:${snapshot.season}`,
+    Object.fromEntries(snapshot.events.map((event) => [String(event.id), serializeEvent(event)])),
+  );
+  hashes.set(
+    `Team:${snapshot.season}`,
+    Object.fromEntries(snapshot.teams.map((team) => [String(team.id), JSON.stringify(team)])),
+  );
+  hashes.set(
+    `Player:${snapshot.season}`,
+    Object.fromEntries(
+      snapshot.players.map((player) => [String(player.id), JSON.stringify(player)]),
+    ),
+  );
+  hashes.set(
+    `Phase:${snapshot.season}`,
+    Object.fromEntries(snapshot.phases.map((phase) => [String(phase.id), JSON.stringify(phase)])),
+  );
+
+  const fixturesByEvent = new Map<number | 'unscheduled', Fixture[]>();
+  for (const fixture of snapshot.fixtures) {
+    const eventKey = fixture.event ?? 'unscheduled';
+    const eventFixtures = fixturesByEvent.get(eventKey) ?? [];
+    eventFixtures.push(fixture);
+    fixturesByEvent.set(eventKey, eventFixtures);
+  }
+  for (const [eventId, fixtures] of fixturesByEvent) {
+    hashes.set(`Fixtures:${snapshot.season}:${eventId}`, fixtureHash(fixtures));
+  }
+
+  const teamById = new Map(
+    snapshot.teams.map((team) => [team.id, { name: team.name, shortName: team.shortName }]),
+  );
+  const fixturesByTeam = buildFixturesByTeam(
+    snapshot.teams.map((team) => team.id),
+    snapshot.fixtures,
+    teamById,
+  );
+  for (const [teamId, eventMap] of fixturesByTeam) {
+    hashes.set(
+      `FixturesByTeam:${snapshot.season}:${teamId}`,
+      Object.fromEntries(
+        [...eventMap].map(([eventId, fixture]) => [String(eventId), JSON.stringify(fixture)]),
+      ),
+    );
+  }
+
+  for (const fields of hashes.values()) {
+    if (Object.keys(fields).length === 0) {
+      throw new CacheError(
+        'Core snapshot cache plan contains an empty hash',
+        'CORE_SNAPSHOT_EMPTY_CACHE_HASH',
+      );
+    }
+  }
+
+  const currentEvent = selectCurrentEventByDeadline(snapshot.events);
+  return {
+    hashes,
+    currentEvent: currentEvent ? serializeEvent(currentEvent) : null,
+  };
+}
+
+async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor = '0';
+  do {
+    const [nextCursor, found] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+    keys.push(...found);
+    cursor = nextCursor;
+  } while (cursor !== '0');
+  return keys;
+}
+
+async function execChecked(
+  command: ReturnType<Redis['pipeline']>,
+  code: string,
+): Promise<Array<[Error | null, unknown]>> {
+  const result = await command.exec();
+  if (!result) throw new CacheError('Redis transaction returned no result', code);
+  const errors = result.filter(([error]) => error !== null);
+  if (errors.length > 0) {
+    throw new CacheError('Redis transaction contained command failures', code);
+  }
+  return result as Array<[Error | null, unknown]>;
+}
+
+function isValidSeason(value: string | null): value is string {
+  return value !== null && /^\d{4}$/.test(value);
+}
+
+function firstResponseValue(result: unknown): string {
+  if (!Array.isArray(result) || result.length === 0) return '';
+  const value = result[0];
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+function responseValue(result: unknown, index: number): string {
+  if (!Array.isArray(result) || result.length <= index) return '';
+  const value = result[index];
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+function fixtureOwnershipMetaKey(key: string, season: string): string | undefined {
+  const match = key.match(new RegExp(`^Fixtures:${season}:(\\d+)$`));
+  if (!match) return undefined;
+  const eventId = Number(match[1]);
+  return Number.isInteger(eventId) && eventId > 0
+    ? liveSnapshotMetaKey(season, eventId)
+    : undefined;
+}
+
+function parseReceipt(value: string): CoreSnapshotCachePublicationReceipt {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new CacheError(
+      'Core snapshot pending publication marker is malformed',
+      'CORE_SNAPSHOT_PENDING_MARKER_INVALID',
+    );
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !('publicationId' in parsed) ||
+    typeof parsed.publicationId !== 'string' ||
+    !('season' in parsed) ||
+    typeof parsed.season !== 'string' ||
+    !('sourceCheckedAt' in parsed) ||
+    typeof parsed.sourceCheckedAt !== 'string' ||
+    !('fixtureIds' in parsed) ||
+    !Array.isArray(parsed.fixtureIds) ||
+    !('finalKeys' in parsed) ||
+    !Array.isArray(parsed.finalKeys) ||
+    !('backups' in parsed) ||
+    !Array.isArray(parsed.backups) ||
+    !('currentEventBackupKey' in parsed) ||
+    typeof parsed.currentEventBackupKey !== 'string'
+  ) {
+    throw new CacheError(
+      'Core snapshot pending publication marker is incomplete',
+      'CORE_SNAPSHOT_PENDING_MARKER_INVALID',
+    );
+  }
+  const receipt = parsed as CoreSnapshotCachePublicationReceipt;
+  const publicationPrefix = `CoreSnapshotBackup:${receipt.season}:${receipt.publicationId}:`;
+  const validCoreKey = (key: string) =>
+    [
+      `Event:${receipt.season}`,
+      `Team:${receipt.season}`,
+      `Player:${receipt.season}`,
+      `Phase:${receipt.season}`,
+    ].includes(key) ||
+    key.startsWith(`Fixtures:${receipt.season}:`) ||
+    key.startsWith(`FixturesByTeam:${receipt.season}:`);
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      receipt.publicationId,
+    ) ||
+    !isValidSeason(receipt.season) ||
+    Number.isNaN(Date.parse(receipt.sourceCheckedAt)) ||
+    receipt.fixtureIds.length > 500 ||
+    receipt.fixtureIds.some((id) => !Number.isInteger(id) || id <= 0) ||
+    new Set(receipt.fixtureIds).size !== receipt.fixtureIds.length ||
+    (receipt.previousActiveSeason !== null && !isValidSeason(receipt.previousActiveSeason)) ||
+    receipt.finalKeys.some((key) => typeof key !== 'string' || !validCoreKey(key)) ||
+    receipt.backups.some(
+      (item) =>
+        !item ||
+        typeof item.key !== 'string' ||
+        typeof item.backupKey !== 'string' ||
+        !validCoreKey(item.key) ||
+        !item.backupKey.startsWith(publicationPrefix),
+    ) ||
+    !receipt.currentEventBackupKey.startsWith(publicationPrefix)
+  ) {
+    throw new CacheError(
+      'Core snapshot pending publication marker contains unsafe keys',
+      'CORE_SNAPSHOT_PENDING_MARKER_INVALID',
+    );
+  }
+  return receipt;
+}
+
+export async function publishCoreSnapshotCache(
+  snapshot: CoreSnapshot,
+  options: PublishOptions = {},
+): Promise<CoreSnapshotCachePublication> {
+  const redis = options.redis ?? (await redisSingleton.getClient());
+  const current = await redis.get(ACTIVE_SEASON_KEY);
+  if (current !== null && !isValidSeason(current)) {
+    throw new CacheError('Active cache season is malformed', 'CORE_SNAPSHOT_ACTIVE_SEASON_INVALID');
+  }
+  if (isValidSeason(current) && isNewerSeason(current, snapshot.season)) {
+    return { published: false, reason: 'newer_active_season', hashCount: 0 };
+  }
+
+  const plan = buildCoreSnapshotCachePlan(snapshot);
+  const token = options.publicationId ?? randomUUID();
+  const staged = new Map<string, string>(
+    [...plan.hashes.keys()].map((finalKey, index) => [
+      finalKey,
+      `CoreSnapshotStage:${snapshot.season}:${token}:${index}`,
+    ]),
+  );
+  const stagingKeys = [...staged.values()];
+
+  try {
+    const stage = redis.pipeline();
+    for (const [finalKey, fields] of plan.hashes) {
+      stage.hset(staged.get(finalKey)!, fields);
+      stage.pexpire(staged.get(finalKey)!, CORE_SNAPSHOT_STAGING_TTL_MS);
+    }
+    await execChecked(stage, 'CORE_SNAPSHOT_STAGE_FAILED');
+
+    const verify = redis.pipeline();
+    for (const stagingKey of stagingKeys) verify.hlen(stagingKey);
+    const verified = await execChecked(verify, 'CORE_SNAPSHOT_STAGE_VERIFY_FAILED');
+    const expectedCounts = [...plan.hashes.values()].map((fields) => Object.keys(fields).length);
+    verified.forEach(([, count], index) => {
+      if (Number(count) !== expectedCounts[index]) {
+        throw new CacheError(
+          'Core snapshot staged hash count mismatch',
+          'CORE_SNAPSHOT_STAGE_INCOMPLETE',
+        );
+      }
+    });
+
+    await options.afterStage?.();
+
+    const latest = await redis.get(ACTIVE_SEASON_KEY);
+    if (isValidSeason(latest) && isNewerSeason(latest, snapshot.season)) {
+      return { published: false, reason: 'newer_active_season', hashCount: 0 };
+    }
+
+    const [existingFixtures, existingTeamFixtures] = await Promise.all([
+      scanKeys(redis, `Fixtures:${snapshot.season}:*`),
+      scanKeys(redis, `FixturesByTeam:${snapshot.season}:*`),
+    ]);
+    const targetKeys = [
+      ...new Set([...plan.hashes.keys(), ...existingFixtures, ...existingTeamFixtures]),
+    ];
+    const backups = targetKeys.map((key, index) => ({
+      key,
+      backupKey: `CoreSnapshotBackup:${snapshot.season}:${token}:${index}`,
+    }));
+    const currentEventBackupKey = `CoreSnapshotBackup:${snapshot.season}:${token}:current-event`;
+    const response = await redis.eval(
+      PUBLISH_SCRIPT,
+      3,
+      ACTIVE_SEASON_KEY,
+      'event:current',
+      CORE_SNAPSHOT_PENDING_PUBLICATION_KEY,
+      JSON.stringify({
+        expectedActive: current ?? '',
+        season: snapshot.season,
+        currentEvent: plan.currentEvent,
+        staged: [...staged].map(([finalKey, stageKey], index) => ({
+          finalKey,
+          stageKey,
+          expectedCount: expectedCounts[index],
+          ...(fixtureOwnershipMetaKey(finalKey, snapshot.season)
+            ? { metaKey: fixtureOwnershipMetaKey(finalKey, snapshot.season) }
+            : {}),
+        })),
+        backups: backups.map((backup) => ({
+          ...backup,
+          ...(fixtureOwnershipMetaKey(backup.key, snapshot.season)
+            ? { metaKey: fixtureOwnershipMetaKey(backup.key, snapshot.season) }
+            : {}),
+        })),
+        publicationId: token,
+        sourceCheckedAt: (options.sourceCheckedAt ?? new Date(0)).toISOString(),
+        fixtureIds: snapshot.fixtures.map((fixture) => fixture.id),
+        previousActiveSeason: current,
+        currentEventBackupKey,
+      }),
+    );
+    const status = firstResponseValue(response);
+    if (status === 'authority_changed') {
+      return { published: false, reason: 'newer_active_season', hashCount: 0 };
+    }
+    if (status !== 'published') {
+      throw new CacheError(
+        'Core snapshot cache publication precondition failed',
+        status === 'pending_publication'
+          ? 'CORE_SNAPSHOT_PENDING_PUBLICATION'
+          : 'CORE_SNAPSHOT_PUBLICATION_FAILED',
+      );
+    }
+
+    const receipt = parseReceipt(responseValue(response, 2));
+
+    return {
+      published: true,
+      reason: 'published',
+      hashCount: receipt.finalKeys.length,
+      receipt,
+    };
+  } finally {
+    if (stagingKeys.length > 0) {
+      await redis.del(...stagingKeys).catch((error) => {
+        logWarn('Failed to remove core snapshot staging keys', {
+          error: error instanceof Error ? error.message : String(error),
+          count: stagingKeys.length,
+        });
+      });
+    }
+  }
+}
+
+export async function readPendingCoreSnapshotCachePublication(
+  redisClient?: Redis,
+): Promise<CoreSnapshotCachePublicationReceipt | null> {
+  const redis = redisClient ?? (await redisSingleton.getClient());
+  const value = await redis.get(CORE_SNAPSHOT_PENDING_PUBLICATION_KEY);
+  return value ? parseReceipt(value) : null;
+}
+
+export async function finalizeCoreSnapshotCachePublication(
+  receipt: CoreSnapshotCachePublicationReceipt,
+  redisClient?: Redis,
+): Promise<void> {
+  const redis = redisClient ?? (await redisSingleton.getClient());
+  const response = await redis.eval(
+    FINALIZE_SCRIPT,
+    1,
+    CORE_SNAPSHOT_PENDING_PUBLICATION_KEY,
+    JSON.stringify(receipt),
+  );
+  const status = firstResponseValue(response);
+  if (status === 'different_publication') {
+    throw new CacheError(
+      'A different core snapshot publication is pending',
+      'CORE_SNAPSHOT_PUBLICATION_AUTHORITY_MISMATCH',
+    );
+  }
+  const activeSeason = await redis.get(ACTIVE_SEASON_KEY);
+  if (activeSeason === receipt.season) rememberCoreSnapshotActiveSeason(receipt.season);
+  else resetActiveSeasonMemo();
+}
+
+export async function rollbackCoreSnapshotCachePublication(
+  receipt: CoreSnapshotCachePublicationReceipt,
+  redisClient?: Redis,
+  durablePlayers?: readonly Player[],
+): Promise<void> {
+  const redis = redisClient ?? (await redisSingleton.getClient());
+  const playerKey = durablePlayers && durablePlayers.length > 0 ? `Player:${receipt.season}` : '';
+  const playerHash = Object.fromEntries(
+    (durablePlayers ?? []).map((player) => [String(player.id), JSON.stringify(player)]),
+  );
+  const response = await redis.eval(
+    ROLLBACK_SCRIPT,
+    3,
+    ACTIVE_SEASON_KEY,
+    'event:current',
+    CORE_SNAPSHOT_PENDING_PUBLICATION_KEY,
+    JSON.stringify(receipt),
+    playerKey,
+    JSON.stringify(playerHash),
+  );
+  if (firstResponseValue(response) === 'different_publication') {
+    throw new CacheError(
+      'A different core snapshot publication is pending',
+      'CORE_SNAPSHOT_PUBLICATION_AUTHORITY_MISMATCH',
+    );
+  }
+  resetActiveSeasonMemo();
+}

--- a/src/cache/fixtures-cache.ts
+++ b/src/cache/fixtures-cache.ts
@@ -24,7 +24,7 @@ function eventIdFromFixturesKey(key: string, season: string): number | null {
   return Number.isInteger(eventId) && eventId > 0 ? eventId : null;
 }
 
-function isLiveSnapshotStagingKey(key: string, season: string): boolean {
+export function isLiveSnapshotStagingKey(key: string, season: string): boolean {
   const suffix = key.slice(`Fixtures:${season}:`.length);
   return /^\d+:staging:[^:]+$/.test(suffix);
 }

--- a/src/cache/fixtures-cache.ts
+++ b/src/cache/fixtures-cache.ts
@@ -86,7 +86,7 @@ function toTeamFixture(
 }
 
 // Returns Map<teamId, Map<eventId, TeamFixture>> — unscheduled fixtures (event=null) are excluded
-function buildFixturesByTeam(
+export function buildFixturesByTeam(
   teamIds: number[],
   fixtures: Fixture[],
   teamById: Map<number, TeamInfo>,

--- a/src/cache/live-snapshot-cache.ts
+++ b/src/cache/live-snapshot-cache.ts
@@ -165,6 +165,17 @@ return 1
 `;
 
 const RETIRE_LIVE_SNAPSHOT_SCRIPT = `
+local preserve_after = ARGV[1]
+local meta_raw = redis.pcall('GET', KEYS[#KEYS])
+if preserve_after ~= '' and type(meta_raw) == 'string' then
+  local decoded, meta = pcall(cjson.decode, meta_raw)
+  if decoded and type(meta) == 'table'
+    and type(meta.checkedAt) == 'string'
+    and meta.checkedAt >= preserve_after
+  then
+    return -1
+  end
+end
 local removed = 0
 for index = 1, #KEYS do
   removed = removed + redis.call('DEL', KEYS[index])
@@ -222,6 +233,14 @@ local matches = hash_matches(fixtures_key, expected_fixtures)
 local meta_raw = redis.pcall('GET', meta_key)
 if owned then
   local decoded, meta = pcall(cjson.decode, meta_raw)
+  if decoded
+    and type(meta) == 'table'
+    and ARGV[6] ~= ''
+    and type(meta.checkedAt) == 'string'
+    and meta.checkedAt >= ARGV[6]
+  then
+    return 3
+  end
   if not decoded
     or type(meta) ~= 'table'
     or meta.fixtureCount ~= entry_count(expected_fixtures)
@@ -483,7 +502,10 @@ export function createLiveSnapshotCache(
      * Fixtures. Remove the metadata pointer and all six coordinated views in
      * one command so readers either see the old snapshot or a complete miss.
      */
-    async retire(eventId: number): Promise<LiveSnapshotRetireResult> {
+    async retire(
+      eventId: number,
+      preserveOwnedCheckedAtOrAfter?: string,
+    ): Promise<LiveSnapshotRetireResult> {
       const [redis, season] = await Promise.all([
         dependencies.getRedisClient(),
         dependencies.getAuthoritativeSeason(),
@@ -492,9 +514,15 @@ export function createLiveSnapshotCache(
         ...LIVE_SNAPSHOT_VIEW_PREFIXES.map((prefix) => `${prefix}:${season}:${eventId}`),
         liveSnapshotMetaKey(season, eventId),
       ];
-      const removedKeys = Number(
-        await redis.eval(RETIRE_LIVE_SNAPSHOT_SCRIPT, keys.length, ...keys),
+      const result = Number(
+        await redis.eval(
+          RETIRE_LIVE_SNAPSHOT_SCRIPT,
+          keys.length,
+          ...keys,
+          preserveOwnedCheckedAtOrAfter ?? '',
+        ),
       );
+      const removedKeys = result === -1 ? 0 : result;
       if (!Number.isInteger(removedKeys) || removedKeys < 0) {
         throw new Error(`Unexpected live snapshot retirement result: ${String(removedKeys)}`);
       }
@@ -513,6 +541,7 @@ export function createLiveSnapshotCache(
       eventId: number,
       fixtures: readonly Fixture[],
       byTeam: LiveBonusByTeam,
+      preserveOwnedCheckedAtOrAfter?: string,
     ): Promise<LiveSnapshotFixtureRefreshResult> {
       if (fixtures.length === 0) {
         throw new Error(
@@ -538,6 +567,7 @@ export function createLiveSnapshotCache(
           season,
           String(FIXTURES_KEY_INDEX),
           String(LIVE_BONUS_V2_KEY_INDEX),
+          preserveOwnedCheckedAtOrAfter ?? '',
         ),
       );
       if (result === -2) {
@@ -545,7 +575,7 @@ export function createLiveSnapshotCache(
           `Live fixture-derived season changed from ${season} before coordinated refresh; retry`,
         );
       }
-      if (result !== 0 && result !== 1 && result !== 2) {
+      if (result !== 0 && result !== 1 && result !== 2 && result !== 3) {
         throw new Error(`Unexpected coordinated fixture refresh result: ${String(result)}`);
       }
 

--- a/src/db/schemas/players.schema.ts
+++ b/src/db/schemas/players.schema.ts
@@ -1,4 +1,4 @@
-import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { timestamps } from './_helpers.schema';
 import { teams } from './teams.schema';
 
@@ -10,6 +10,7 @@ export const players = pgTable('players', {
     .notNull()
     .references(() => teams.id),
   price: integer('price').default(0).notNull(),
+  priceSourceCheckedAt: timestamp('price_source_checked_at', { withTimezone: true }),
   startPrice: integer('start_price').default(0).notNull(),
   firstName: text('first_name'),
   secondName: text('second_name'),

--- a/src/db/schemas/players.schema.ts
+++ b/src/db/schemas/players.schema.ts
@@ -10,6 +10,8 @@ export const players = pgTable('players', {
     .notNull()
     .references(() => teams.id),
   price: integer('price').default(0).notNull(),
+  // Latest source-ordering marker shared by core and price writers. It keeps
+  // an older price replay from clearing or overwriting a newer core snapshot.
   priceSourceCheckedAt: timestamp('price_source_checked_at', { withTimezone: true }),
   startPrice: integer('start_price').default(0).notNull(),
   firstName: text('first_name'),

--- a/src/domain/core-snapshot.ts
+++ b/src/domain/core-snapshot.ts
@@ -1,0 +1,220 @@
+import { deriveSeasonFromEvents, deriveSeasonFromFixtures } from '../cache/cache-season';
+import { transformEvents } from '../transformers/events';
+import { transformFixtures } from '../transformers/fixtures';
+import { transformPhases } from '../transformers/phases';
+import { transformPlayersStrict } from '../transformers/players';
+import { transformTeams } from '../transformers/teams';
+import { ValidationError } from '../utils/errors';
+
+import type {
+  Event,
+  Fixture,
+  FPLBootstrapResponse,
+  Phase,
+  Player,
+  RawFPLFixture,
+  Team,
+} from '../types';
+
+export const CORE_SNAPSHOT_EXPECTED_EVENTS = 38;
+export const CORE_SNAPSHOT_EXPECTED_TEAMS = 20;
+export const CORE_SNAPSHOT_EXPECTED_FIXTURES = 380;
+// A valid FPL club must have enough selectable players to field a starting XI.
+// This deliberately conservative floor catches severely truncated bootstrap
+// payloads without coupling publication to the season's fluctuating squad size.
+export const CORE_SNAPSHOT_MIN_PLAYERS_PER_TEAM = 11;
+
+export const CORE_SNAPSHOT_MUTATION_SCOPES = [
+  'data-core:events',
+  'data-core:teams',
+  'data-core:players',
+  'data-core:phases',
+  'data-core:fixtures',
+] as const;
+
+export interface CoreSnapshot {
+  season: string;
+  events: Event[];
+  teams: Team[];
+  players: Player[];
+  phases: Phase[];
+  fixtures: Fixture[];
+}
+
+function reject(reason: string, details?: Record<string, number>): never {
+  throw new ValidationError(
+    `Core snapshot rejected: ${reason}`,
+    'CORE_SNAPSHOT_INCOMPLETE',
+    details,
+  );
+}
+
+function requireExactCount(label: string, actual: number, expected: number): void {
+  if (actual !== expected) reject(`${label} count`, { actual, expected });
+}
+
+function requireUniqueIds(label: string, ids: number[]): void {
+  const unique = new Set(ids);
+  if (unique.size !== ids.length) {
+    reject(`${label} identifiers are not unique`, {
+      actual: ids.length,
+      unique: unique.size,
+    });
+  }
+}
+
+function requireCompleteEventRange(events: Event[]): void {
+  const ids = new Set(events.map((event) => event.id));
+  for (let eventId = 1; eventId <= CORE_SNAPSHOT_EXPECTED_EVENTS; eventId += 1) {
+    if (!ids.has(eventId)) reject('event range is incomplete');
+  }
+}
+
+function requirePlayerCoverage(players: Player[], teamIds: Set<number>): void {
+  if (players.length === 0) reject('players are empty');
+  requireUniqueIds(
+    'player',
+    players.map((player) => player.id),
+  );
+
+  const positions = new Set<number>();
+  const playersByTeam = new Map<number, number>([...teamIds].map((teamId) => [teamId, 0]));
+  for (const player of players) {
+    if (!teamIds.has(player.teamId)) reject('player references an unknown team');
+    if (player.type < 1 || player.type > 4) reject('player position is outside 1-4');
+    positions.add(player.type);
+    playersByTeam.set(player.teamId, (playersByTeam.get(player.teamId) ?? 0) + 1);
+  }
+
+  if (positions.size !== 4) reject('player positions are incomplete', { actual: positions.size });
+  for (const [teamId, count] of playersByTeam) {
+    if (count < CORE_SNAPSHOT_MIN_PLAYERS_PER_TEAM) {
+      reject('player team roster is incomplete', {
+        teamId,
+        actual: count,
+        expected: CORE_SNAPSHOT_MIN_PLAYERS_PER_TEAM,
+      });
+    }
+  }
+}
+
+function requirePhaseCoverage(phases: Phase[]): void {
+  if (phases.length === 0) reject('phases are empty');
+  requireUniqueIds(
+    'phase',
+    phases.map((phase) => phase.id),
+  );
+
+  for (const phase of phases) {
+    if (
+      phase.startEvent < 1 ||
+      phase.stopEvent > CORE_SNAPSHOT_EXPECTED_EVENTS ||
+      phase.startEvent > phase.stopEvent
+    ) {
+      reject('phase range is invalid');
+    }
+  }
+
+  if (
+    !phases.some(
+      (phase) => phase.startEvent === 1 && phase.stopEvent === CORE_SNAPSHOT_EXPECTED_EVENTS,
+    )
+  ) {
+    reject('full-season phase is missing');
+  }
+}
+
+function requireFixtureCoverage(fixtures: Fixture[], teamIds: Set<number>): void {
+  requireExactCount('fixtures', fixtures.length, CORE_SNAPSHOT_EXPECTED_FIXTURES);
+  requireUniqueIds(
+    'fixture',
+    fixtures.map((fixture) => fixture.id),
+  );
+
+  const appearances = new Map<number, number>([...teamIds].map((teamId) => [teamId, 0]));
+  const pairings = new Map<string, { lowerHome: number; upperHome: number }>();
+  for (const fixture of fixtures) {
+    if (!teamIds.has(fixture.teamH) || !teamIds.has(fixture.teamA)) {
+      reject('fixture references an unknown team');
+    }
+    if (fixture.teamH === fixture.teamA) reject('fixture has the same home and away team');
+    if (
+      fixture.event !== null &&
+      (fixture.event < 1 || fixture.event > CORE_SNAPSHOT_EXPECTED_EVENTS)
+    ) {
+      reject('fixture event is outside 1-38');
+    }
+    appearances.set(fixture.teamH, (appearances.get(fixture.teamH) ?? 0) + 1);
+    appearances.set(fixture.teamA, (appearances.get(fixture.teamA) ?? 0) + 1);
+    const lower = Math.min(fixture.teamH, fixture.teamA);
+    const upper = Math.max(fixture.teamH, fixture.teamA);
+    const pairing = pairings.get(`${lower}:${upper}`) ?? { lowerHome: 0, upperHome: 0 };
+    if (fixture.teamH === lower) pairing.lowerHome += 1;
+    else pairing.upperHome += 1;
+    pairings.set(`${lower}:${upper}`, pairing);
+  }
+
+  for (const count of appearances.values()) {
+    if (count !== CORE_SNAPSHOT_EXPECTED_EVENTS) {
+      reject('team fixture coverage is incomplete', {
+        actual: count,
+        expected: CORE_SNAPSHOT_EXPECTED_EVENTS,
+      });
+    }
+  }
+
+  const expectedPairings = (teamIds.size * (teamIds.size - 1)) / 2;
+  if (pairings.size !== expectedPairings) {
+    reject('fixture opponent pair coverage is incomplete', {
+      actual: pairings.size,
+      expected: expectedPairings,
+    });
+  }
+  for (const pairing of pairings.values()) {
+    if (pairing.lowerHome !== 1 || pairing.upperHome !== 1) {
+      reject('fixture home-and-away pairing is invalid');
+    }
+  }
+}
+
+export function prepareCoreSnapshot(
+  bootstrap: FPLBootstrapResponse,
+  rawFixtures: RawFPLFixture[],
+): CoreSnapshot {
+  requireExactCount('events', bootstrap.events.length, CORE_SNAPSHOT_EXPECTED_EVENTS);
+  requireExactCount('teams', bootstrap.teams.length, CORE_SNAPSHOT_EXPECTED_TEAMS);
+  requireExactCount('fixtures', rawFixtures.length, CORE_SNAPSHOT_EXPECTED_FIXTURES);
+
+  const events = transformEvents(bootstrap.events);
+  const teams = transformTeams(bootstrap.teams);
+  const players = transformPlayersStrict(bootstrap.elements);
+  const phases = transformPhases(bootstrap.phases);
+  const fixtures = transformFixtures(rawFixtures);
+
+  requireExactCount('transformed events', events.length, bootstrap.events.length);
+  requireExactCount('transformed teams', teams.length, bootstrap.teams.length);
+  requireExactCount('transformed players', players.length, bootstrap.elements.length);
+  requireExactCount('transformed phases', phases.length, bootstrap.phases.length);
+  requireExactCount('transformed fixtures', fixtures.length, rawFixtures.length);
+
+  requireUniqueIds(
+    'event',
+    events.map((event) => event.id),
+  );
+  requireCompleteEventRange(events);
+  requireUniqueIds(
+    'team',
+    teams.map((team) => team.id),
+  );
+  const teamIds = new Set(teams.map((team) => team.id));
+  requirePlayerCoverage(players, teamIds);
+  requirePhaseCoverage(phases);
+  requireFixtureCoverage(fixtures, teamIds);
+
+  const eventSeason = deriveSeasonFromEvents(bootstrap.events);
+  const fixtureSeason = deriveSeasonFromFixtures(rawFixtures);
+  if (!eventSeason || !fixtureSeason) reject('season cannot be derived from both sources');
+  if (eventSeason !== fixtureSeason) reject('event and fixture seasons disagree');
+
+  return { season: eventSeason, events, teams, players, phases, fixtures };
+}

--- a/src/domain/job-priority.ts
+++ b/src/domain/job-priority.ts
@@ -22,6 +22,7 @@ export const MUTATION_PRIORITY_TABLES = {
 } as const;
 
 export type DataSyncPriorityJobName =
+  | 'core-snapshot'
   | 'events'
   | 'fixtures'
   | 'fixtures-all-gameweeks'

--- a/src/domain/mutation-scope.ts
+++ b/src/domain/mutation-scope.ts
@@ -74,18 +74,25 @@ export function resolveMutationScopes(input: MutationScopeInput): string[] {
 
   if (queue === 'data-sync') {
     switch (jobName) {
-      case 'players':
-      case 'player-prices':
-        return ['data-core:players'];
+      case 'core-snapshot':
       case 'events':
       case 'fixtures':
       case 'fixtures-all-gameweeks':
       case 'teams':
-      case 'player-stats':
+      case 'players':
       case 'phases':
+        return [
+          'data-core:events',
+          'data-core:teams',
+          'data-core:players',
+          'data-core:phases',
+          'data-core:fixtures',
+        ];
+      case 'player-prices':
+        return ['data-core:players'];
+      case 'player-stats':
       case 'player-values':
-        // All-gameweek backfill shares the fixtures core lock with single-event syncs.
-        return [`data-core:${jobName === 'fixtures-all-gameweeks' ? 'fixtures' : jobName}`];
+        return [`data-core:${jobName}`];
       default:
         return [];
     }

--- a/src/jobs/data-sync-enqueue.ts
+++ b/src/jobs/data-sync-enqueue.ts
@@ -11,6 +11,18 @@ import {
 
 export type { DataSyncEnqueueOptions, DataSyncJobSource } from './data-sync-job-definition';
 
+export function getCoreSnapshotJobId(
+  source: DataSyncJobSource,
+  options: DataSyncEnqueueOptions = {},
+): string | undefined {
+  if (options.jobId) return options.jobId;
+  if (source === 'cron') return `core-snapshot-${formatCronDateKey()}`;
+  // An event transition must observe the event that caused the trigger. Keep
+  // it distinct from an older repair job that may still be queued or active.
+  if (source === 'event-transition') return undefined;
+  return 'core-snapshot-repair';
+}
+
 async function enqueueDataSyncJob(
   jobName: DataSyncJobName,
   source: DataSyncJobSource = 'cron',
@@ -59,9 +71,7 @@ export const enqueueCoreSnapshotJob = (
 ) =>
   enqueueDataSyncJob('core-snapshot', source, {
     ...options,
-    jobId:
-      options?.jobId ??
-      (source === 'cron' ? `core-snapshot-${formatCronDateKey()}` : 'core-snapshot-repair'),
+    jobId: getCoreSnapshotJobId(source, options),
     removeOnSettle: true,
   });
 

--- a/src/jobs/data-sync-enqueue.ts
+++ b/src/jobs/data-sync-enqueue.ts
@@ -53,23 +53,33 @@ async function enqueueDataSyncJob(
   }
 }
 
-export const enqueueEventsSyncJob = (source?: DataSyncJobSource) =>
-  enqueueDataSyncJob('events', source);
+export const enqueueCoreSnapshotJob = (
+  source: DataSyncJobSource = 'cron',
+  options?: DataSyncEnqueueOptions,
+) =>
+  enqueueDataSyncJob('core-snapshot', source, {
+    ...options,
+    jobId:
+      options?.jobId ??
+      (source === 'cron' ? `core-snapshot-${formatCronDateKey()}` : 'core-snapshot-repair'),
+    removeOnSettle: true,
+  });
+
+// Compatibility producers all converge on the one coherent core publisher.
+export const enqueueEventsSyncJob = (source?: DataSyncJobSource) => enqueueCoreSnapshotJob(source);
 
 export const enqueueFixturesSyncJob = (
   source?: DataSyncJobSource,
   options?: DataSyncEnqueueOptions,
-) => enqueueDataSyncJob('fixtures', source, options);
+) => enqueueCoreSnapshotJob(source, options);
 
-/** Full GW1–38 fixtures backfill with per-gameweek error isolation. */
+/** The authoritative fixture endpoint already returns the complete season feed. */
 export const enqueueFixturesAllGameweeksSyncJob = (source?: DataSyncJobSource) =>
-  enqueueDataSyncJob('fixtures-all-gameweeks', source);
+  enqueueCoreSnapshotJob(source);
 
-export const enqueueTeamsSyncJob = (source?: DataSyncJobSource) =>
-  enqueueDataSyncJob('teams', source);
+export const enqueueTeamsSyncJob = (source?: DataSyncJobSource) => enqueueCoreSnapshotJob(source);
 
-export const enqueuePlayersSyncJob = (source?: DataSyncJobSource) =>
-  enqueueDataSyncJob('players', source);
+export const enqueuePlayersSyncJob = (source?: DataSyncJobSource) => enqueueCoreSnapshotJob(source);
 
 export const enqueuePlayerPricesSyncJob = (
   source: DataSyncJobSource,
@@ -81,8 +91,7 @@ export const enqueuePlayerStatsSyncJob = (
   options?: DataSyncEnqueueOptions,
 ) => enqueueDataSyncJob('player-stats', source, options);
 
-export const enqueuePhasesSyncJob = (source?: DataSyncJobSource) =>
-  enqueueDataSyncJob('phases', source);
+export const enqueuePhasesSyncJob = (source?: DataSyncJobSource) => enqueueCoreSnapshotJob(source);
 
 export const enqueuePlayerValuesSyncJob = (
   source?: DataSyncJobSource,

--- a/src/jobs/data-sync.jobs.ts
+++ b/src/jobs/data-sync.jobs.ts
@@ -2,13 +2,9 @@ import { cron } from '@elysiajs/cron';
 import { Elysia } from 'elysia';
 
 import {
-  enqueueEventsSyncJob,
-  enqueueFixturesSyncJob,
+  enqueueCoreSnapshotJob,
   enqueuePlayerStatsSyncJob,
-  enqueuePhasesSyncJob,
   enqueuePlayerPricesSyncJob,
-  enqueuePlayersSyncJob,
-  enqueueTeamsSyncJob,
 } from './data-sync-enqueue';
 import {
   PLAYER_PRICES_REPLAY_CRON_PATTERN,
@@ -20,23 +16,22 @@ import { logInfo } from '../utils/logger';
 import { CRON_TIMEZONE, formatCronDateKey } from '../utils/timezone';
 
 /**
- * Core entity syncs (events/teams/fixtures/players/phases) run year-round so a
- * newly published FPL season is picked up before the calendar season window
- * opens. Services short-circuit on empty pre-season payloads. Player-specific
- * jobs use current ?? next so GW1 data is refreshed before the first kickoff.
+ * The complete core snapshot runs year-round so a newly published FPL season
+ * is picked up before the calendar season window opens. Player-specific jobs
+ * use current ?? next so GW1 data is refreshed before the first kickoff.
  */
 export function registerDataSyncJobs(app: Elysia) {
   return app
     .use(
       cron({
-        name: 'events-sync',
+        name: 'core-snapshot-sync',
         pattern: '35 6 * * *',
         timezone: CRON_TIMEZONE,
         async run() {
           try {
-            await executeTrackedCron('events-sync', async () => {
-              const job = await enqueueEventsSyncJob('cron');
-              logInfo('Events sync job enqueued via cron', { jobId: job.id });
+            await executeTrackedCron('core-snapshot-sync', async () => {
+              const job = await enqueueCoreSnapshotJob('cron');
+              logInfo('Core snapshot job enqueued via cron', { jobId: job.id });
             });
           } catch {
             // Failure details are already emitted by runTrackedJob.
@@ -71,57 +66,6 @@ export function registerDataSyncJobs(app: Elysia) {
     )
     .use(
       cron({
-        name: 'teams-sync',
-        pattern: '37 6 * * *',
-        timezone: CRON_TIMEZONE,
-        async run() {
-          try {
-            await executeTrackedCron('teams-sync', async () => {
-              const job = await enqueueTeamsSyncJob('cron');
-              logInfo('Teams sync job enqueued via cron', { jobId: job.id });
-            });
-          } catch {
-            // Failure details are already emitted by runTrackedJob.
-          }
-        },
-      }),
-    )
-    .use(
-      cron({
-        name: 'fixtures-sync',
-        pattern: '40 6 * * *',
-        timezone: CRON_TIMEZONE,
-        async run() {
-          try {
-            await executeTrackedCron('fixtures-sync', async () => {
-              const job = await enqueueFixturesSyncJob('cron');
-              logInfo('Fixtures sync job enqueued via cron', { jobId: job.id });
-            });
-          } catch {
-            // Failure details are already emitted by runTrackedJob.
-          }
-        },
-      }),
-    )
-    .use(
-      cron({
-        name: 'players-sync',
-        pattern: '43 6 * * *',
-        timezone: CRON_TIMEZONE,
-        async run() {
-          try {
-            await executeTrackedCron('players-sync', async () => {
-              const job = await enqueuePlayersSyncJob('cron');
-              logInfo('Players sync job enqueued via cron', { jobId: job.id });
-            });
-          } catch {
-            // Failure details are already emitted by runTrackedJob.
-          }
-        },
-      }),
-    )
-    .use(
-      cron({
         name: 'player-stats-sync',
         pattern: PLAYER_STATS_CRON_PATTERN,
         timezone: CRON_TIMEZONE,
@@ -133,23 +77,6 @@ export function registerDataSyncJobs(app: Elysia) {
               }
               const job = await enqueuePlayerStatsSyncJob('cron');
               logInfo('Player stats sync job enqueued via cron', { jobId: job.id });
-            });
-          } catch {
-            // Failure details are already emitted by runTrackedJob.
-          }
-        },
-      }),
-    )
-    .use(
-      cron({
-        name: 'phases-sync',
-        pattern: '45 6 * * *',
-        timezone: CRON_TIMEZONE,
-        async run() {
-          try {
-            await executeTrackedCron('phases-sync', async () => {
-              const job = await enqueuePhasesSyncJob('cron');
-              logInfo('Phases sync job enqueued via cron', { jobId: job.id });
             });
           } catch {
             // Failure details are already emitted by runTrackedJob.

--- a/src/jobs/event-current-refresh.job.ts
+++ b/src/jobs/event-current-refresh.job.ts
@@ -5,7 +5,7 @@ import { eventsCache } from '../cache/operations';
 import { isFPLSeason } from '../utils/conditions';
 import { executeTrackedCron } from '../utils/job-run-logger';
 import { logInfo } from '../utils/logger';
-import { enqueueEventsSyncJob } from './data-sync-enqueue';
+import { enqueueCoreSnapshotJob } from './data-sync-enqueue';
 import { CRON_TIMEZONE } from '../utils/timezone';
 
 export type ManualEventCurrentRefreshResult = {
@@ -26,7 +26,7 @@ export async function runManualEventCurrentRefresh(): Promise<ManualEventCurrent
 
   logInfo('Manual event-current-refresh: gameweek id changed, enqueuing events sync');
   try {
-    const job = await enqueueEventsSyncJob('manual');
+    const job = await enqueueCoreSnapshotJob('manual');
     logInfo('Events sync job enqueued (manual after event:current refresh)', { jobId: job.id });
     return { refreshed: true, eventsSyncJobId: job.id };
   } catch {
@@ -47,7 +47,7 @@ export async function runEventCurrentRefresh() {
   if (updated) {
     logInfo('Gameweek transition detected - triggering events sync');
     try {
-      const job = await enqueueEventsSyncJob('event-transition');
+      const job = await enqueueCoreSnapshotJob('event-transition');
       logInfo('Events sync job enqueued (transition)', { jobId: job.id });
     } catch {
       logInfo('Events sync job already enqueued or failed (transition)');

--- a/src/queues/data-sync.queue.ts
+++ b/src/queues/data-sync.queue.ts
@@ -4,6 +4,7 @@ import { closeTieredQueues, createTieredQueueSet } from './tiered-queue';
 export const dataSyncQueueName = 'data-sync';
 
 export type DataSyncJobName =
+  | 'core-snapshot'
   | 'events'
   | 'fixtures'
   | 'fixtures-all-gameweeks'

--- a/src/repositories/core-snapshot-authority.ts
+++ b/src/repositories/core-snapshot-authority.ts
@@ -1,0 +1,84 @@
+import { sql } from 'drizzle-orm';
+
+import { getDb, type DbOrTransaction } from '../db/singleton';
+import { DatabaseError } from '../utils/errors';
+
+export interface CoreSnapshotAuthorityRecord {
+  season: string;
+  revision: number;
+  publicationId: string;
+  committedAt: Date;
+}
+
+type CoreSnapshotAuthorityRow = {
+  season: string;
+  revision: string | number;
+  publicationId: string;
+  committedAt: Date;
+};
+
+function mapAuthority(row: CoreSnapshotAuthorityRow): CoreSnapshotAuthorityRecord {
+  const revision = Number(row.revision);
+  if (!Number.isSafeInteger(revision) || revision <= 0) {
+    throw new DatabaseError(
+      'Core snapshot authority revision is invalid.',
+      'CORE_SNAPSHOT_AUTHORITY_INVALID',
+    );
+  }
+  return { ...row, revision };
+}
+
+export async function allocateCoreSnapshotRevision(dbInstance?: DbOrTransaction): Promise<number> {
+  const db = dbInstance ?? (await getDb());
+  const rows = (await db.execute(sql`
+    SELECT nextval('public.core_snapshot_revision_seq') AS revision
+  `)) as unknown as Array<{ revision: string | number }>;
+  const revision = Number(rows[0]?.revision);
+  if (!Number.isSafeInteger(revision) || revision <= 0) {
+    throw new DatabaseError(
+      'Failed to reserve a core snapshot revision.',
+      'CORE_SNAPSHOT_REVISION_RESERVATION_FAILED',
+    );
+  }
+  return revision;
+}
+
+export async function findCoreSnapshotAuthority(
+  dbInstance?: DbOrTransaction,
+  options?: { lock?: boolean },
+): Promise<CoreSnapshotAuthorityRecord | null> {
+  const db = dbInstance ?? (await getDb());
+  const lockClause = options?.lock ? sql`FOR UPDATE` : sql``;
+  const rows = (await db.execute(sql`
+    SELECT
+      season,
+      revision,
+      publication_id AS "publicationId",
+      committed_at AS "committedAt"
+    FROM public.core_snapshot_authority
+    WHERE singleton_id = 1
+    ${lockClause}
+  `)) as unknown as CoreSnapshotAuthorityRow[];
+  return rows[0] ? mapAuthority(rows[0]) : null;
+}
+
+export async function recordCoreSnapshotAuthority(
+  record: Pick<CoreSnapshotAuthorityRecord, 'season' | 'revision' | 'publicationId'>,
+  dbInstance: DbOrTransaction,
+): Promise<void> {
+  await dbInstance.execute(sql`
+    INSERT INTO public.core_snapshot_authority (
+      singleton_id,
+      season,
+      revision,
+      publication_id,
+      committed_at
+    )
+    VALUES (1, ${record.season}, ${record.revision}, ${record.publicationId}::uuid, now())
+    ON CONFLICT (singleton_id) DO UPDATE SET
+      season = excluded.season,
+      revision = excluded.revision,
+      publication_id = excluded.publication_id,
+      committed_at = excluded.committed_at
+  `);
+}

--- a/src/repositories/events.ts
+++ b/src/repositories/events.ts
@@ -1,17 +1,14 @@
 import { and, asc, desc, eq, gt, isNotNull, lte, sql } from 'drizzle-orm';
 
 import { events, type DbEvent, type DbEventInsert } from '../db/schemas/index.schema';
-import { getDb } from '../db/singleton';
+import { getDb, type DbOrTransaction } from '../db/singleton';
 import { neighbourEventId } from '../domain/events';
 import { DatabaseError } from '../utils/errors';
 import { logError, logInfo } from '../utils/logger';
 
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Event as DomainEvent } from '../types';
 
-type DatabaseInstance = PostgresJsDatabase<Record<string, never>>;
-
-export const createEventRepository = (dbInstance?: DatabaseInstance) => {
+export const createEventRepository = (dbInstance?: DbOrTransaction) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   const findCurrentInternal = async (): Promise<DbEvent | null> => {

--- a/src/repositories/fixtures.ts
+++ b/src/repositories/fixtures.ts
@@ -144,13 +144,40 @@ export const createFixtureRepository = (dbInstance?: DbOrTransaction) => {
     markAbsentUnscheduled: async (
       acceptedIds: readonly number[],
       preserveOwnedCheckedAtOrAfter?: Date,
+      acceptedCodes: readonly number[] = [],
     ): Promise<number> => {
       try {
         const uniqueIds = [...new Set(acceptedIds.filter((id) => Number.isInteger(id) && id > 0))];
         if (uniqueIds.length === 0) return 0;
+        const uniqueCodes = [
+          ...new Set(acceptedCodes.filter((code) => Number.isInteger(code) && code > 0)),
+        ];
         const preserveOwnedCheckedAtOrAfterIso = preserveOwnedCheckedAtOrAfter?.toISOString();
 
         const db = await getDbInstance();
+        const ownershipFence = preserveOwnedCheckedAtOrAfterIso
+          ? sql`NOT EXISTS (
+              SELECT 1
+              FROM ${events}
+              WHERE ${events.id} = ${eventFixtures.eventId}
+                AND ${events.liveSnapshotCheckedAt} >= ${preserveOwnedCheckedAtOrAfterIso}::timestamptz
+            )`
+          : undefined;
+        let retiredCodeConflicts = 0;
+        if (uniqueCodes.length > 0) {
+          const removed = await db
+            .delete(eventFixtures)
+            .where(
+              and(
+                isNotNull(eventFixtures.eventId),
+                notInArray(eventFixtures.id, uniqueIds),
+                inArray(eventFixtures.code, uniqueCodes),
+                ownershipFence,
+              ),
+            )
+            .returning({ id: eventFixtures.id });
+          retiredCodeConflicts = removed.length;
+        }
         const result = await db
           .update(eventFixtures)
           .set({ eventId: null, updatedAt: new Date() })
@@ -158,19 +185,13 @@ export const createFixtureRepository = (dbInstance?: DbOrTransaction) => {
             and(
               isNotNull(eventFixtures.eventId),
               notInArray(eventFixtures.id, uniqueIds),
-              preserveOwnedCheckedAtOrAfterIso
-                ? sql`NOT EXISTS (
-                    SELECT 1
-                    FROM ${events}
-                    WHERE ${events.id} = ${eventFixtures.eventId}
-                      AND ${events.liveSnapshotCheckedAt} >= ${preserveOwnedCheckedAtOrAfterIso}::timestamptz
-                  )`
-                : undefined,
+              ownershipFence,
             ),
           )
           .returning({ id: eventFixtures.id });
-        logInfo('Retired fixtures absent from the complete snapshot', { count: result.length });
-        return result.length;
+        const count = retiredCodeConflicts + result.length;
+        logInfo('Retired fixtures absent from the complete snapshot', { count });
+        return count;
       } catch (error) {
         logError('Failed to retire fixtures absent from the complete snapshot', error, {
           acceptedCount: acceptedIds.length,

--- a/src/repositories/fixtures.ts
+++ b/src/repositories/fixtures.ts
@@ -169,7 +169,6 @@ export const createFixtureRepository = (dbInstance?: DbOrTransaction) => {
             .delete(eventFixtures)
             .where(
               and(
-                isNotNull(eventFixtures.eventId),
                 notInArray(eventFixtures.id, uniqueIds),
                 inArray(eventFixtures.code, uniqueCodes),
                 ownershipFence,

--- a/src/repositories/fixtures.ts
+++ b/src/repositories/fixtures.ts
@@ -1,7 +1,8 @@
-import { eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, notInArray, sql } from 'drizzle-orm';
 
 import {
   eventFixtures,
+  events,
   type DbEventFixture,
   type DbEventFixtureInsert,
 } from '../db/schemas/index.schema';
@@ -73,6 +74,27 @@ export const createFixtureRepository = (dbInstance?: DbOrTransaction) => {
       }
     },
 
+    findByIds: async (ids: readonly number[]): Promise<DomainFixture[]> => {
+      try {
+        const uniqueIds = [...new Set(ids.filter((id) => Number.isInteger(id) && id > 0))];
+        if (uniqueIds.length === 0) return [];
+        const db = await getDbInstance();
+        const rows = await db
+          .select()
+          .from(eventFixtures)
+          .where(inArray(eventFixtures.id, uniqueIds))
+          .orderBy(eventFixtures.id);
+        return rows.map(mapDbFixtureToDomain);
+      } catch (error) {
+        logError('Failed to find fixtures by ids', error, { count: ids.length });
+        throw new DatabaseError(
+          'Failed to retrieve fixtures by ids',
+          'FIND_BY_IDS_ERROR',
+          error instanceof Error ? error : undefined,
+        );
+      }
+    },
+
     findEventIdsByFixtureIds: async (ids: number[]): Promise<Map<number, number | null>> => {
       try {
         if (ids.length === 0) {
@@ -114,6 +136,48 @@ export const createFixtureRepository = (dbInstance?: DbOrTransaction) => {
         throw new DatabaseError(
           'Failed to mark fixtures as unscheduled',
           'MARK_UNSCHEDULED_ERROR',
+          error instanceof Error ? error : undefined,
+        );
+      }
+    },
+
+    markAbsentUnscheduled: async (
+      acceptedIds: readonly number[],
+      preserveOwnedCheckedAtOrAfter?: Date,
+    ): Promise<number> => {
+      try {
+        const uniqueIds = [...new Set(acceptedIds.filter((id) => Number.isInteger(id) && id > 0))];
+        if (uniqueIds.length === 0) return 0;
+        const preserveOwnedCheckedAtOrAfterIso = preserveOwnedCheckedAtOrAfter?.toISOString();
+
+        const db = await getDbInstance();
+        const result = await db
+          .update(eventFixtures)
+          .set({ eventId: null, updatedAt: new Date() })
+          .where(
+            and(
+              isNotNull(eventFixtures.eventId),
+              notInArray(eventFixtures.id, uniqueIds),
+              preserveOwnedCheckedAtOrAfterIso
+                ? sql`NOT EXISTS (
+                    SELECT 1
+                    FROM ${events}
+                    WHERE ${events.id} = ${eventFixtures.eventId}
+                      AND ${events.liveSnapshotCheckedAt} >= ${preserveOwnedCheckedAtOrAfterIso}::timestamptz
+                  )`
+                : undefined,
+            ),
+          )
+          .returning({ id: eventFixtures.id });
+        logInfo('Retired fixtures absent from the complete snapshot', { count: result.length });
+        return result.length;
+      } catch (error) {
+        logError('Failed to retire fixtures absent from the complete snapshot', error, {
+          acceptedCount: acceptedIds.length,
+        });
+        throw new DatabaseError(
+          'Failed to retire fixtures absent from the complete snapshot',
+          'MARK_ABSENT_UNSCHEDULED_ERROR',
           error instanceof Error ? error : undefined,
         );
       }

--- a/src/repositories/phases.ts
+++ b/src/repositories/phases.ts
@@ -1,16 +1,13 @@
 import { sql } from 'drizzle-orm';
 
 import { phases, type DbPhase, type DbPhaseInsert } from '../db/schemas/index.schema';
-import { getDb } from '../db/singleton';
+import { getDb, type DbOrTransaction } from '../db/singleton';
 import { DatabaseError } from '../utils/errors';
 import { logError, logInfo } from '../utils/logger';
 
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Phase as DomainPhase } from '../types';
 
-type DatabaseInstance = PostgresJsDatabase<Record<string, never>>;
-
-export const createPhaseRepository = (dbInstance?: DatabaseInstance) => {
+export const createPhaseRepository = (dbInstance?: DbOrTransaction) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   return {

--- a/src/repositories/player-values.ts
+++ b/src/repositories/player-values.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, lt, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, lt, lte, sql } from 'drizzle-orm';
 
 import { playerValues, type DbPlayerValueInsert } from '../db/schemas/index.schema';
 import { getDb } from '../db/singleton';
@@ -96,6 +96,7 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
       elementIds: number[],
       fromChangeDate: string,
       beforeChangeDate: string,
+      asOf?: Date,
     ): Promise<StoredPlayerValue[]> => {
       if (elementIds.length === 0) {
         return [];
@@ -120,6 +121,7 @@ export const createPlayerValuesRepository = (dbInstance?: DatabaseInstance) => {
               inArray(playerValues.elementId, uniqueIds),
               gte(playerValues.changeDate, fromChangeDate),
               lt(playerValues.changeDate, beforeChangeDate),
+              ...(asOf ? [lte(playerValues.createdAt, asOf)] : []),
             ),
           )
           .orderBy(

--- a/src/repositories/players.ts
+++ b/src/repositories/players.ts
@@ -1,4 +1,4 @@
-import { inArray, sql } from 'drizzle-orm';
+import { and, inArray, sql } from 'drizzle-orm';
 
 import { players, type DbPlayer, type DbPlayerInsert } from '../db/schemas/index.schema';
 import { getDb, type DbOrTransaction } from '../db/singleton';
@@ -92,6 +92,7 @@ export const createPlayerRepository = (dbInstance?: DbOrTransaction) => {
         )} ELSE ${players.price} END`;
 
         const db = await getDbInstance();
+        const sourceCheckedAtIso = sourceCheckedAt.toISOString();
         const updated = await db
           .update(players)
           .set({
@@ -99,7 +100,15 @@ export const createPlayerRepository = (dbInstance?: DbOrTransaction) => {
             priceSourceCheckedAt: sourceCheckedAt,
             updatedAt: sql`NOW()`,
           })
-          .where(inArray(players.id, elementIds))
+          .where(
+            and(
+              inArray(players.id, elementIds),
+              sql`(
+                ${players.priceSourceCheckedAt} IS NULL OR
+                ${players.priceSourceCheckedAt} <= ${sourceCheckedAtIso}::timestamptz
+              )`,
+            ),
+          )
           .returning();
 
         const mappedPlayers = updated.map(mapDbPlayerToDomain);

--- a/src/repositories/players.ts
+++ b/src/repositories/players.ts
@@ -1,14 +1,11 @@
 import { inArray, sql } from 'drizzle-orm';
 
 import { players, type DbPlayer, type DbPlayerInsert } from '../db/schemas/index.schema';
-import { getDb } from '../db/singleton';
+import { getDb, type DbOrTransaction } from '../db/singleton';
 import { DatabaseError } from '../utils/errors';
 import { logError, logInfo } from '../utils/logger';
 
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Player as DomainPlayer } from '../types';
-
-type DatabaseInstance = PostgresJsDatabase<Record<string, never>>;
 
 function mapDbPlayerToDomain(player: DbPlayer): DomainPlayer {
   return {
@@ -24,10 +21,26 @@ function mapDbPlayerToDomain(player: DbPlayer): DomainPlayer {
   };
 }
 
-export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
+export const createPlayerRepository = (dbInstance?: DbOrTransaction) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   return {
+    findAll: async (options: { lock?: boolean } = {}): Promise<DomainPlayer[]> => {
+      try {
+        const db = await getDbInstance();
+        const query = db.select().from(players);
+        const rows = options.lock ? await query.for('update') : await query;
+        return rows.map(mapDbPlayerToDomain);
+      } catch (error) {
+        logError('Failed to retrieve all players', error);
+        throw new DatabaseError(
+          'Failed to retrieve players',
+          'FIND_ALL_PLAYERS_ERROR',
+          error instanceof Error ? error : undefined,
+        );
+      }
+    },
+
     findByIds: async (ids: number[]): Promise<DomainPlayer[]> => {
       if (ids.length === 0) {
         return [];
@@ -59,6 +72,7 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
 
     updatePrices: async (
       priceUpdates: Array<{ elementId: number; value: number }>,
+      sourceCheckedAt: Date,
     ): Promise<DomainPlayer[]> => {
       if (priceUpdates.length === 0) {
         return [];
@@ -80,7 +94,11 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
         const db = await getDbInstance();
         const updated = await db
           .update(players)
-          .set({ price: priceExpression, updatedAt: sql`NOW()` })
+          .set({
+            price: priceExpression,
+            priceSourceCheckedAt: sourceCheckedAt,
+            updatedAt: sql`NOW()`,
+          })
           .where(inArray(players.id, elementIds))
           .returning();
 
@@ -97,7 +115,10 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
       }
     },
 
-    upsertBatch: async (domainPlayers: DomainPlayer[]): Promise<DomainPlayer[]> => {
+    upsertBatch: async (
+      domainPlayers: DomainPlayer[],
+      preservePriceSourceCheckedAtOrAfter?: Date,
+    ): Promise<DomainPlayer[]> => {
       try {
         if (domainPlayers.length === 0) {
           return [];
@@ -116,6 +137,8 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
         }));
 
         const db = await getDbInstance();
+        const preservePriceSourceCheckedAtOrAfterIso =
+          preservePriceSourceCheckedAtOrAfter?.toISOString();
         const result = await db
           .insert(players)
           .values(newPlayers)
@@ -126,6 +149,14 @@ export const createPlayerRepository = (dbInstance?: DatabaseInstance) => {
               type: sql`excluded.type`,
               teamId: sql`excluded.team_id`,
               price: sql`excluded.price`,
+              priceSourceCheckedAt: preservePriceSourceCheckedAtOrAfterIso
+                ? sql`CASE
+                    WHEN ${players.priceSourceCheckedAt} >=
+                      ${preservePriceSourceCheckedAtOrAfterIso}::timestamptz
+                    THEN ${players.priceSourceCheckedAt}
+                    ELSE NULL
+                  END`
+                : null,
               startPrice: sql`excluded.start_price`,
               firstName: sql`excluded.first_name`,
               secondName: sql`excluded.second_name`,

--- a/src/repositories/players.ts
+++ b/src/repositories/players.ts
@@ -133,12 +133,16 @@ export const createPlayerRepository = (dbInstance?: DbOrTransaction) => {
           return [];
         }
 
+        const sourceCheckedAtIso = preservePriceSourceCheckedAtOrAfter?.toISOString();
         const newPlayers: DbPlayerInsert[] = domainPlayers.map((player) => ({
           id: player.id,
           code: player.code,
           type: player.type,
           teamId: player.teamId,
           price: player.price,
+          ...(sourceCheckedAtIso
+            ? { priceSourceCheckedAt: preservePriceSourceCheckedAtOrAfter }
+            : {}),
           startPrice: player.startPrice,
           firstName: player.firstName,
           secondName: player.secondName,
@@ -146,8 +150,6 @@ export const createPlayerRepository = (dbInstance?: DbOrTransaction) => {
         }));
 
         const db = await getDbInstance();
-        const preservePriceSourceCheckedAtOrAfterIso =
-          preservePriceSourceCheckedAtOrAfter?.toISOString();
         const result = await db
           .insert(players)
           .values(newPlayers)
@@ -158,12 +160,11 @@ export const createPlayerRepository = (dbInstance?: DbOrTransaction) => {
               type: sql`excluded.type`,
               teamId: sql`excluded.team_id`,
               price: sql`excluded.price`,
-              priceSourceCheckedAt: preservePriceSourceCheckedAtOrAfterIso
+              priceSourceCheckedAt: sourceCheckedAtIso
                 ? sql`CASE
-                    WHEN ${players.priceSourceCheckedAt} >=
-                      ${preservePriceSourceCheckedAtOrAfterIso}::timestamptz
+                    WHEN ${players.priceSourceCheckedAt} >= ${sourceCheckedAtIso}::timestamptz
                     THEN ${players.priceSourceCheckedAt}
-                    ELSE NULL
+                    ELSE ${sourceCheckedAtIso}::timestamptz
                   END`
                 : null,
               startPrice: sql`excluded.start_price`,

--- a/src/repositories/teams.ts
+++ b/src/repositories/teams.ts
@@ -1,16 +1,13 @@
 import { sql } from 'drizzle-orm';
 
 import { teams, type DbTeam, type DbTeamInsert } from '../db/schemas/index.schema';
-import { getDb } from '../db/singleton';
+import { getDb, type DbOrTransaction } from '../db/singleton';
 import { DatabaseError } from '../utils/errors';
 import { logError, logInfo } from '../utils/logger';
 
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Team as DomainTeam } from '../types';
 
-type DatabaseInstance = PostgresJsDatabase<Record<string, never>>;
-
-export const createTeamRepository = (dbInstance?: DatabaseInstance) => {
+export const createTeamRepository = (dbInstance?: DbOrTransaction) => {
   const getDbInstance = async () => dbInstance || (await getDb());
 
   return {

--- a/src/services/core-fixture-derivatives.service.ts
+++ b/src/services/core-fixture-derivatives.service.ts
@@ -46,19 +46,22 @@ export async function reconcileCoreFixtureDerivatives(
   sourceCheckedAt: Date,
   dependencies: CoreFixtureDerivativeDependencies = defaultDependencies,
 ): Promise<{ checkedEvents: number; retiredEmptyEvents: number }> {
-  const fixtures = await dependencies.findByIds(fixtureIds);
-  const preserveOwnedCheckedAtOrAfter = sourceCheckedAt.toISOString();
-  const byEvent = new Map<EventId, Fixture[]>();
-  for (const fixture of fixtures) {
-    if (fixture.event === null) continue;
-    const eventFixtures = byEvent.get(fixture.event) ?? [];
-    eventFixtures.push(fixture);
-    byEvent.set(fixture.event, eventFixtures);
-  }
-
   let retiredEmptyEvents = 0;
   const eventIds = Array.from({ length: CORE_SNAPSHOT_EXPECTED_EVENTS }, (_, index) => index + 1);
   await dependencies.serializeEvents(eventIds, async () => {
+    // Read canonical rows only after acquiring the same event fence as Live
+    // writers. A Live commit that won the fence must be the source used to
+    // rebuild fallback derivatives when its Redis publication is delayed.
+    const fixtures = await dependencies.findByIds(fixtureIds);
+    const preserveOwnedCheckedAtOrAfter = sourceCheckedAt.toISOString();
+    const byEvent = new Map<EventId, Fixture[]>();
+    for (const fixture of fixtures) {
+      if (fixture.event === null) continue;
+      const eventFixtures = byEvent.get(fixture.event) ?? [];
+      eventFixtures.push(fixture);
+      byEvent.set(fixture.event, eventFixtures);
+    }
+
     for (const eventId of eventIds) {
       const eventFixtures = byEvent.get(eventId) ?? [];
       if (eventFixtures.length > 0) {

--- a/src/services/core-fixture-derivatives.service.ts
+++ b/src/services/core-fixture-derivatives.service.ts
@@ -1,0 +1,84 @@
+import { liveSnapshotCache } from '../cache/operations';
+import { CORE_SNAPSHOT_EXPECTED_EVENTS } from '../domain/core-snapshot';
+import { computeFixtureSummedBonusByTeam } from '../domain/live-bonus';
+import { fixtureRepository } from '../repositories/fixtures';
+import { withLiveSnapshotEventsSerialization } from './live-snapshot.service';
+
+import type { LiveBonusByTeam } from '../domain/live-bonus';
+import type { EventId, TeamId } from '../types/base.type';
+import type { Fixture } from '../types';
+
+type CoreFixtureDerivativeCoordinator = Pick<
+  typeof liveSnapshotCache,
+  'refreshFixtureDerivatives' | 'retire'
+>;
+
+export interface CoreFixtureDerivativeDependencies {
+  findByIds: (fixtureIds: readonly number[]) => Promise<Fixture[]>;
+  coordinator: CoreFixtureDerivativeCoordinator;
+  serializeEvents: (eventIds: readonly number[], operation: () => Promise<void>) => Promise<void>;
+}
+
+const defaultDependencies: CoreFixtureDerivativeDependencies = {
+  findByIds: fixtureRepository.findByIds,
+  coordinator: liveSnapshotCache,
+  serializeEvents: (eventIds, operation) =>
+    withLiveSnapshotEventsSerialization(eventIds, async () => operation()),
+};
+
+function serializeBonusByTeam(source: Map<TeamId, Map<number, number>>): LiveBonusByTeam {
+  return Object.fromEntries(
+    [...source].map(([teamId, playerBonus]) => [
+      String(teamId),
+      Object.fromEntries([...playerBonus].map(([elementId, bonus]) => [String(elementId), bonus])),
+    ]),
+  ) as LiveBonusByTeam;
+}
+
+/**
+ * Reconcile fixture-owned Live cache views against the canonical rows accepted
+ * by a complete core publication. Unchanged owned snapshots remain intact;
+ * changed ones are retired atomically by the coordinator and fall back to the
+ * corrected fixture source until the separately managed Live pipeline republishes.
+ */
+export async function reconcileCoreFixtureDerivatives(
+  fixtureIds: readonly number[],
+  sourceCheckedAt: Date,
+  dependencies: CoreFixtureDerivativeDependencies = defaultDependencies,
+): Promise<{ checkedEvents: number; retiredEmptyEvents: number }> {
+  const fixtures = await dependencies.findByIds(fixtureIds);
+  const preserveOwnedCheckedAtOrAfter = sourceCheckedAt.toISOString();
+  const byEvent = new Map<EventId, Fixture[]>();
+  for (const fixture of fixtures) {
+    if (fixture.event === null) continue;
+    const eventFixtures = byEvent.get(fixture.event) ?? [];
+    eventFixtures.push(fixture);
+    byEvent.set(fixture.event, eventFixtures);
+  }
+
+  let retiredEmptyEvents = 0;
+  const eventIds = Array.from({ length: CORE_SNAPSHOT_EXPECTED_EVENTS }, (_, index) => index + 1);
+  await dependencies.serializeEvents(eventIds, async () => {
+    for (const eventId of eventIds) {
+      const eventFixtures = byEvent.get(eventId) ?? [];
+      if (eventFixtures.length > 0) {
+        const byTeam = serializeBonusByTeam(computeFixtureSummedBonusByTeam(eventFixtures));
+        await dependencies.coordinator.refreshFixtureDerivatives(
+          eventId,
+          eventFixtures,
+          byTeam,
+          preserveOwnedCheckedAtOrAfter,
+        );
+        continue;
+      }
+
+      const retirement = await dependencies.coordinator.retire(
+        eventId,
+        preserveOwnedCheckedAtOrAfter,
+      );
+      if (retirement.removedKeys > 0) retiredEmptyEvents += 1;
+    }
+  });
+
+  return { checkedEvents: CORE_SNAPSHOT_EXPECTED_EVENTS, retiredEmptyEvents };
+}

--- a/src/services/core-snapshot-persistence.service.ts
+++ b/src/services/core-snapshot-persistence.service.ts
@@ -1,0 +1,385 @@
+import { inArray, sql } from 'drizzle-orm';
+
+import { acquireActiveSeasonWriteFence } from '../cache/cache-season';
+import { events, players, teams } from '../db/schemas/index.schema';
+import {
+  getDb,
+  type DbHandle,
+  type DbOrTransaction,
+  type TransactionHandle,
+} from '../db/singleton';
+import { createEventRepository } from '../repositories/events';
+import { createFixtureRepository } from '../repositories/fixtures';
+import { createPhaseRepository } from '../repositories/phases';
+import { createPlayerRepository } from '../repositories/players';
+import { createTeamRepository } from '../repositories/teams';
+import {
+  findCoreSnapshotAuthority,
+  recordCoreSnapshotAuthority,
+} from '../repositories/core-snapshot-authority';
+import { DatabaseError } from '../utils/errors';
+
+import type { CoreSnapshot } from '../domain/core-snapshot';
+
+const CORE_SNAPSHOT_AUTHORITY_LOCK_KEY = 912_883_472;
+
+export async function withCoreSnapshotAuthorityLock<T>(
+  operation: (transaction: TransactionHandle) => Promise<T>,
+  dbInstance?: DbHandle,
+): Promise<T> {
+  const db = dbInstance ?? (await getDb());
+  return db.transaction(async (transaction) => {
+    // Season authority is always acquired before core authority. Partial
+    // repairs use the same order with a shared season fence, so a complete
+    // publication can neither race a repair nor deadlock with fixture writers.
+    await acquireActiveSeasonWriteFence(transaction);
+    await transaction.execute(
+      sql`SELECT pg_advisory_xact_lock(${CORE_SNAPSHOT_AUTHORITY_LOCK_KEY})`,
+    );
+    return operation(transaction);
+  });
+}
+
+export interface CoreSnapshotPersistenceResult {
+  events: number;
+  teams: number;
+  players: number;
+  phases: number;
+  fixtures: number;
+}
+
+export interface CoreSnapshotCommitResult<T> {
+  status: 'committed' | 'stale';
+  persistence: CoreSnapshotPersistenceResult | null;
+  finalization: T | null;
+}
+
+export interface CoreSnapshotPublicationOptions<T> {
+  revision: number;
+  publicationId: string;
+  previousActiveSeason: string | null;
+  /** PostgreSQL ordering evidence captured before the upstream reads began. */
+  sourceCheckedAt?: Date;
+  finalize: (snapshot: CoreSnapshot) => Promise<T>;
+  compensate: (finalization: T) => Promise<void>;
+  afterCommit: (finalization: T) => Promise<void>;
+}
+
+export async function readCoreSnapshotOrderingTimestamp(dbInstance?: DbHandle): Promise<Date> {
+  const db = dbInstance ?? (await getDb());
+  const rows = await db.execute<{ checkedAt: Date | string }>(
+    sql`SELECT clock_timestamp() AS "checkedAt"`,
+  );
+  const checkedAt =
+    rows[0]?.checkedAt instanceof Date
+      ? rows[0].checkedAt
+      : new Date(String(rows[0]?.checkedAt ?? ''));
+  if (Number.isNaN(checkedAt.getTime())) {
+    throw new DatabaseError(
+      'Core snapshot ordering timestamp is invalid.',
+      'CORE_SNAPSHOT_ORDERING_TIMESTAMP_INVALID',
+    );
+  }
+  return checkedAt;
+}
+
+function requirePersistedCount(label: string, actual: number, expected: number): void {
+  if (actual !== expected) {
+    throw new DatabaseError(
+      `Core snapshot ${label} persistence was incomplete`,
+      'CORE_SNAPSHOT_PERSISTENCE_INCOMPLETE',
+    );
+  }
+}
+
+async function persistCoreSnapshotRows(
+  snapshot: CoreSnapshot,
+  db: DbOrTransaction,
+  sourceCheckedAt?: Date,
+): Promise<CoreSnapshotPersistenceResult> {
+  // The cache can represent fixtures that FPL has not assigned to a gameweek,
+  // while older deployed database schemas still require event_id. Keep those
+  // fixtures in the cache snapshot and persist only schedulable rows.
+  const schedulableFixtures = snapshot.fixtures.filter((fixture) => fixture.event !== null);
+  const savedEvents = await createEventRepository(db).upsertBatch(snapshot.events);
+  const savedTeams = await createTeamRepository(db).upsertBatch(snapshot.teams);
+  const savedPlayers = await createPlayerRepository(db).upsertBatch(
+    snapshot.players,
+    sourceCheckedAt,
+  );
+  const savedPhases = await createPhaseRepository(db).upsertBatch(snapshot.phases);
+  const fixtureRepository = createFixtureRepository(db);
+  const unscheduledFixtureIds = snapshot.fixtures
+    .filter((fixture) => fixture.event === null)
+    .map((fixture) => fixture.id);
+  if (unscheduledFixtureIds.length > 0) {
+    await fixtureRepository.markUnscheduled(unscheduledFixtureIds);
+  }
+  const savedFixtures = await fixtureRepository.upsertBatch(schedulableFixtures);
+  await fixtureRepository.markAbsentUnscheduled(
+    snapshot.fixtures.map((fixture) => fixture.id),
+    sourceCheckedAt,
+  );
+
+  requirePersistedCount('events', savedEvents.length, snapshot.events.length);
+  requirePersistedCount('teams', savedTeams.length, snapshot.teams.length);
+  requirePersistedCount('players', savedPlayers.length, snapshot.players.length);
+  requirePersistedCount('phases', savedPhases.length, snapshot.phases.length);
+  requirePersistedCount('fixtures', savedFixtures.length, schedulableFixtures.length);
+
+  return {
+    events: savedEvents.length,
+    teams: savedTeams.length,
+    players: savedPlayers.length,
+    phases: savedPhases.length,
+    fixtures: savedFixtures.length,
+  };
+}
+
+/**
+ * Retain fields owned by durable writers that completed after this core
+ * snapshot started fetching. The returned snapshot is used for both database
+ * persistence and cache publication, so neither surface can regress.
+ */
+async function reconcileDurableWinners(
+  snapshot: CoreSnapshot,
+  sourceCheckedAt: Date | undefined,
+  db: DbOrTransaction,
+): Promise<CoreSnapshot> {
+  if (!sourceCheckedAt) return snapshot;
+
+  // Lock the same canonical rows the later upserts will replace. A partial
+  // writer that committed first is visible below; one that starts later waits
+  // and becomes the final winner after this short transaction commits.
+  const storedPlayers = await db
+    .select({
+      id: players.id,
+      price: players.price,
+      priceSourceCheckedAt: players.priceSourceCheckedAt,
+    })
+    .from(players)
+    .where(
+      inArray(
+        players.id,
+        snapshot.players.map((player) => player.id),
+      ),
+    )
+    .for('update');
+  const newerPriceById = new Map(
+    storedPlayers
+      .filter(
+        (row) =>
+          row.priceSourceCheckedAt &&
+          row.priceSourceCheckedAt.getTime() >= sourceCheckedAt.getTime(),
+      )
+      .map((row) => [row.id, row.price]),
+  );
+
+  // The event rows are the durable Live ownership fence. Lock all 38 before
+  // reading their markers so a Live write can neither slip between this audit
+  // and the fixture upsert nor deadlock on a changing event subset.
+  const storedEvents = await db
+    .select({ id: events.id, checkedAt: events.liveSnapshotCheckedAt })
+    .from(events)
+    .for('update');
+  const liveOwnedEventIds = new Set(
+    storedEvents
+      .filter((row) => row.checkedAt && row.checkedAt.getTime() >= sourceCheckedAt.getTime())
+      .map((row) => row.id),
+  );
+  const storedFixtures =
+    liveOwnedEventIds.size > 0 ? await createFixtureRepository(db).findAll() : [];
+  const storedFixturesById = new Map(storedFixtures.map((fixture) => [fixture.id, fixture]));
+  const fixtures = snapshot.fixtures.map((fixture) => {
+    const stored = storedFixturesById.get(fixture.id);
+    const storedEventId = stored?.event;
+    const isLiveOwned =
+      (fixture.event !== null && liveOwnedEventIds.has(fixture.event)) ||
+      (storedEventId !== null &&
+        storedEventId !== undefined &&
+        liveOwnedEventIds.has(storedEventId));
+    if (!isLiveOwned) return fixture;
+    if (!stored) {
+      throw new DatabaseError(
+        'A Live-owned fixture is missing from canonical storage.',
+        'CORE_SNAPSHOT_LIVE_FIXTURE_MISSING',
+      );
+    }
+    // Repository timestamps are storage metadata and are not part of the FPL
+    // cache contract. Keep the candidate representation while retaining every
+    // newer upstream-owned fixture field.
+    return {
+      ...stored,
+      createdAt: fixture.createdAt,
+      updatedAt: fixture.updatedAt,
+    };
+  });
+
+  return {
+    ...snapshot,
+    players: snapshot.players.map((player) => {
+      const price = newerPriceById.get(player.id);
+      return price === undefined ? player : { ...player, price };
+    }),
+    fixtures,
+  };
+}
+
+async function assertIdentityCompatibility(
+  snapshot: CoreSnapshot,
+  previousActiveSeason: string | null,
+  authoritySeason: string | null,
+  db: DbOrTransaction,
+): Promise<void> {
+  const previousSeason = authoritySeason ?? previousActiveSeason;
+  if (previousSeason && previousSeason !== snapshot.season) {
+    throw new DatabaseError(
+      'Core snapshot season rollover requires the separately approved database rollover runbook.',
+      'CORE_SNAPSHOT_MANUAL_ROLLOVER_REQUIRED',
+    );
+  }
+
+  const [storedTeams, storedPlayers] = await Promise.all([
+    db.select({ id: teams.id, code: teams.code, pulseId: teams.pulseId }).from(teams),
+    db.select({ id: players.id, code: players.code }).from(players),
+  ]);
+  const candidateTeamsById = new Map(snapshot.teams.map((team) => [team.id, team]));
+  const candidateTeamIdsByCode = new Map(snapshot.teams.map((team) => [team.code, team.id]));
+  const candidateTeamIdsByPulse = new Map(snapshot.teams.map((team) => [team.pulseId, team.id]));
+  const candidatePlayersById = new Map(snapshot.players.map((player) => [player.id, player]));
+  const candidatePlayerIdsByCode = new Map(
+    snapshot.players.map((player) => [player.code, player.id]),
+  );
+
+  const teamConflict = storedTeams.some((stored) => {
+    const candidate = candidateTeamsById.get(stored.id);
+    return (
+      (candidate && (candidate.code !== stored.code || candidate.pulseId !== stored.pulseId)) ||
+      (candidateTeamIdsByCode.get(stored.code) ?? stored.id) !== stored.id ||
+      (candidateTeamIdsByPulse.get(stored.pulseId) ?? stored.id) !== stored.id
+    );
+  });
+  const playerConflict = storedPlayers.some((stored) => {
+    const candidate = candidatePlayersById.get(stored.id);
+    return (
+      (candidate && candidate.code !== stored.code) ||
+      (candidatePlayerIdsByCode.get(stored.code) ?? stored.id) !== stored.id
+    );
+  });
+
+  if (teamConflict || playerConflict) {
+    throw new DatabaseError(
+      'Core snapshot identities conflict with canonical rows.',
+      'CORE_SNAPSHOT_IDENTITY_CONFLICT',
+    );
+  }
+}
+
+export async function persistCoreSnapshot(
+  snapshot: CoreSnapshot,
+  dbInstance?: DbHandle,
+): Promise<CoreSnapshotPersistenceResult> {
+  const db = dbInstance ?? (await getDb());
+  return db.transaction((transaction) => persistCoreSnapshotRows(snapshot, transaction));
+}
+
+export async function persistCoreSnapshotWithFinalizer<T>(
+  snapshot: CoreSnapshot,
+  options: CoreSnapshotPublicationOptions<T>,
+  dbInstance?: DbHandle,
+): Promise<CoreSnapshotCommitResult<T>> {
+  const db = dbInstance ?? (await getDb());
+  let persistence: CoreSnapshotPersistenceResult | null = null;
+  let finalization: T | null = null;
+  let finalized = false;
+  let transactionCommitted = false;
+
+  try {
+    const result = await withCoreSnapshotAuthorityLock(async (transaction) => {
+      const authority = await findCoreSnapshotAuthority(transaction, { lock: true });
+      if (authority && authority.revision >= options.revision) {
+        return {
+          status: 'stale',
+          persistence: null,
+          finalization: null,
+        } satisfies CoreSnapshotCommitResult<T>;
+      }
+
+      await assertIdentityCompatibility(
+        snapshot,
+        options.previousActiveSeason,
+        authority?.season ?? null,
+        transaction,
+      );
+      const reconciledSnapshot = await reconcileDurableWinners(
+        snapshot,
+        options.sourceCheckedAt,
+        transaction,
+      );
+      persistence = await persistCoreSnapshotRows(
+        reconciledSnapshot,
+        transaction,
+        options.sourceCheckedAt,
+      );
+      finalization = await options.finalize(reconciledSnapshot);
+      finalized = true;
+      await recordCoreSnapshotAuthority(
+        {
+          season: snapshot.season,
+          revision: options.revision,
+          publicationId: options.publicationId,
+        },
+        transaction,
+      );
+      return {
+        status: 'committed',
+        persistence,
+        finalization,
+      } satisfies CoreSnapshotCommitResult<T>;
+    }, db);
+    transactionCommitted = result.status === 'committed';
+    if (result.status === 'committed' && result.finalization !== null) {
+      await options.afterCommit(result.finalization);
+    }
+    return result;
+  } catch (error) {
+    if (finalized && !transactionCommitted && finalization !== null) {
+      let committedPublication = false;
+      try {
+        committedPublication = await withCoreSnapshotAuthorityLock(async (transaction) => {
+          const authority = await findCoreSnapshotAuthority(transaction, { lock: true });
+          return authority?.publicationId === options.publicationId;
+        }, db);
+      } catch (reconciliationError) {
+        // The transaction result is ambiguous and durable authority cannot be
+        // read. Preserve the pending Redis receipt so a later recovery attempt
+        // can decide whether to finalize or compensate safely.
+        throw new DatabaseError(
+          'Core snapshot commit outcome could not be reconciled.',
+          'CORE_SNAPSHOT_COMMIT_OUTCOME_UNKNOWN',
+          reconciliationError instanceof Error ? reconciliationError : undefined,
+        );
+      }
+
+      if (committedPublication) {
+        await options.afterCommit(finalization);
+        return {
+          status: 'committed',
+          persistence,
+          finalization,
+        };
+      }
+
+      try {
+        await options.compensate(finalization);
+      } catch (compensationError) {
+        throw new DatabaseError(
+          'Core snapshot database commit and cache compensation both failed.',
+          'CORE_SNAPSHOT_COMPENSATION_FAILED',
+          compensationError instanceof Error ? compensationError : undefined,
+        );
+      }
+    }
+    throw error;
+  }
+}

--- a/src/services/core-snapshot-persistence.service.ts
+++ b/src/services/core-snapshot-persistence.service.ts
@@ -121,6 +121,7 @@ async function persistCoreSnapshotRows(
   await fixtureRepository.markAbsentUnscheduled(
     snapshot.fixtures.map((fixture) => fixture.id),
     sourceCheckedAt,
+    snapshot.fixtures.map((fixture) => fixture.code),
   );
   const savedFixtures = await fixtureRepository.upsertBatch(schedulableFixtures);
 

--- a/src/services/core-snapshot-persistence.service.ts
+++ b/src/services/core-snapshot-persistence.service.ts
@@ -115,11 +115,14 @@ async function persistCoreSnapshotRows(
   if (unscheduledFixtureIds.length > 0) {
     await fixtureRepository.markUnscheduled(unscheduledFixtureIds);
   }
-  const savedFixtures = await fixtureRepository.upsertBatch(schedulableFixtures);
+  // Retire rows omitted from the authoritative snapshot before inserting any
+  // replacement fixture. The unique (event, home, away) index otherwise lets
+  // an upstream fixture-id replacement fail before the old row can be cleared.
   await fixtureRepository.markAbsentUnscheduled(
     snapshot.fixtures.map((fixture) => fixture.id),
     sourceCheckedAt,
   );
+  const savedFixtures = await fixtureRepository.upsertBatch(schedulableFixtures);
 
   requirePersistedCount('events', savedEvents.length, snapshot.events.length);
   requirePersistedCount('teams', savedTeams.length, snapshot.teams.length);

--- a/src/services/core-snapshot-publication.service.ts
+++ b/src/services/core-snapshot-publication.service.ts
@@ -1,0 +1,127 @@
+import {
+  finalizeCoreSnapshotCachePublication,
+  publishCoreSnapshotCache,
+  readPendingCoreSnapshotCachePublication,
+  rollbackCoreSnapshotCachePublication,
+  type CoreSnapshotCachePublication,
+} from '../cache/core-snapshot-cache';
+import { events } from '../db/schemas/index.schema';
+import { findCoreSnapshotAuthority } from '../repositories/core-snapshot-authority';
+import { createPlayerRepository } from '../repositories/players';
+import { CacheError } from '../utils/errors';
+import { logInfo } from '../utils/logger';
+import {
+  persistCoreSnapshotWithFinalizer,
+  readCoreSnapshotOrderingTimestamp,
+  type CoreSnapshotCommitResult,
+  withCoreSnapshotAuthorityLock,
+} from './core-snapshot-persistence.service';
+import { reconcileCoreFixtureDerivatives } from './core-fixture-derivatives.service';
+
+import type { TransactionHandle } from '../db/singleton';
+
+import type { CoreSnapshot } from '../domain/core-snapshot';
+
+export interface CoreSnapshotPublicationContext {
+  revision: number;
+  publicationId: string;
+  previousActiveSeason: string | null;
+  sourceCheckedAt: Date;
+}
+
+export { readCoreSnapshotOrderingTimestamp };
+
+function requireReceipt(publication: CoreSnapshotCachePublication) {
+  if (!publication.published || !publication.receipt) {
+    throw new CacheError(
+      'Core snapshot cache publication did not produce a recovery receipt',
+      'CORE_SNAPSHOT_PUBLICATION_LOST_AUTHORITY',
+    );
+  }
+  return publication.receipt;
+}
+
+async function finalizeCommittedPublication(
+  receipt: ReturnType<typeof requireReceipt>,
+): Promise<void> {
+  await reconcileCoreFixtureDerivatives(receipt.fixtureIds, new Date(receipt.sourceCheckedAt));
+  await finalizeCoreSnapshotCachePublication(receipt);
+}
+
+async function rollbackWithDurablePartialWinners(
+  receipt: ReturnType<typeof requireReceipt>,
+  transaction: TransactionHandle,
+): Promise<void> {
+  // Match core persistence lock order. A partial writer that completed first
+  // is visible here; one that starts later waits and republishes after recovery.
+  const durablePlayers = await createPlayerRepository(transaction).findAll({ lock: true });
+  await transaction.select({ id: events.id }).from(events).for('update');
+  await rollbackCoreSnapshotCachePublication(receipt, undefined, durablePlayers);
+}
+
+export async function commitCoreSnapshotPublication(
+  snapshot: CoreSnapshot,
+  context: CoreSnapshotPublicationContext,
+): Promise<CoreSnapshotCommitResult<CoreSnapshotCachePublication>> {
+  return persistCoreSnapshotWithFinalizer(snapshot, {
+    revision: context.revision,
+    publicationId: context.publicationId,
+    previousActiveSeason: context.previousActiveSeason,
+    sourceCheckedAt: context.sourceCheckedAt,
+    finalize: async (reconciledSnapshot) => {
+      const publication = await publishCoreSnapshotCache(reconciledSnapshot, {
+        publicationId: context.publicationId,
+        sourceCheckedAt: context.sourceCheckedAt,
+      });
+      requireReceipt(publication);
+      return publication;
+    },
+    compensate: async (publication) => {
+      await withCoreSnapshotAuthorityLock((transaction) =>
+        rollbackWithDurablePartialWinners(requireReceipt(publication), transaction),
+      );
+    },
+    afterCommit: async (publication) => {
+      await finalizeCommittedPublication(requireReceipt(publication));
+    },
+  });
+}
+
+export async function recoverPendingCoreSnapshotPublication(): Promise<
+  'none' | 'finalized' | 'rolled_back'
+> {
+  const decision = await withCoreSnapshotAuthorityLock(async (transaction) => {
+    // Read the receipt only after acquiring the same database lock used by a
+    // publisher. Recovery can then never mistake an in-flight transaction for
+    // a rolled-back publication, even if the Redis mutation guard is disabled
+    // or its lease is lost.
+    const pending = await readPendingCoreSnapshotCachePublication();
+    if (!pending) return 'none';
+
+    const authority = await findCoreSnapshotAuthority(transaction, { lock: true });
+    if (authority?.publicationId === pending.publicationId) {
+      return { status: 'committed' as const, pending };
+    }
+
+    await rollbackWithDurablePartialWinners(pending, transaction);
+    logInfo('Rolled back uncommitted core snapshot publication recovery', {
+      season: pending.season,
+      publicationId: pending.publicationId,
+    });
+    return { status: 'rolled_back' as const };
+  });
+
+  if (decision === 'none') return 'none';
+  if (decision.status === 'rolled_back') return 'rolled_back';
+
+  // Event serialization takes the shared season fence, so committed recovery
+  // completes after releasing the core authority transaction's write fence.
+  // The Redis receipt remains pending until every derivative is reconciled;
+  // any failure is therefore recoverable by the next attempt.
+  await finalizeCommittedPublication(decision.pending);
+  logInfo('Finalized committed core snapshot publication recovery', {
+    season: decision.pending.season,
+    publicationId: decision.pending.publicationId,
+  });
+  return 'finalized';
+}

--- a/src/services/core-snapshot.service.ts
+++ b/src/services/core-snapshot.service.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  clearStaleSeasonCache,
+  isNewerSeason,
+  readStoredActiveCacheSeason,
+} from '../cache/cache-season';
+import { fplClient, type FPLBootstrapResponse } from '../clients/fpl';
+import {
+  CORE_SNAPSHOT_MUTATION_SCOPES,
+  prepareCoreSnapshot,
+  type CoreSnapshot,
+} from '../domain/core-snapshot';
+import { allocateCoreSnapshotRevision } from '../repositories/core-snapshot-authority';
+import {
+  commitCoreSnapshotPublication,
+  readCoreSnapshotOrderingTimestamp,
+  recoverPendingCoreSnapshotPublication,
+  type CoreSnapshotPublicationContext,
+} from './core-snapshot-publication.service';
+
+import type { RawFPLFixture } from '../types';
+
+export type CoreSnapshotMilestone = 'fetched' | 'validated' | 'locked' | 'persisted' | 'published';
+
+export interface CoreSnapshotSyncResult {
+  outcome: 'ready' | 'noop';
+  season: string;
+  events: number;
+  teams: number;
+  players: number;
+  phases: number;
+  fixtures: number;
+  requiredUnits: number;
+  reusedUnits: number;
+  succeededUnits: number;
+  failedUnits: number;
+}
+
+export interface CoreSnapshotDependencies {
+  getBootstrap: () => Promise<FPLBootstrapResponse>;
+  getFixtures: () => Promise<RawFPLFixture[]>;
+  getActiveSeason: () => Promise<string | null>;
+  readOrderingTimestamp: () => Promise<Date>;
+  reserveRevision: () => Promise<number>;
+  createPublicationId: () => string;
+  recoverPending: () => Promise<unknown>;
+  commit: (
+    snapshot: CoreSnapshot,
+    context: CoreSnapshotPublicationContext,
+  ) => Promise<{ status: 'committed' | 'stale' }>;
+  cleanup: (season: string) => Promise<void>;
+  withPersistenceLock: <T>(operation: () => Promise<T>) => Promise<T>;
+  onMilestone?: (milestone: CoreSnapshotMilestone) => void;
+}
+
+const defaultDependencies: CoreSnapshotDependencies = {
+  getBootstrap: () => fplClient.getBootstrap(),
+  getFixtures: () => fplClient.getFixtures(),
+  getActiveSeason: readStoredActiveCacheSeason,
+  readOrderingTimestamp: readCoreSnapshotOrderingTimestamp,
+  reserveRevision: allocateCoreSnapshotRevision,
+  createPublicationId: randomUUID,
+  recoverPending: async () => {
+    const { withMutationConflictGuard } = await import('../utils/mutation-lock');
+    return withMutationConflictGuard(
+      {
+        queueName: 'data-sync',
+        jobName: 'core-snapshot-recovery',
+        scopes: [...CORE_SNAPSHOT_MUTATION_SCOPES],
+      },
+      recoverPendingCoreSnapshotPublication,
+    );
+  },
+  commit: commitCoreSnapshotPublication,
+  cleanup: (season) => clearStaleSeasonCache(season),
+  withPersistenceLock: async (operation) => {
+    const { withMutationConflictGuard } = await import('../utils/mutation-lock');
+    return withMutationConflictGuard(
+      {
+        queueName: 'data-sync',
+        jobName: 'core-snapshot',
+        scopes: [...CORE_SNAPSHOT_MUTATION_SCOPES],
+      },
+      operation,
+    );
+  },
+};
+
+function workUnits(snapshot: CoreSnapshot): number {
+  return (
+    snapshot.events.length +
+    snapshot.teams.length +
+    snapshot.players.length +
+    snapshot.phases.length +
+    snapshot.fixtures.length
+  );
+}
+
+function result(snapshot: CoreSnapshot, published: boolean): CoreSnapshotSyncResult {
+  const requiredUnits = workUnits(snapshot);
+  return {
+    outcome: published ? 'ready' : 'noop',
+    season: snapshot.season,
+    events: snapshot.events.length,
+    teams: snapshot.teams.length,
+    players: snapshot.players.length,
+    phases: snapshot.phases.length,
+    fixtures: snapshot.fixtures.length,
+    requiredUnits,
+    reusedUnits: published ? 0 : requiredUnits,
+    succeededUnits: published ? requiredUnits : 0,
+    failedUnits: 0,
+  };
+}
+
+export async function syncCoreSnapshot(
+  dependencies: CoreSnapshotDependencies = defaultDependencies,
+): Promise<CoreSnapshotSyncResult> {
+  await dependencies.recoverPending();
+  const revision = await dependencies.reserveRevision();
+  const publicationId = dependencies.createPublicationId();
+  const sourceCheckedAt = await dependencies.readOrderingTimestamp();
+  const [bootstrap, fixtures] = await Promise.all([
+    dependencies.getBootstrap(),
+    dependencies.getFixtures(),
+  ]);
+  dependencies.onMilestone?.('fetched');
+
+  const snapshot = prepareCoreSnapshot(bootstrap, fixtures);
+  dependencies.onMilestone?.('validated');
+
+  return dependencies.withPersistenceLock(async () => {
+    dependencies.onMilestone?.('locked');
+    const activeSeason = await dependencies.getActiveSeason();
+    if (activeSeason && isNewerSeason(activeSeason, snapshot.season)) {
+      return result(snapshot, false);
+    }
+
+    const publication = await dependencies.commit(snapshot, {
+      revision,
+      publicationId,
+      previousActiveSeason: activeSeason,
+      sourceCheckedAt,
+    });
+    if (publication.status === 'stale') {
+      return result(snapshot, false);
+    }
+    dependencies.onMilestone?.('persisted');
+    await dependencies.cleanup(snapshot.season);
+    dependencies.onMilestone?.('published');
+    return result(snapshot, true);
+  });
+}

--- a/src/services/core-snapshot.service.ts
+++ b/src/services/core-snapshot.service.ts
@@ -147,7 +147,12 @@ export async function syncCoreSnapshot(
       return result(snapshot, false);
     }
     dependencies.onMilestone?.('persisted');
-    await dependencies.cleanup(snapshot.season);
+    // The publication can release its lock before a newer season acquires the
+    // authority. Recheck before deleting any season-prefixed cache keys.
+    const cleanupSeason = await dependencies.getActiveSeason();
+    if (cleanupSeason === snapshot.season) {
+      await dependencies.cleanup(snapshot.season);
+    }
     dependencies.onMilestone?.('published');
     return result(snapshot, true);
   });

--- a/src/services/events.service.ts
+++ b/src/services/events.service.ts
@@ -1,11 +1,9 @@
 import { eventsCache } from '../cache/operations';
-import { fplClient } from '../clients/fpl';
 import { normalizeEventDeadline } from '../domain/events';
 import { eventRepository } from '../repositories/events';
-import { transformEvents } from '../transformers/events';
-import { resolvePublishedSeasonFromEvents } from './cache-season.service';
+import { syncCoreSnapshot } from './core-snapshot.service';
 import type { Event } from '../types';
-import { logDebug, logError, logInfo } from '../utils/logger';
+import { logDebug, logError } from '../utils/logger';
 
 /**
  * Events Service - Business Logic Layer
@@ -79,73 +77,10 @@ export async function syncEvents(): Promise<{
   errors: number;
   warningCount: number;
 }> {
-  try {
-    logInfo('Starting events sync from FPL API');
-    const syncStart = Date.now();
-
-    // 1. Fetch from FPL API
-    const fetchStart = Date.now();
-    const bootstrapData = await fplClient.getBootstrap();
-    const fetchDuration = Date.now() - fetchStart;
-    logInfo('Events sync stage completed', { stage: 'fetch', durationMs: fetchDuration });
-
-    if (!bootstrapData.events || !Array.isArray(bootstrapData.events)) {
-      throw new Error('Invalid events data from FPL API');
-    }
-
-    logInfo('Raw events data fetched', { count: bootstrapData.events.length });
-
-    if (bootstrapData.events.length === 0) {
-      logInfo('No events returned from FPL API; preserving existing events cache');
-      return {
-        count: 0,
-        errors: 0,
-        warningCount: 0,
-      };
-    }
-
-    // 2. Transform to domain events (transformer validates each record via Zod)
-    const transformStart = Date.now();
-    const events = transformEvents(bootstrapData.events);
-    const transformDuration = Date.now() - transformStart;
-    const transformErrors = bootstrapData.events.length - events.length;
-
-    logInfo('Events transformed', {
-      total: bootstrapData.events.length,
-      successful: events.length,
-      skipped: transformErrors,
-      durationMs: transformDuration,
-    });
-
-    // 3. Save to database (batch upsert)
-    const dbStart = Date.now();
-    const savedEvents = await eventRepository.upsertBatch(events);
-    const dbDuration = Date.now() - dbStart;
-    logInfo('Events upserted to database', { count: savedEvents.length });
-    logInfo('Events sync stage completed', { stage: 'database', durationMs: dbDuration });
-
-    // 4. Update cache with full event objects
-    const cacheStart = Date.now();
-    await eventsCache.set(
-      savedEvents,
-      await resolvePublishedSeasonFromEvents(bootstrapData.events),
-    );
-    const cacheDuration = Date.now() - cacheStart;
-    logInfo('Events cache updated', { durationMs: cacheDuration });
-
-    const result = {
-      count: savedEvents.length,
-      errors: transformErrors,
-      warningCount: 0,
-    };
-
-    logInfo('Events sync completed successfully', {
-      ...result,
-      totalDurationMs: Date.now() - syncStart,
-    });
-    return result;
-  } catch (error) {
-    logError('Events sync failed', error);
-    throw error;
-  }
+  const result = await syncCoreSnapshot();
+  return {
+    count: result.events,
+    errors: result.failedUnits,
+    warningCount: 0,
+  };
 }

--- a/src/services/fixtures.service.ts
+++ b/src/services/fixtures.service.ts
@@ -1,344 +1,60 @@
-import { fixturesCache, liveSnapshotCache } from '../cache/operations';
-import { deriveSeasonFromFixtures } from '../cache/cache-season';
-import { fplClient } from '../clients/fpl';
-import {
-  findOmittedEventFixtureIds,
-  resolveFixtureCacheLockEventIds,
-  resolveFixtureDerivativeReconciliationEventIds,
-  resolveFixtureCacheTransitions,
-  type FixtureCacheTransitions,
-} from '../domain/fixture-cache-transition';
-import { createFixtureRepository, fixtureRepository } from '../repositories/fixtures';
-import { transformFixtures } from '../transformers/fixtures';
-import type { Fixture, RawFPLFixture } from '../types';
-import { logError, logInfo, logWarn } from '../utils/logger';
-import { getCurrentEvent } from './events.service';
-import { syncFixtureDerivedSnapshotCache } from './live-bonus.service';
-import {
-  syncLiveSnapshot,
-  withFixtureSyncSerialization,
-  withLiveSnapshotDurableEventsWriteFence,
-} from './live-snapshot.service';
+import { fixturesCache } from '../cache/operations';
+import { fixtureRepository } from '../repositories/fixtures';
+import { logError, logInfo } from '../utils/logger';
+import { syncCoreSnapshot } from './core-snapshot.service';
+import { syncLiveSnapshot } from './live-snapshot.service';
 
-/**
- * Fixtures Service - Business Logic Layer
- *
- * Handles fixture operations focused on synchronization and cache management.
- */
-
-// Sync all fixtures from FPL API
-export async function syncFixtures(eventId?: number): Promise<{ count: number; errors: number }> {
-  try {
-    const logContext = eventId ? { eventId } : {};
-    logInfo('Starting fixtures sync from FPL API', logContext);
-
-    type FixtureSyncContext = {
-      rawFixtures: RawFPLFixture[];
-      fixtures: Fixture[];
-      recoveredFullFixtureFeed: boolean;
-      unscheduledFixtures: Fixture[];
-      schedulableFixtures: Fixture[];
-      payloadSeason?: string;
-      transitions: FixtureCacheTransitions;
-    };
-
-    const result = await withFixtureSyncSerialization(
-      async (): Promise<{ eventIds: readonly number[]; context: FixtureSyncContext }> => {
-        // Fetch only after entering the global fixture lane. The PostgreSQL
-        // ordering token is already fixed by withFixtureSyncSerialization, so
-        // a live snapshot that wins an event lock during this fetch makes the
-        // later durable fence reject this payload.
-        let rawFixtures = await fplClient.getFixtures(eventId);
-        if (!Array.isArray(rawFixtures)) {
-          throw new Error('Invalid fixtures data from FPL API');
-        }
-        logInfo('Raw fixtures data fetched', { count: rawFixtures.length, ...logContext });
-
-        let fixtures = transformFixtures(rawFixtures);
-        const eventScopedFixtureIds = new Set(fixtures.map((fixture) => fixture.id));
-        let recoveredFullFixtureFeed = false;
-        if (eventId) {
-          const persistedEventFixtures = await fixtureRepository.findByEvent(eventId);
-          const omittedFixtureIds = findOmittedEventFixtureIds(
-            eventId,
-            persistedEventFixtures,
-            eventScopedFixtureIds,
-          );
-          if (omittedFixtureIds.length > 0) {
-            const fullRawFixtures = await fplClient.getFixtures();
-            if (!Array.isArray(fullRawFixtures) || fullRawFixtures.length === 0) {
-              throw new Error(
-                `Full fixture recovery returned no data for event ${eventId}; omitted fixture IDs: ${omittedFixtureIds.join(', ')}`,
-              );
-            }
-            const fullFixtures = transformFixtures(fullRawFixtures);
-            const fullFixtureIds = new Set(fullFixtures.map((fixture) => fixture.id));
-            const unresolvedFixtureIds = omittedFixtureIds.filter(
-              (fixtureId) => !fullFixtureIds.has(fixtureId),
-            );
-            if (unresolvedFixtureIds.length > 0) {
-              throw new Error(
-                `Full fixture recovery could not resolve omitted fixture IDs for event ${eventId}: ${unresolvedFixtureIds.join(', ')}`,
-              );
-            }
-            rawFixtures = fullRawFixtures;
-            fixtures = fullFixtures;
-            recoveredFullFixtureFeed = true;
-            logWarn('Promoted event-scoped fixture sync to full-feed recovery', {
-              eventId,
-              omittedFixtureIds,
-              recoveredCount: fixtures.length,
-            });
-          }
-        }
-
-        const fixtureIds = fixtures.map((fixture) => fixture.id);
-        const existingEvents = await fixtureRepository.findEventIdsByFixtureIds(fixtureIds);
-        const transitions = resolveFixtureCacheTransitions(fixtures, existingEvents);
-        const unscheduledFixtures = fixtures.filter((fixture) => fixture.event === null);
-        const schedulableFixtures = fixtures.filter((fixture) => fixture.event !== null);
-        logInfo('Fixtures transformed', {
-          total: rawFixtures.length,
-          successful: fixtures.length,
-          errors: rawFixtures.length - fixtures.length,
-          recoveredFullFixtureFeed,
-          ...logContext,
-        });
-
-        return {
-          eventIds: resolveFixtureCacheLockEventIds(fixtures, transitions.invalidatedEventIds),
-          context: {
-            rawFixtures,
-            fixtures,
-            recoveredFullFixtureFeed,
-            unscheduledFixtures,
-            schedulableFixtures,
-            payloadSeason: deriveSeasonFromFixtures(rawFixtures) ?? undefined,
-            transitions,
-          },
-        };
-      },
-      async (context, checkedAt, lockedEventIds, activeSeason) => {
-        const {
-          rawFixtures,
-          fixtures,
-          recoveredFullFixtureFeed,
-          unscheduledFixtures,
-          schedulableFixtures,
-          payloadSeason,
-          transitions,
-        } = context;
-        if (rawFixtures.length === 0) {
-          logWarn('No fixtures returned from FPL API', logContext);
-          return { count: 0, errors: 0 };
-        }
-        if (unscheduledFixtures.length > 0) {
-          logWarn('Persisting only event ownership for unscheduled fixtures', {
-            unscheduledCount: unscheduledFixtures.length,
-            fixtureIds: unscheduledFixtures.map((fixture) => fixture.id),
-          });
-        }
-        if (payloadSeason && payloadSeason !== activeSeason) {
-          throw new Error(
-            `Fixture payload season ${payloadSeason} does not match fenced active season ${activeSeason}; sync events first`,
-          );
-        }
-
-        // Claim every affected event in one transaction. The callback runs only
-        // if all claims win; Redis retirement precedes the fixture mutation so
-        // a Redis failure still rolls back PostgreSQL ownership and checkpoints.
-        const durable = await withLiveSnapshotDurableEventsWriteFence(
-          lockedEventIds,
-          checkedAt,
-          async (tx) => {
-            if (transitions.invalidatedEventIds.size > 0) {
-              await Promise.all(
-                Array.from(transitions.invalidatedEventIds).map((invalidatedEventId) =>
-                  liveSnapshotCache.retire(invalidatedEventId),
-                ),
-              );
-              logInfo('Retired live snapshots before fixture identity changes', {
-                ...(eventId ? { eventId } : {}),
-                invalidatedEventIds: Array.from(transitions.invalidatedEventIds),
-              });
-            }
-            const repository = createFixtureRepository(tx);
-            let markedUnscheduled = 0;
-            if (unscheduledFixtures.length > 0) {
-              markedUnscheduled = await repository.markUnscheduled(
-                unscheduledFixtures.map((fixture) => fixture.id),
-              );
-              logInfo('Persisted unscheduled fixture ownership', {
-                requested: unscheduledFixtures.length,
-                updated: markedUnscheduled,
-              });
-            }
-            const savedFixtures = await repository.upsertBatch(schedulableFixtures);
-            return { savedFixtures, markedUnscheduled };
-          },
-        );
-        if (!durable.accepted || !durable.value) {
-          throw new Error(
-            `Fixture sync for ${eventId ? `event ${eventId}` : 'all events'} was superseded by live snapshot event ${durable.rejectedEventId ?? 'unknown'} at ${durable.winnerCheckedAt.toISOString()}; retry`,
-          );
-        }
-        const { savedFixtures, markedUnscheduled } = durable.value;
-        logInfo('Fixtures persisted to database', {
-          count: savedFixtures.length + markedUnscheduled,
-          scheduledCount: savedFixtures.length,
-          unscheduledCount: markedUnscheduled,
-          ...logContext,
-        });
-
-        let snapshotOwnedEventIds: ReadonlySet<number> = new Set();
-        if (eventId && !recoveredFullFixtureFeed) {
-          await fixturesCache.setByEvent(
-            eventId,
-            savedFixtures.filter((fixture) => fixture.event === eventId),
-            activeSeason,
-          );
-        } else {
-          snapshotOwnedEventIds = await fixturesCache.set(
-            [...savedFixtures, ...unscheduledFixtures],
-            activeSeason,
-          );
-        }
-
-        if (
-          eventId &&
-          !recoveredFullFixtureFeed &&
-          transitions.unscheduledFixtureIdsToRemove.size > 0
-        ) {
-          await fixturesCache.removeUnscheduledFixtureIds([
-            ...transitions.unscheduledFixtureIdsToRemove,
-          ]);
-        }
-
-        // FPL can correct any prior gameweek in the unfiltered daily feed.
-        // Reuse the ownership result from the atomic fixture-cache replacement,
-        // then reconcile only owned snapshots plus the current and explicitly
-        // requested compatibility events. This avoids both a second Redis
-        // round trip and 38 blind cache rebuilds while ensuring non-expiring
-        // metadata cannot hide a historical correction.
-        const fixturesByEvent = new Map<number, Fixture[]>();
-        for (const fixture of savedFixtures) {
-          if (fixture.event === null) continue;
-          const bucket = fixturesByEvent.get(fixture.event) ?? [];
-          bucket.push(fixture);
-          fixturesByEvent.set(fixture.event, bucket);
-        }
-        const representedEventIds = [...fixturesByEvent.keys()];
-        const currentEventId = (await getCurrentEvent())?.id;
-        const reconciliationEventIds = resolveFixtureDerivativeReconciliationEventIds(
-          representedEventIds,
-          [...snapshotOwnedEventIds],
-          [eventId, currentEventId],
-        );
-        await Promise.all(
-          reconciliationEventIds.map((reconciliationEventId) =>
-            syncFixtureDerivedSnapshotCache(
-              reconciliationEventId,
-              fixturesByEvent.get(reconciliationEventId)!,
-              liveSnapshotCache,
-            ),
-          ),
-        );
-        logInfo('Fixtures cache updated', logContext);
-
-        return {
-          count: savedFixtures.length + markedUnscheduled,
-          errors: rawFixtures.length - fixtures.length,
-        };
-      },
-    );
-
-    logInfo('Fixtures sync completed successfully', result);
-    return result;
-  } catch (error) {
-    logError('Fixtures sync failed', error, eventId ? { eventId } : {});
-    throw error;
-  }
+interface FixtureSyncOptions {
+  /** Retained for source compatibility; core publication derives and fences the season itself. */
+  publishedSeason?: string | null;
 }
 
-// Sync all fixtures for all gameweeks (1-38)
+/**
+ * Fixtures share identity and cache views with events and teams. A named or
+ * event-scoped legacy refresh therefore runs the same complete core publisher
+ * instead of maintaining a second partial-write protocol.
+ */
+export async function syncFixtures(
+  eventId?: number,
+  _options: FixtureSyncOptions = {},
+): Promise<{ count: number; errors: number }> {
+  logInfo('Routing fixture refresh through the coherent core snapshot', {
+    requestedEventId: eventId ?? null,
+  });
+  const result = await syncCoreSnapshot();
+  return { count: result.fixtures, errors: result.failedUnits };
+}
+
+/**
+ * Compatibility entry point for the retired 38-request backfill. One complete
+ * fixture feed is authoritative and the summary is derived from the committed
+ * database rows.
+ */
 export async function syncAllGameweeks(): Promise<{
   totalCount: number;
   totalErrors: number;
   perGameweek: Array<{ eventId: number; count: number; errors: number }>;
 }> {
-  try {
-    logInfo('Starting comprehensive fixtures sync for all gameweeks');
-
-    const results: Array<{ eventId: number; count: number; errors: number }> = [];
-    let totalCount = 0;
-    let totalErrors = 0;
-
-    // FPL has 38 gameweeks
-    for (let eventId = 1; eventId <= 38; eventId++) {
-      try {
-        logInfo(`Syncing gameweek ${eventId}/38`);
-
-        const result = await syncFixtures(eventId);
-        results.push({ eventId, count: result.count, errors: result.errors });
-
-        totalCount += result.count;
-        totalErrors += result.errors;
-
-        logInfo(`Gameweek ${eventId} synced`, {
-          count: result.count,
-          errors: result.errors,
-        });
-
-        // Small delay to avoid overwhelming the API
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      } catch (error) {
-        logError(`Failed to sync gameweek ${eventId}`, error);
-        results.push({ eventId, count: 0, errors: 1 });
-        totalErrors += 1;
-      }
+  const result = await syncCoreSnapshot();
+  const fixtures = await fixtureRepository.findAll();
+  const counts = new Map<number, number>();
+  for (const fixture of fixtures) {
+    if (fixture.event !== null) {
+      counts.set(fixture.event, (counts.get(fixture.event) ?? 0) + 1);
     }
-
-    // Final cache update with all fixtures. Keep it in the same mandatory lane
-    // as normal fixture syncs so a later sync cannot be overwritten by this
-    // backfill's trailing rebuild.
-    await withFixtureSyncSerialization(
-      async () => {
-        const allFixtures = await fixtureRepository.findAll();
-        return {
-          eventIds: resolveFixtureCacheLockEventIds(allFixtures, new Set()),
-          context: allFixtures,
-        };
-      },
-      async (allFixtures, _checkedAt, _lockedEventIds, activeSeason) => {
-        const payloadSeason = deriveSeasonFromFixtures(allFixtures);
-        if (payloadSeason && payloadSeason !== activeSeason) {
-          throw new Error(
-            `Fixture payload season ${payloadSeason} does not match fenced active season ${activeSeason}; sync events first`,
-          );
-        }
-        await fixturesCache.set(allFixtures, activeSeason);
-      },
-    );
-
-    logInfo('All gameweeks sync completed', {
-      totalCount,
-      totalErrors,
-      gameweeks: results.length,
-    });
-
-    return {
-      totalCount,
-      totalErrors,
-      perGameweek: results,
-    };
-  } catch (error) {
-    logError('All gameweeks sync failed', error);
-    throw error;
   }
+  return {
+    totalCount: result.fixtures,
+    totalErrors: result.failedUnits,
+    perGameweek: Array.from({ length: 38 }, (_, index) => ({
+      eventId: index + 1,
+      count: counts.get(index + 1) ?? 0,
+      errors: 0,
+    })),
+  };
 }
 
-// Compatibility service retained for callers outside BullMQ. Use the canonical
-// coordinated publisher so no direct fixture upsert can race the six live views.
+// Live publication remains owned by the separately managed Live pipeline.
 export async function syncLiveScores(eventId: number): Promise<{ updated: number }> {
   try {
     const snapshot = await syncLiveSnapshot(eventId, { persistEventLives: false });
@@ -356,7 +72,6 @@ export async function syncLiveScores(eventId: number): Promise<{ updated: number
   }
 }
 
-// Clear fixtures cache
 export async function clearFixturesCache(): Promise<void> {
   try {
     logInfo('Clearing fixtures cache');

--- a/src/services/job-trigger.service.ts
+++ b/src/services/job-trigger.service.ts
@@ -1,12 +1,8 @@
 import {
-  enqueueEventsSyncJob,
-  enqueueFixturesSyncJob,
-  enqueuePhasesSyncJob,
+  enqueueCoreSnapshotJob,
   enqueuePlayerPricesSyncJob,
-  enqueuePlayersSyncJob,
   enqueuePlayerStatsSyncJob,
   enqueuePlayerValuesSyncJob,
-  enqueueTeamsSyncJob,
 } from '../jobs/data-sync-enqueue';
 import {
   enqueueEntryInfoSyncJob,
@@ -77,8 +73,8 @@ export type JobTriggerResult =
 
 const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
   {
-    name: 'events-sync',
-    description: 'Sync events from FPL API',
+    name: 'core-snapshot-sync',
+    description: 'Atomically sync events, teams, players, phases, and fixtures',
     schedule: 'Daily at 06:35 UTC+8 (year-round discovery)',
   },
   {
@@ -86,21 +82,6 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
     description:
       'Recompute Redis event:current from Event hash; enqueue events-sync if gameweek id changes',
     schedule: 'Every minute (cron); POST here for immediate run (ignores season window)',
-  },
-  {
-    name: 'fixtures-sync',
-    description: 'Sync fixtures from FPL API',
-    schedule: 'Daily at 06:40 UTC+8 (year-round discovery)',
-  },
-  {
-    name: 'teams-sync',
-    description: 'Sync teams from FPL API',
-    schedule: 'Daily at 06:37 UTC+8 (year-round discovery)',
-  },
-  {
-    name: 'players-sync',
-    description: 'Sync players from FPL API',
-    schedule: 'Daily at 06:43 UTC+8 (year-round discovery)',
   },
   {
     name: 'player-prices',
@@ -111,11 +92,6 @@ const TRIGGERABLE_JOBS: TriggerableJobInfo[] = [
     name: 'player-stats-sync',
     description: 'Sync player stats from FPL API',
     schedule: 'Daily at 09:40 UTC+8 (current event or preseason next event)',
-  },
-  {
-    name: 'phases-sync',
-    description: 'Sync phases from FPL API',
-    schedule: 'Daily at 06:45 UTC+8 (year-round discovery)',
   },
   {
     name: 'player-values-sync',
@@ -271,16 +247,18 @@ function requirePlayerPricesChangeDate(input: unknown): string {
 function buildJobMap(input?: unknown): Record<string, () => Promise<unknown>> {
   return {
     'event-current-refresh': () => runManualEventCurrentRefresh(),
-    'events-sync': () => enqueueEventsSyncJob('manual'),
-    'fixtures-sync': () => enqueueFixturesSyncJob('manual'),
-    'teams-sync': () => enqueueTeamsSyncJob('manual'),
-    'players-sync': () => enqueuePlayersSyncJob('manual'),
+    'core-snapshot-sync': () => enqueueCoreSnapshotJob('manual'),
+    // Backward-compatible manual aliases; each queues the same complete snapshot.
+    'events-sync': () => enqueueCoreSnapshotJob('manual'),
+    'fixtures-sync': () => enqueueCoreSnapshotJob('manual'),
+    'teams-sync': () => enqueueCoreSnapshotJob('manual'),
+    'players-sync': () => enqueueCoreSnapshotJob('manual'),
     'player-prices': () =>
       enqueuePlayerPricesSyncJob('manual', {
         changeDate: requirePlayerPricesChangeDate(input),
       }),
     'player-stats-sync': () => enqueuePlayerStatsSyncJob('manual'),
-    'phases-sync': () => enqueuePhasesSyncJob('manual'),
+    'phases-sync': () => enqueueCoreSnapshotJob('manual'),
     'player-values-sync': () => enqueuePlayerValuesSyncJob('manual'),
     'entry-info-daily': () => enqueueEntryInfoSyncJob('manual'),
     'entry-event-picks-daily': async () => {

--- a/src/services/live-snapshot.service.ts
+++ b/src/services/live-snapshot.service.ts
@@ -245,14 +245,6 @@ export async function persistLiveSnapshotDurably({
   if (finalizeEvent && !persistEventLives) {
     throw new Error('A final live snapshot requires durable event-live persistence');
   }
-  if (!persistFixtures && !persistEventLives) {
-    return {
-      accepted: true,
-      winnerCheckedAt: checkedAt,
-      persistedFixtures: false,
-      persistedEventLives: false,
-    };
-  }
 
   const fenced = await withLiveSnapshotDurableWriteFence(eventId, checkedAt, async (tx) => {
     if (persistFixtures) {

--- a/src/services/phases.service.ts
+++ b/src/services/phases.service.ts
@@ -1,9 +1,5 @@
 import { phasesCache } from '../cache/operations';
-import { fplClient } from '../clients/fpl';
-import { phaseRepository } from '../repositories/phases';
-import { transformPhases } from '../transformers/phases';
-import { logError, logInfo } from '../utils/logger';
-import { resolvePublishedSeasonFromEvents } from './cache-season.service';
+import { syncCoreSnapshot } from './core-snapshot.service';
 
 /**
  * Phases Service - Business Logic Layer
@@ -20,48 +16,6 @@ export async function clearPhasesCache(): Promise<void> {
 
 // Sync phases from FPL API
 export async function syncPhases(): Promise<{ count: number; errors: number }> {
-  try {
-    logInfo('Starting phases sync from FPL API');
-
-    // 1. Fetch from FPL API
-    const bootstrapData = await fplClient.getBootstrap();
-
-    if (!bootstrapData.phases || !Array.isArray(bootstrapData.phases)) {
-      throw new Error('Invalid phases data from FPL API');
-    }
-
-    logInfo('FPL bootstrap data fetched', { phaseCount: bootstrapData.phases.length });
-
-    if (bootstrapData.phases.length === 0) {
-      logInfo('No phases returned from FPL API; preserving existing phases cache');
-      return { count: 0, errors: 0 };
-    }
-
-    // 2. Transform to domain phases
-    const phases = transformPhases(bootstrapData.phases);
-    logInfo('Phases transformed', {
-      total: bootstrapData.phases.length,
-      successful: phases.length,
-      errors: bootstrapData.phases.length - phases.length,
-    });
-
-    // 3. Save to database (batch upsert)
-    const savedPhases = await phaseRepository.upsertBatch(phases);
-    logInfo('Phases saved to database', { count: savedPhases.length });
-
-    // 4. Update cache
-    await phasesCache.set(phases, await resolvePublishedSeasonFromEvents(bootstrapData.events));
-    logInfo('Phases cache updated');
-
-    const result = {
-      count: savedPhases.length,
-      errors: bootstrapData.phases.length - phases.length,
-    };
-
-    logInfo('Phases sync completed successfully', result);
-    return result;
-  } catch (error) {
-    logError('Phases sync failed', error);
-    throw error;
-  }
+  const result = await syncCoreSnapshot();
+  return { count: result.phases, errors: result.failedUnits };
 }

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -81,6 +81,7 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
       currentChangedIds,
       fromChangeDate,
       beforeChangeDate,
+      sourceCheckedAt,
     );
     const latestById = new Map(latestRows.map((row) => [row.elementId, row]));
     const missingLatest = currentChangedIds.filter((elementId) => !latestById.has(elementId));

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -94,12 +94,18 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
     }));
     const updatedPlayers = await dependencies.updatePrices(priceUpdates, sourceCheckedAt);
     const updatedIds = new Set(updatedPlayers.map((player) => player.id));
-    const missingPlayers = currentChangedIds.filter((elementId) => !updatedIds.has(elementId));
-    if (missingPlayers.length > 0) {
-      throw new Error(`Player rows missing for price update: ${missingPlayers.join(', ')}`);
+    const winningPriceUpdates = priceUpdates.filter((update) => updatedIds.has(update.elementId));
+    const skippedIds = currentChangedIds.filter((elementId) => !updatedIds.has(elementId));
+    if (skippedIds.length > 0) {
+      logInfo('Skipped stale player price updates', {
+        changeDate,
+        count: skippedIds.length,
+      });
     }
 
-    await dependencies.mergePlayerPricesCache(priceUpdates, publishedPlayerIds);
+    if (winningPriceUpdates.length > 0) {
+      await dependencies.mergePlayerPricesCache(winningPriceUpdates, publishedPlayerIds);
+    }
     logInfo('Player prices updated in database and cache', {
       changeDate,
       count: updatedPlayers.length,

--- a/src/services/player-prices.service.ts
+++ b/src/services/player-prices.service.ts
@@ -5,6 +5,7 @@ import { playerRepository } from '../repositories/players';
 import { transformPlayers } from '../transformers/players';
 import { logInfo } from '../utils/logger';
 import { getPlayerValueSeasonBounds } from '../utils/player-value-season';
+import { readCoreSnapshotOrderingTimestamp } from './core-snapshot-persistence.service';
 
 export type PlayerPricesSyncDependencies = {
   findByChangeDate: typeof playerValuesRepository.findByChangeDate;
@@ -12,6 +13,7 @@ export type PlayerPricesSyncDependencies = {
   getBootstrap: typeof fplClient.getBootstrap;
   updatePrices: typeof playerRepository.updatePrices;
   mergePlayerPricesCache: typeof playersCache.mergePrices;
+  readOrderingTimestamp: typeof readCoreSnapshotOrderingTimestamp;
 };
 
 const defaultDependencies: PlayerPricesSyncDependencies = {
@@ -20,6 +22,7 @@ const defaultDependencies: PlayerPricesSyncDependencies = {
   getBootstrap: () => fplClient.getBootstrap(),
   updatePrices: playerRepository.updatePrices,
   mergePlayerPricesCache: playersCache.mergePrices,
+  readOrderingTimestamp: readCoreSnapshotOrderingTimestamp,
 };
 
 export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencies) {
@@ -43,6 +46,10 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
       logInfo('No player price changes to apply', { changeDate });
       return { count: 0, changeDate };
     }
+
+    // Use PostgreSQL time captured before price source reads so this evidence
+    // is directly comparable with a core snapshot's pre-fetch ordering marker.
+    const sourceCheckedAt = await dependencies.readOrderingTimestamp();
 
     const bootstrap = await dependencies.getBootstrap();
     if (!Array.isArray(bootstrap.elements) || bootstrap.elements.length === 0) {
@@ -85,7 +92,7 @@ export function createPlayerPricesSync(dependencies: PlayerPricesSyncDependencie
       elementId,
       value: latestById.get(elementId)!.value,
     }));
-    const updatedPlayers = await dependencies.updatePrices(priceUpdates);
+    const updatedPlayers = await dependencies.updatePrices(priceUpdates, sourceCheckedAt);
     const updatedIds = new Set(updatedPlayers.map((player) => player.id));
     const missingPlayers = currentChangedIds.filter((elementId) => !updatedIds.has(elementId));
     if (missingPlayers.length > 0) {

--- a/src/services/players.service.ts
+++ b/src/services/players.service.ts
@@ -1,136 +1,20 @@
-import { playersCache } from '../cache/operations';
-import { fplClient } from '../clients/fpl';
-import { playerRepository } from '../repositories/players';
-import { transformPlayersStrict } from '../transformers/players';
-import { logError, logInfo } from '../utils/logger';
-import { resolvePublishedSeasonFromEvents } from './cache-season.service';
-
-import type { FPLBootstrapResponse } from '../clients/fpl';
-import type { Player } from '../types';
-
-/**
- * Players Service - Business Logic Layer
- *
- * Handles all player-related operations:
- * - Data synchronization from FPL API
- * - Database operations
- */
-
-type PlayersBootstrap = Pick<FPLBootstrapResponse, 'elements' | 'events'>;
+import { syncCoreSnapshot, type CoreSnapshotSyncResult } from './core-snapshot.service';
 
 export type PlayersSyncDependencies = {
-  getBootstrap: () => Promise<PlayersBootstrap>;
-  upsertPlayers: (players: Player[]) => Promise<Player[]>;
-  setPlayersCache: (players: Player[], season?: string) => Promise<void>;
-  resolvePublishedSeason: (events: FPLBootstrapResponse['events']) => Promise<string | undefined>;
+  syncCore: () => Promise<CoreSnapshotSyncResult>;
 };
 
-const defaultDependencies: PlayersSyncDependencies = {
-  getBootstrap: () => fplClient.getBootstrap(),
-  upsertPlayers: playerRepository.upsertBatch,
-  setPlayersCache: playersCache.set,
-  resolvePublishedSeason: resolvePublishedSeasonFromEvents,
-};
-
-function assertUniquePlayerIds(players: readonly Player[], source: string): void {
-  const ids = new Set<number>();
-  for (const player of players) {
-    if (ids.has(player.id)) {
-      throw new Error(`${source} contains duplicate player ID ${player.id}`);
-    }
-    ids.add(player.id);
-  }
-}
-
-function assertPersistedRosterMatches(
-  expected: readonly Player[],
-  persisted: readonly Player[],
-): void {
-  assertUniquePlayerIds(expected, 'Transformed player roster');
-  assertUniquePlayerIds(persisted, 'Persisted player roster');
-
-  const persistedById = new Map(persisted.map((player) => [player.id, player]));
-  const fields = [
-    'code',
-    'type',
-    'teamId',
-    'price',
-    'startPrice',
-    'firstName',
-    'secondName',
-    'webName',
-  ] as const satisfies readonly (keyof Player)[];
-
-  if (persistedById.size !== expected.length) {
-    throw new Error(
-      `Player persistence returned an incomplete roster: ${persistedById.size}/${expected.length}`,
-    );
-  }
-
-  for (const player of expected) {
-    const persistedPlayer = persistedById.get(player.id);
-    if (!persistedPlayer || fields.some((field) => persistedPlayer[field] !== player[field])) {
-      throw new Error(`Player persistence verification failed for player ${player.id}`);
-    }
-  }
-}
-
+/**
+ * Player identity is part of the coherent non-Live core snapshot. Keeping this
+ * compatibility entry point mapped to that publisher prevents a legacy player
+ * refresh from racing or partially overwriting events, teams, phases, or
+ * fixtures fetched from the same FPL bootstrap.
+ */
 export function createPlayersSync(dependencies: PlayersSyncDependencies) {
   return async function syncPlayers(): Promise<{ count: number; errors: number }> {
-    try {
-      logInfo('Starting players sync from FPL API');
-
-      // 1. Fetch data from FPL API
-      const fplData = await dependencies.getBootstrap();
-
-      if (!fplData.elements || !Array.isArray(fplData.elements)) {
-        throw new Error('Invalid players data from FPL API');
-      }
-
-      logInfo('Raw players data fetched', { count: fplData.elements.length });
-
-      if (fplData.elements.length === 0) {
-        logInfo('No players returned from FPL API; preserving existing players cache');
-        return { count: 0, errors: 0 };
-      }
-
-      // 2. Transform the complete roster. A single invalid or duplicate element
-      // must preserve the previously published identity baseline.
-      const transformedPlayers = transformPlayersStrict(fplData.elements);
-      assertUniquePlayerIds(transformedPlayers, 'FPL player roster');
-      logInfo('Players transformed', {
-        total: fplData.elements.length,
-        successful: transformedPlayers.length,
-        errors: 0,
-      });
-
-      // 3. Batch upsert to database and verify every row before publication.
-      const upsertedPlayers = await dependencies.upsertPlayers(transformedPlayers);
-      assertPersistedRosterMatches(transformedPlayers, upsertedPlayers);
-      logInfo('Players upserted to database', { count: upsertedPlayers.length });
-
-      // 4. Atomically replace the shared Redis roster only after database
-      // verification succeeds. Live snapshot workers read this shared truth on
-      // every producer cycle, so no process-local invalidation is required.
-      await dependencies.setPlayersCache(
-        upsertedPlayers,
-        await dependencies.resolvePublishedSeason(fplData.events),
-      );
-      logInfo('Players cache updated');
-
-      const result = {
-        count: upsertedPlayers.length,
-        errors: 0,
-      };
-
-      logInfo('Players sync completed', result);
-      return result;
-    } catch (error) {
-      logError('Players sync failed', error);
-      throw error;
-    }
+    const result = await dependencies.syncCore();
+    return { count: result.players, errors: result.failedUnits };
   };
 }
 
-// Sync players from FPL API
-export const syncPlayers = createPlayersSync(defaultDependencies);
+export const syncPlayers = createPlayersSync({ syncCore: syncCoreSnapshot });

--- a/src/services/teams.service.ts
+++ b/src/services/teams.service.ts
@@ -1,9 +1,4 @@
-import { teamsCache } from '../cache/operations';
-import { fplClient } from '../clients/fpl';
-import { teamRepository } from '../repositories/teams';
-import { transformTeams } from '../transformers/teams';
-import { logError, logInfo } from '../utils/logger';
-import { resolvePublishedSeasonFromEvents } from './cache-season.service';
+import { syncCoreSnapshot } from './core-snapshot.service';
 
 /**
  * Teams Service - Business Logic Layer
@@ -15,48 +10,6 @@ import { resolvePublishedSeasonFromEvents } from './cache-season.service';
 
 // Sync teams from FPL API
 export async function syncTeams(): Promise<{ count: number; errors: number }> {
-  try {
-    logInfo('Starting teams sync from FPL API');
-
-    // 1. Fetch from FPL API
-    const bootstrapData = await fplClient.getBootstrap();
-
-    if (!bootstrapData.teams || !Array.isArray(bootstrapData.teams)) {
-      throw new Error('Invalid teams data from FPL API');
-    }
-
-    logInfo('FPL bootstrap data fetched', { teamCount: bootstrapData.teams.length });
-
-    if (bootstrapData.teams.length === 0) {
-      logInfo('No teams returned from FPL API; preserving existing teams cache');
-      return { count: 0, errors: 0 };
-    }
-
-    // 2. Transform to domain teams
-    const teams = transformTeams(bootstrapData.teams);
-    logInfo('Teams transformed', {
-      total: bootstrapData.teams.length,
-      successful: teams.length,
-      errors: bootstrapData.teams.length - teams.length,
-    });
-
-    // 3. Save to database (batch upsert)
-    const savedTeams = await teamRepository.upsertBatch(teams);
-    logInfo('Teams saved to database', { count: savedTeams.length });
-
-    // 4. Update cache
-    await teamsCache.set(teams, await resolvePublishedSeasonFromEvents(bootstrapData.events));
-    logInfo('Teams cache updated');
-
-    const result = {
-      count: savedTeams.length,
-      errors: bootstrapData.teams.length - teams.length,
-    };
-
-    logInfo('Teams sync completed successfully', result);
-    return result;
-  } catch (error) {
-    logError('Teams sync failed', error);
-    throw error;
-  }
+  const result = await syncCoreSnapshot();
+  return { count: result.teams, errors: result.failedUnits };
 }

--- a/src/workers/data-sync.worker.ts
+++ b/src/workers/data-sync.worker.ts
@@ -7,20 +7,16 @@ import {
   getDataSyncQueueName,
   isDataSyncTieredQueueEnabled,
 } from '../queues/data-sync.queue';
-import { syncEvents } from '../services/events.service';
-import { syncAllGameweeks, syncFixtures } from '../services/fixtures.service';
-import { syncPhases } from '../services/phases.service';
-import { syncPlayers } from '../services/players.service';
 import { syncPlayerPricesForDate } from '../services/player-prices.service';
 import { syncCurrentPlayerStats, syncPlayerStatsForEvent } from '../services/player-stats.service';
 import { syncCurrentPlayerValues } from '../services/player-values.service';
+import { syncCoreSnapshot } from '../services/core-snapshot.service';
 import {
   resolveBullMqAttemptQueueWaitMs,
   runDataSyncAttempt,
   type DataSyncAttemptContext,
 } from '../utils/data-sync-attempt';
 import { logJobTriggered, runTrackedJob } from '../utils/job-run-logger';
-import { syncTeams } from '../services/teams.service';
 import { getQueueConnection } from '../utils/queue';
 import { logError, logInfo } from '../utils/logger';
 import { alertOnFinalFailure } from '../utils/notify';
@@ -28,6 +24,16 @@ import { withMutationConflictGuard } from '../utils/mutation-lock';
 import { formatCronDateKey } from '../utils/timezone';
 import { startStrictPriorityGate } from './strict-priority-gate';
 import type { WorkerRuntime } from './worker-runtime';
+
+const CORE_SNAPSHOT_JOB_NAMES = new Set([
+  'core-snapshot',
+  'events',
+  'fixtures',
+  'fixtures-all-gameweeks',
+  'teams',
+  'players',
+  'phases',
+]);
 
 const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
   const context = {
@@ -54,49 +60,49 @@ const processDataSyncJob = async (job: Job<DataSyncJobData>) => {
 
   logJobTriggered(context);
 
-  return runDataSyncAttempt(attemptContext, () =>
-    withMutationConflictGuard(
+  return runDataSyncAttempt(attemptContext, () => {
+    const execute = () =>
+      runTrackedJob(context, async () => {
+        switch (job.name) {
+          case 'core-snapshot':
+          case 'events':
+          case 'fixtures':
+          case 'fixtures-all-gameweeks':
+          case 'teams':
+          case 'players':
+          case 'phases':
+            return syncCoreSnapshot();
+          case 'player-prices':
+            if (!job.data.changeDate) {
+              throw new Error('player-prices job requires changeDate');
+            }
+            return syncPlayerPricesForDate(job.data.changeDate);
+          case 'player-stats':
+            return job.data.eventId !== undefined
+              ? syncPlayerStatsForEvent(job.data.eventId)
+              : syncCurrentPlayerStats({ onTargetEventResolved: recordResolvedTarget });
+          case 'player-values':
+            return syncCurrentPlayerValues(
+              job.data.changeDate ?? formatCronDateKey(new Date(job.data.triggeredAt)),
+              { onTargetEventResolved: recordResolvedTarget },
+            );
+          default:
+            throw new Error(`Unknown data-sync job: ${job.name}`);
+        }
+      });
+
+    // Core aliases perform upstream reads before acquiring their own short
+    // multi-table persistence/publication lock.
+    if (CORE_SNAPSHOT_JOB_NAMES.has(job.name)) return execute();
+    return withMutationConflictGuard(
       {
         queueName: job.queueName,
         jobName: job.name,
         jobId: String(job.id),
       },
-      () =>
-        runTrackedJob(context, async () => {
-          switch (job.name) {
-            case 'events':
-              return syncEvents();
-            case 'fixtures':
-              return syncFixtures(job.data.eventId);
-            case 'fixtures-all-gameweeks':
-              // Per-GW loop with isolated errors — not the same as syncFixtures(undefined).
-              return syncAllGameweeks();
-            case 'teams':
-              return syncTeams();
-            case 'players':
-              return syncPlayers();
-            case 'player-prices':
-              if (!job.data.changeDate) {
-                throw new Error('player-prices job requires changeDate');
-              }
-              return syncPlayerPricesForDate(job.data.changeDate);
-            case 'player-stats':
-              return job.data.eventId !== undefined
-                ? syncPlayerStatsForEvent(job.data.eventId)
-                : syncCurrentPlayerStats({ onTargetEventResolved: recordResolvedTarget });
-            case 'phases':
-              return syncPhases();
-            case 'player-values':
-              return syncCurrentPlayerValues(
-                job.data.changeDate ?? formatCronDateKey(new Date(job.data.triggeredAt)),
-                { onTargetEventResolved: recordResolvedTarget },
-              );
-            default:
-              throw new Error(`Unknown data-sync job: ${job.name}`);
-          }
-        }),
-    ),
-  );
+      execute,
+    );
+  });
 };
 
 export function createDataSyncWorker(): WorkerRuntime {

--- a/tests/fixtures/core-snapshot.fixtures.ts
+++ b/tests/fixtures/core-snapshot.fixtures.ts
@@ -1,0 +1,129 @@
+import { singleRawEventFixture } from './events.fixtures';
+import { rawFPLElementsFixture } from './player-stats.fixtures';
+import { singleRawTeamFixture } from './teams.fixtures';
+
+import type {
+  FPLBootstrapResponse,
+  RawFPLEvent,
+  RawFPLFixture,
+  RawFPLPhase,
+  RawFPLTeam,
+} from '../../src/types';
+
+function buildEvents(): RawFPLEvent[] {
+  const firstDeadline = Date.parse('2026-08-14T17:30:00.000Z');
+  return Array.from({ length: 38 }, (_, index) => {
+    const deadline = new Date(firstDeadline + index * 7 * 24 * 60 * 60_000);
+    return {
+      ...singleRawEventFixture,
+      id: index + 1,
+      name: `Gameweek ${index + 1}`,
+      deadline_time: deadline.toISOString(),
+      deadline_time_epoch: Math.floor(deadline.getTime() / 1000),
+      is_previous: false,
+      is_current: false,
+      is_next: index === 0,
+      finished: false,
+      data_checked: false,
+    };
+  });
+}
+
+function buildTeams(): RawFPLTeam[] {
+  return Array.from({ length: 20 }, (_, index) => ({
+    ...singleRawTeamFixture,
+    id: index + 1,
+    code: 10_000 + index,
+    name: `Team ${index + 1}`,
+    short_name: `T${String(index + 1).padStart(2, '0')}`,
+    position: index + 1,
+    pulse_id: 20_000 + index,
+  }));
+}
+
+function firstHalfPairings(): Array<Array<[number, number]>> {
+  const rotating = Array.from({ length: 20 }, (_, index) => index + 1);
+  const rounds: Array<Array<[number, number]>> = [];
+
+  for (let round = 0; round < 19; round += 1) {
+    const pairings: Array<[number, number]> = [];
+    for (let index = 0; index < 10; index += 1) {
+      pairings.push([rotating[index], rotating[19 - index]]);
+    }
+    rounds.push(pairings);
+    rotating.splice(1, 0, rotating.pop()!);
+  }
+  return rounds;
+}
+
+function buildFixtures(): RawFPLFixture[] {
+  const firstHalf = firstHalfPairings();
+  const rounds = [
+    ...firstHalf,
+    ...firstHalf.map((round) => round.map(([home, away]) => [away, home] as [number, number])),
+  ];
+  let fixtureId = 1;
+
+  return rounds.flatMap((round, roundIndex) =>
+    round.map(([teamH, teamA]) => {
+      const id = fixtureId;
+      fixtureId += 1;
+      return {
+        code: 30_000 + id,
+        event: roundIndex + 1,
+        finished: false,
+        finished_provisional: false,
+        id,
+        kickoff_time: new Date(
+          Date.parse('2026-08-15T14:00:00.000Z') + roundIndex * 7 * 24 * 60 * 60_000,
+        ).toISOString(),
+        minutes: 0,
+        provisional_start_time: false,
+        started: false,
+        team_a: teamA,
+        team_a_score: null,
+        team_h: teamH,
+        team_h_score: null,
+        stats: [],
+        team_h_difficulty: 3,
+        team_a_difficulty: 3,
+        pulse_id: 40_000 + id,
+      };
+    }),
+  );
+}
+
+export function buildCoreSnapshotFixture(options?: { playerCount?: number }): {
+  bootstrap: FPLBootstrapResponse;
+  fixtures: RawFPLFixture[];
+} {
+  const playerCount = options?.playerCount ?? 220;
+  const players = Array.from({ length: playerCount }, (_, index) => {
+    const base = rawFPLElementsFixture[index % rawFPLElementsFixture.length];
+    return {
+      ...base,
+      id: index + 1,
+      code: 50_000 + index,
+      element_type: (index % 4) + 1,
+      team: (index % 20) + 1,
+      web_name: `Player ${index + 1}`,
+    };
+  });
+  const phases: RawFPLPhase[] = [
+    { id: 1, name: 'Overall', start_event: 1, stop_event: 38, highest_score: null },
+  ];
+
+  return {
+    bootstrap: {
+      events: buildEvents(),
+      teams: buildTeams(),
+      elements: players,
+      phases,
+      total_players: 1,
+      game_settings: {},
+      element_stats: [],
+      element_types: [],
+    },
+    fixtures: buildFixtures(),
+  };
+}

--- a/tests/integration/core-snapshot-atomicity.test.ts
+++ b/tests/integration/core-snapshot-atomicity.test.ts
@@ -8,6 +8,7 @@ import { eq, sql } from 'drizzle-orm';
 import {
   buildCoreSnapshotCachePlan,
   CORE_SNAPSHOT_PENDING_PUBLICATION_KEY,
+  CORE_SNAPSHOT_STAGING_TTL_MS,
   finalizeCoreSnapshotCachePublication,
   publishCoreSnapshotCache,
   readPendingCoreSnapshotCachePublication,
@@ -154,6 +155,38 @@ describeAtomicity('core snapshot atomicity', () => {
     expect(await redis.keys(`Fixtures:${snapshot.season}:*`)).toHaveLength(38);
     expect(await redis.keys(`FixturesByTeam:${snapshot.season}:*`)).toHaveLength(20);
     expect(await redis.exists('EntryInfo:2526:sentinel')).toBe(0);
+  });
+
+  test('persists published hashes and excludes Live staging keys from backups', async () => {
+    const redis = await redisSingleton.getClient();
+    const liveStagingKey = `Fixtures:${snapshot.season}:1:staging:${randomUUID()}`;
+    let publication: Awaited<ReturnType<typeof publishCoreSnapshotCache>> | undefined;
+
+    await redis.hset(liveStagingKey, 'sentinel', 'live-staging-view');
+    await redis.pexpire(liveStagingKey, CORE_SNAPSHOT_STAGING_TTL_MS);
+
+    try {
+      publication = await publishCoreSnapshotCache(snapshot, {
+        publicationId: randomUUID(),
+        redis,
+      });
+      expect(publication.published).toBe(true);
+      if (!publication.receipt) throw new Error('Core publication receipt is missing');
+
+      for (const key of publication.receipt.finalKeys) {
+        expect(await redis.pttl(key)).toBe(-1);
+      }
+      expect(publication.receipt.backups.some((backup) => backup.key === liveStagingKey)).toBe(
+        false,
+      );
+      expect(await redis.hgetall(liveStagingKey)).toEqual({ sentinel: 'live-staging-view' });
+      expect(await redis.pttl(liveStagingKey)).toBeGreaterThan(0);
+
+      await finalizeCoreSnapshotCachePublication(publication.receipt, redis);
+    } finally {
+      const finalKeys = publication?.receipt?.finalKeys ?? [];
+      await redis.del(liveStagingKey, ...finalKeys, 'event:current');
+    }
   });
 
   test('preserves fixture hashes owned by a published Live snapshot', async () => {
@@ -308,6 +341,58 @@ describeAtomicity('core snapshot atomicity', () => {
     };
 
     await persistCoreSnapshot(snapshot);
+
+    try {
+      await persistCoreSnapshotWithFinalizer(replacementSnapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        finalize: async () => ({ published: true }),
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(
+        await db
+          .select({ id: eventFixtures.id })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, originalFixture.id)),
+      ).toEqual([]);
+      expect(
+        await db
+          .select({ eventId: eventFixtures.eventId })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, replacementFixtureId)),
+      ).toEqual([{ eventId: originalFixture.event }]);
+    } finally {
+      await db.delete(eventFixtures).where(eq(eventFixtures.id, replacementFixtureId));
+      await persistCoreSnapshot(snapshot);
+    }
+  });
+
+  test('retires an omitted unscheduled fixture before inserting a code replacement', async () => {
+    const db = await getDb();
+    const originalFixture = snapshot.fixtures.find((fixture) => fixture.event !== null)!;
+    const replacementFixtureId = 999_997;
+    const replacementFixture = {
+      ...originalFixture,
+      id: replacementFixtureId,
+      code: originalFixture.code,
+      pulseId: replacementFixtureId,
+    };
+    const replacementSnapshot: CoreSnapshot = {
+      ...snapshot,
+      fixtures: [
+        ...snapshot.fixtures.filter((fixture) => fixture.id !== originalFixture.id),
+        replacementFixture,
+      ],
+    };
+
+    await persistCoreSnapshot(snapshot);
+    await db
+      .update(eventFixtures)
+      .set({ eventId: null })
+      .where(eq(eventFixtures.id, originalFixture.id));
 
     try {
       await persistCoreSnapshotWithFinalizer(replacementSnapshot, {

--- a/tests/integration/core-snapshot-atomicity.test.ts
+++ b/tests/integration/core-snapshot-atomicity.test.ts
@@ -1,0 +1,1118 @@
+import { assertIntegrationEnv } from './helpers/env-guard';
+
+assertIntegrationEnv();
+import { randomUUID } from 'node:crypto';
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { eq, sql } from 'drizzle-orm';
+
+import {
+  buildCoreSnapshotCachePlan,
+  CORE_SNAPSHOT_PENDING_PUBLICATION_KEY,
+  finalizeCoreSnapshotCachePublication,
+  publishCoreSnapshotCache,
+  readPendingCoreSnapshotCachePublication,
+  rollbackCoreSnapshotCachePublication,
+} from '../../src/cache/core-snapshot-cache';
+import { clearStaleSeasonCache, resetActiveSeasonMemo } from '../../src/cache/cache-season';
+import { redisSingleton } from '../../src/cache/singleton';
+import { eventFixtures, events, players } from '../../src/db/schemas/index.schema';
+import { getDb, type DbHandle } from '../../src/db/singleton';
+import { prepareCoreSnapshot, type CoreSnapshot } from '../../src/domain/core-snapshot';
+import { allocateCoreSnapshotRevision } from '../../src/repositories/core-snapshot-authority';
+import { createFixtureRepository } from '../../src/repositories/fixtures';
+import { createPlayerRepository } from '../../src/repositories/players';
+import {
+  persistCoreSnapshot,
+  persistCoreSnapshotWithFinalizer,
+  readCoreSnapshotOrderingTimestamp,
+} from '../../src/services/core-snapshot-persistence.service';
+import {
+  commitCoreSnapshotPublication,
+  recoverPendingCoreSnapshotPublication,
+} from '../../src/services/core-snapshot-publication.service';
+import {
+  syncCoreSnapshot,
+  type CoreSnapshotMilestone,
+} from '../../src/services/core-snapshot.service';
+import { buildCoreSnapshotFixture } from '../fixtures/core-snapshot.fixtures';
+
+const describeAtomicity =
+  process.env.RUN_CORE_SNAPSHOT_INTEGRATION === '1' ? describe : describe.skip;
+
+describeAtomicity('core snapshot atomicity', () => {
+  let snapshot: CoreSnapshot;
+
+  beforeAll(() => {
+    const input = buildCoreSnapshotFixture({ playerCount: 600 });
+    snapshot = prepareCoreSnapshot(input.bootstrap, input.fixtures);
+  });
+
+  beforeEach(async () => {
+    const redis = await redisSingleton.getClient();
+    const transientKeys = await redis.keys('CoreSnapshot*');
+    if (transientKeys.length > 0) await redis.del(...transientKeys);
+    await redis.set('Season:active', snapshot.season);
+    resetActiveSeasonMemo();
+  });
+
+  test('keeps the published cache view unchanged when staging fails', async () => {
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', snapshot.season);
+    await redis.del(`Event:${snapshot.season}`);
+    await redis.hset(`Event:${snapshot.season}`, 'sentinel', 'old-view');
+    resetActiveSeasonMemo();
+
+    await expect(
+      publishCoreSnapshotCache(snapshot, {
+        redis,
+        publicationId: randomUUID(),
+        afterStage: async () => {
+          const stagingKeys = await redis.keys(`CoreSnapshotStage:${snapshot.season}:*`);
+          expect(stagingKeys.length).toBeGreaterThan(0);
+          for (const key of stagingKeys) expect(await redis.pttl(key)).toBeGreaterThan(0);
+          throw new Error('injected staging failure');
+        },
+      }),
+    ).rejects.toThrow('injected staging failure');
+
+    expect(await redis.get('Season:active')).toBe(snapshot.season);
+    expect(await redis.hgetall(`Event:${snapshot.season}`)).toEqual({ sentinel: 'old-view' });
+    expect(await redis.keys(`CoreSnapshotStage:${snapshot.season}:*`)).toEqual([]);
+  });
+
+  test('checks every staged hash atomically before replacing any published key', async () => {
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', snapshot.season);
+    await redis.del(`Event:${snapshot.season}`);
+    await redis.hset(`Event:${snapshot.season}`, 'sentinel', 'old-view');
+
+    await expect(
+      publishCoreSnapshotCache(snapshot, {
+        redis,
+        publicationId: randomUUID(),
+        afterStage: async () => {
+          const stagingKeys = await redis.keys(`CoreSnapshotStage:${snapshot.season}:*`);
+          expect(stagingKeys.length).toBeGreaterThan(1);
+          await redis.del(stagingKeys[0]);
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'CORE_SNAPSHOT_PUBLICATION_FAILED' });
+
+    expect(await redis.get('Season:active')).toBe(snapshot.season);
+    expect(await redis.hgetall(`Event:${snapshot.season}`)).toEqual({ sentinel: 'old-view' });
+    expect(await redis.exists(CORE_SNAPSHOT_PENDING_PUBLICATION_KEY)).toBe(0);
+  });
+
+  test('declines publication when the active-season authority is malformed', async () => {
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', 'bad-season');
+
+    await expect(
+      publishCoreSnapshotCache(snapshot, { publicationId: randomUUID(), redis }),
+    ).rejects.toMatchObject({ code: 'CORE_SNAPSHOT_ACTIVE_SEASON_INVALID' });
+    expect(await redis.keys(`CoreSnapshotStage:${snapshot.season}:*`)).toEqual([]);
+    expect(await redis.exists(CORE_SNAPSHOT_PENDING_PUBLICATION_KEY)).toBe(0);
+  });
+
+  test('publishes all core cache families together after persistence', async () => {
+    const input = buildCoreSnapshotFixture({ playerCount: 600 });
+    let bootstrapCalls = 0;
+    let fixtureCalls = 0;
+    const milestones: CoreSnapshotMilestone[] = [];
+
+    const redis = await redisSingleton.getClient();
+    await redis.set('EntryInfo:2526:sentinel', 'stale');
+
+    const result = await syncCoreSnapshot({
+      getBootstrap: async () => {
+        bootstrapCalls += 1;
+        return input.bootstrap;
+      },
+      getFixtures: async () => {
+        fixtureCalls += 1;
+        return input.fixtures;
+      },
+      getActiveSeason: async () => snapshot.season,
+      readOrderingTimestamp: readCoreSnapshotOrderingTimestamp,
+      reserveRevision: allocateCoreSnapshotRevision,
+      createPublicationId: randomUUID,
+      recoverPending: recoverPendingCoreSnapshotPublication,
+      commit: commitCoreSnapshotPublication,
+      cleanup: clearStaleSeasonCache,
+      withPersistenceLock: async (operation) => operation(),
+      onMilestone: (milestone) => milestones.push(milestone),
+    });
+
+    expect(result.outcome).toBe('ready');
+    expect(bootstrapCalls).toBe(1);
+    expect(fixtureCalls).toBe(1);
+    expect(milestones).toEqual(['fetched', 'validated', 'locked', 'persisted', 'published']);
+    expect(await redis.hlen(`Event:${snapshot.season}`)).toBe(38);
+    expect(await redis.hlen(`Team:${snapshot.season}`)).toBe(20);
+    expect(await redis.hlen(`Player:${snapshot.season}`)).toBe(600);
+    expect(await redis.hlen(`Phase:${snapshot.season}`)).toBe(1);
+    expect(await redis.keys(`Fixtures:${snapshot.season}:*`)).toHaveLength(38);
+    expect(await redis.keys(`FixturesByTeam:${snapshot.season}:*`)).toHaveLength(20);
+    expect(await redis.exists('EntryInfo:2526:sentinel')).toBe(0);
+  });
+
+  test('preserves fixture hashes owned by a published Live snapshot', async () => {
+    const redis = await redisSingleton.getClient();
+    const eventId = 1;
+    const fixtureKey = `Fixtures:${snapshot.season}:${eventId}`;
+    const metaKey = `LiveSnapshotMeta:${snapshot.season}:${eventId}`;
+    await redis.del(fixtureKey, metaKey);
+    await redis.hset(fixtureKey, 'sentinel', 'live-owned-view');
+    await redis.set(metaKey, 'published');
+
+    try {
+      const publication = await publishCoreSnapshotCache(snapshot, {
+        publicationId: randomUUID(),
+        redis,
+      });
+
+      expect(publication.published).toBe(true);
+      expect(publication.receipt?.finalKeys).not.toContain(fixtureKey);
+      expect(publication.receipt?.backups.some((backup) => backup.key === fixtureKey)).toBe(false);
+      expect(await redis.hgetall(fixtureKey)).toEqual({ sentinel: 'live-owned-view' });
+      expect(await redis.hlen(`Event:${snapshot.season}`)).toBe(38);
+
+      if (!publication.receipt) throw new Error('Core publication receipt is missing');
+      await finalizeCoreSnapshotCachePublication(publication.receipt, redis);
+    } finally {
+      await redis.del(fixtureKey, metaKey);
+    }
+  });
+
+  test('preserves a Live-owned durable fixture when a core fetch predates it', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const fixture = snapshot.fixtures.find((candidate) => candidate.event !== null)!;
+    const sourceCheckedAt = await readCoreSnapshotOrderingTimestamp();
+    const liveCheckedAt = new Date(sourceCheckedAt.getTime() + 60_000);
+    let publishedFixture: CoreSnapshot['fixtures'][number] | undefined;
+
+    try {
+      await db
+        .update(events)
+        .set({ liveSnapshotCheckedAt: liveCheckedAt })
+        .where(eq(events.id, fixture.event!));
+      await db
+        .update(eventFixtures)
+        .set({
+          minutes: 88,
+          started: true,
+          teamHScore: 7,
+          teamAScore: 6,
+          updatedAt: liveCheckedAt,
+        })
+        .where(eq(eventFixtures.id, fixture.id));
+
+      const result = await persistCoreSnapshotWithFinalizer(snapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        sourceCheckedAt,
+        finalize: async (reconciled) => {
+          publishedFixture = reconciled.fixtures.find((candidate) => candidate.id === fixture.id);
+          return { published: true };
+        },
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(result.status).toBe('committed');
+      expect(publishedFixture).toMatchObject({
+        minutes: 88,
+        started: true,
+        teamHScore: 7,
+        teamAScore: 6,
+      });
+      expect(
+        await db
+          .select({ minutes: eventFixtures.minutes, teamHScore: eventFixtures.teamHScore })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, fixture.id)),
+      ).toEqual([{ minutes: 88, teamHScore: 7 }]);
+    } finally {
+      await db
+        .update(events)
+        .set({ liveSnapshotCheckedAt: null })
+        .where(eq(events.id, fixture.event!));
+      await persistCoreSnapshot(snapshot);
+    }
+  });
+
+  test('retires a durable scheduled fixture omitted by a complete core snapshot', async () => {
+    const db = await getDb();
+    const ghostFixtureId = 999_999;
+
+    await persistCoreSnapshot(snapshot);
+    await db.insert(eventFixtures).values({
+      id: ghostFixtureId,
+      code: ghostFixtureId,
+      eventId: 1,
+      finished: false,
+      finishedProvisional: false,
+      kickoffTime: new Date('2026-08-15T14:00:00.000Z'),
+      minutes: 0,
+      provisionalStartTime: false,
+      started: false,
+      teamAId: 1,
+      teamAScore: null,
+      teamHId: 1,
+      teamHScore: null,
+      stats: [],
+      teamHDifficulty: 3,
+      teamADifficulty: 3,
+      pulseId: ghostFixtureId,
+    });
+
+    try {
+      await persistCoreSnapshotWithFinalizer(snapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        finalize: async () => ({ published: true }),
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(
+        await db
+          .select({ eventId: eventFixtures.eventId })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, ghostFixtureId)),
+      ).toEqual([{ eventId: null }]);
+    } finally {
+      await db.delete(eventFixtures).where(eq(eventFixtures.id, ghostFixtureId));
+    }
+  });
+
+  test('preserves a newer durable player price in the published core snapshot', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const player = snapshot.players[0];
+    const sourceCheckedAt = await readCoreSnapshotOrderingTimestamp();
+    const priceCheckedAt = new Date(sourceCheckedAt.getTime() + 60_000);
+    const newerPrice = player.price + 3;
+    let publishedPrice: number | undefined;
+
+    try {
+      await db
+        .update(players)
+        .set({
+          price: newerPrice,
+          priceSourceCheckedAt: priceCheckedAt,
+          updatedAt: priceCheckedAt,
+        })
+        .where(eq(players.id, player.id));
+
+      const result = await persistCoreSnapshotWithFinalizer(snapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        sourceCheckedAt,
+        finalize: async (reconciled) => {
+          publishedPrice = reconciled.players.find(
+            (candidate) => candidate.id === player.id,
+          )?.price;
+          return { published: true };
+        },
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(result.status).toBe('committed');
+      expect(publishedPrice).toBe(newerPrice);
+      expect(
+        await db.select({ price: players.price }).from(players).where(eq(players.id, player.id)),
+      ).toEqual([{ price: newerPrice }]);
+    } finally {
+      await persistCoreSnapshot(snapshot);
+    }
+  });
+
+  test('does not mistake an earlier core upsert for newer price evidence', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const player = snapshot.players[0];
+    const sourceCheckedAt = await readCoreSnapshotOrderingTimestamp();
+    const candidatePrice = player.price + 5;
+    let publishedPrice: number | undefined;
+
+    const earlierCoreSnapshot: CoreSnapshot = {
+      ...snapshot,
+      players: snapshot.players.map((candidate) =>
+        candidate.id === player.id ? { ...candidate, price: player.price - 1 } : candidate,
+      ),
+    };
+    const winningSnapshot: CoreSnapshot = {
+      ...snapshot,
+      players: snapshot.players.map((candidate) =>
+        candidate.id === player.id ? { ...candidate, price: candidatePrice } : candidate,
+      ),
+    };
+
+    try {
+      await createPlayerRepository(db).upsertBatch(earlierCoreSnapshot.players);
+
+      const result = await persistCoreSnapshotWithFinalizer(winningSnapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        sourceCheckedAt,
+        finalize: async (reconciled) => {
+          publishedPrice = reconciled.players.find(
+            (candidate) => candidate.id === player.id,
+          )?.price;
+          return { published: true };
+        },
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(result.status).toBe('committed');
+      expect(publishedPrice).toBe(candidatePrice);
+      expect(
+        await db.select({ price: players.price }).from(players).where(eq(players.id, player.id)),
+      ).toEqual([{ price: candidatePrice }]);
+    } finally {
+      await persistCoreSnapshot(snapshot);
+    }
+  });
+
+  test('carries newer price authority through successive waiting core revisions', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const player = snapshot.players[0];
+    const firstCoreCheckedAt = await readCoreSnapshotOrderingTimestamp();
+    const secondCoreCheckedAt = new Date(firstCoreCheckedAt.getTime() + 1_000);
+    const priceCheckedAt = new Date(firstCoreCheckedAt.getTime() + 2_000);
+    const partialPrice = player.price + 7;
+    const firstCoreSnapshot: CoreSnapshot = {
+      ...snapshot,
+      players: snapshot.players.map((candidate) =>
+        candidate.id === player.id ? { ...candidate, price: player.price + 1 } : candidate,
+      ),
+    };
+    const secondCoreSnapshot: CoreSnapshot = {
+      ...snapshot,
+      players: snapshot.players.map((candidate) =>
+        candidate.id === player.id ? { ...candidate, price: player.price + 2 } : candidate,
+      ),
+    };
+
+    try {
+      await db
+        .update(players)
+        .set({ price: partialPrice, priceSourceCheckedAt: priceCheckedAt })
+        .where(eq(players.id, player.id));
+
+      const first = await persistCoreSnapshotWithFinalizer(firstCoreSnapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        sourceCheckedAt: firstCoreCheckedAt,
+        finalize: async () => ({ published: true }),
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+      expect(first.status).toBe('committed');
+      expect(
+        await db
+          .select({
+            price: players.price,
+            priceSourceCheckedAt: players.priceSourceCheckedAt,
+          })
+          .from(players)
+          .where(eq(players.id, player.id)),
+      ).toEqual([{ price: partialPrice, priceSourceCheckedAt: priceCheckedAt }]);
+
+      let publishedPrice: number | undefined;
+      const second = await persistCoreSnapshotWithFinalizer(secondCoreSnapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        sourceCheckedAt: secondCoreCheckedAt,
+        finalize: async (reconciled) => {
+          publishedPrice = reconciled.players.find(
+            (candidate) => candidate.id === player.id,
+          )?.price;
+          return { published: true };
+        },
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(second.status).toBe('committed');
+      expect(publishedPrice).toBe(partialPrice);
+      expect(
+        await db
+          .select({
+            price: players.price,
+            priceSourceCheckedAt: players.priceSourceCheckedAt,
+          })
+          .from(players)
+          .where(eq(players.id, player.id)),
+      ).toEqual([{ price: partialPrice, priceSourceCheckedAt: priceCheckedAt }]);
+    } finally {
+      await createPlayerRepository(db).upsertBatch(snapshot.players);
+    }
+  });
+
+  test('rolls database writes back when cache publication fails', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const before = await db.select({ name: events.name }).from(events).where(eq(events.id, 1));
+    const candidate: CoreSnapshot = {
+      ...snapshot,
+      events: snapshot.events.map((event) =>
+        event.id === 1 ? { ...event, name: 'Must Roll Back On Cache Failure' } : event,
+      ),
+    };
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', snapshot.season);
+    await redis.del(`Event:${snapshot.season}`);
+    await redis.hset(`Event:${snapshot.season}`, 'sentinel', 'old-view');
+    resetActiveSeasonMemo();
+
+    const publicationId = randomUUID();
+    await expect(
+      persistCoreSnapshotWithFinalizer(candidate, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId,
+        previousActiveSeason: snapshot.season,
+        finalize: () =>
+          publishCoreSnapshotCache(candidate, {
+            publicationId,
+            redis,
+            afterStage: async () => {
+              throw new Error('injected cache publication failure');
+            },
+          }),
+        compensate: async (publication) => {
+          if (publication.receipt) {
+            await rollbackCoreSnapshotCachePublication(publication.receipt, redis);
+          }
+        },
+        afterCommit: async (publication) => {
+          if (publication.receipt) {
+            await finalizeCoreSnapshotCachePublication(publication.receipt, redis);
+          }
+        },
+      }),
+    ).rejects.toThrow('injected cache publication failure');
+
+    const after = await db.select({ name: events.name }).from(events).where(eq(events.id, 1));
+    expect(after).toEqual(before);
+    expect(await redis.hgetall(`Event:${snapshot.season}`)).toEqual({ sentinel: 'old-view' });
+    expect(await redis.exists(CORE_SNAPSHOT_PENDING_PUBLICATION_KEY)).toBe(0);
+  });
+
+  test('compensates Redis when the database transaction fails after publication', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const before = await db.select({ name: events.name }).from(events).where(eq(events.id, 1));
+    const candidate: CoreSnapshot = {
+      ...snapshot,
+      events: snapshot.events.map((event) =>
+        event.id === 1 ? { ...event, name: 'Must Compensate Cache' } : event,
+      ),
+    };
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', snapshot.season);
+    await redis.del(`Event:${snapshot.season}`);
+    await redis.hset(`Event:${snapshot.season}`, 'sentinel', 'old-view');
+    const publicationId = randomUUID();
+
+    await db.execute(sql`
+      CREATE OR REPLACE FUNCTION public.fail_core_snapshot_authority_for_test()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        RAISE EXCEPTION 'injected authority commit failure';
+      END
+      $$
+    `);
+    await db.execute(sql`
+      DROP TRIGGER IF EXISTS fail_core_snapshot_authority_for_test
+      ON public.core_snapshot_authority
+    `);
+    await db.execute(sql`
+      CREATE TRIGGER fail_core_snapshot_authority_for_test
+      BEFORE INSERT OR UPDATE ON public.core_snapshot_authority
+      FOR EACH ROW EXECUTE FUNCTION public.fail_core_snapshot_authority_for_test()
+    `);
+    try {
+      await expect(
+        persistCoreSnapshotWithFinalizer(candidate, {
+          revision: await allocateCoreSnapshotRevision(),
+          publicationId,
+          previousActiveSeason: snapshot.season,
+          finalize: () => publishCoreSnapshotCache(candidate, { publicationId, redis }),
+          compensate: async (publication) => {
+            if (publication.receipt) {
+              await rollbackCoreSnapshotCachePublication(publication.receipt, redis);
+            }
+          },
+          afterCommit: async (publication) => {
+            if (publication.receipt) {
+              await finalizeCoreSnapshotCachePublication(publication.receipt, redis);
+            }
+          },
+        }),
+      ).rejects.toThrow('injected authority commit failure');
+    } finally {
+      await db.execute(sql`
+        DROP TRIGGER IF EXISTS fail_core_snapshot_authority_for_test
+        ON public.core_snapshot_authority
+      `);
+      await db.execute(sql`DROP FUNCTION IF EXISTS public.fail_core_snapshot_authority_for_test()`);
+    }
+
+    const after = await db.select({ name: events.name }).from(events).where(eq(events.id, 1));
+    expect(after).toEqual(before);
+    expect(await redis.hgetall(`Event:${snapshot.season}`)).toEqual({ sentinel: 'old-view' });
+    expect(await redis.exists(CORE_SNAPSHOT_PENDING_PUBLICATION_KEY)).toBe(0);
+  });
+
+  test('reconciles a durable commit whose client response is lost', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const candidate: CoreSnapshot = {
+      ...snapshot,
+      events: snapshot.events.map((event) =>
+        event.id === 1 ? { ...event, name: 'Committed Despite Lost Response' } : event,
+      ),
+    };
+    const redis = await redisSingleton.getClient();
+    const publicationId = randomUUID();
+    let rejectNextTransactionResponse = true;
+    let compensated = false;
+    const ambiguousCommitDb = {
+      transaction: async <T>(operation: Parameters<DbHandle['transaction']>[0]) => {
+        const result = await db.transaction(operation);
+        if (rejectNextTransactionResponse) {
+          rejectNextTransactionResponse = false;
+          throw new Error('simulated lost PostgreSQL commit response');
+        }
+        return result as T;
+      },
+    } as unknown as DbHandle;
+
+    const result = await persistCoreSnapshotWithFinalizer(
+      candidate,
+      {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId,
+        previousActiveSeason: snapshot.season,
+        finalize: () => publishCoreSnapshotCache(candidate, { publicationId, redis }),
+        compensate: async (publication) => {
+          compensated = true;
+          if (publication.receipt) {
+            await rollbackCoreSnapshotCachePublication(publication.receipt, redis);
+          }
+        },
+        afterCommit: async (publication) => {
+          if (publication.receipt) {
+            await finalizeCoreSnapshotCachePublication(publication.receipt, redis);
+          }
+        },
+      },
+      ambiguousCommitDb,
+    );
+
+    expect(result.status).toBe('committed');
+    expect(compensated).toBe(false);
+    expect(await readPendingCoreSnapshotCachePublication(redis)).toBeNull();
+    expect(await db.select({ name: events.name }).from(events).where(eq(events.id, 1))).toEqual([
+      { name: 'Committed Despite Lost Response' },
+    ]);
+  });
+
+  test('preserves the recovery receipt while an ambiguous commit cannot be queried', async () => {
+    const db = await getDb();
+    const redis = await redisSingleton.getClient();
+    const publicationId = randomUUID();
+    let transactionCalls = 0;
+    const unavailableAfterCommitDb = {
+      transaction: async (operation: Parameters<DbHandle['transaction']>[0]) => {
+        transactionCalls += 1;
+        if (transactionCalls > 1) {
+          throw new Error('simulated PostgreSQL reconciliation outage');
+        }
+        await db.transaction(operation);
+        throw new Error('simulated lost PostgreSQL commit response');
+      },
+    } as unknown as DbHandle;
+
+    await expect(
+      persistCoreSnapshotWithFinalizer(
+        snapshot,
+        {
+          revision: await allocateCoreSnapshotRevision(),
+          publicationId,
+          previousActiveSeason: snapshot.season,
+          finalize: () => publishCoreSnapshotCache(snapshot, { publicationId, redis }),
+          compensate: async (publication) => {
+            if (publication.receipt) {
+              await rollbackCoreSnapshotCachePublication(publication.receipt, redis);
+            }
+          },
+          afterCommit: async (publication) => {
+            if (publication.receipt) {
+              await finalizeCoreSnapshotCachePublication(publication.receipt, redis);
+            }
+          },
+        },
+        unavailableAfterCommitDb,
+      ),
+    ).rejects.toMatchObject({ code: 'CORE_SNAPSHOT_COMMIT_OUTCOME_UNKNOWN' });
+
+    expect((await readPendingCoreSnapshotCachePublication(redis))?.publicationId).toBe(
+      publicationId,
+    );
+
+    // A derivative failure must leave the committed receipt available for the
+    // next recovery attempt instead of declaring the publication complete.
+    await redis.set('Season:active', 'bad-season');
+    resetActiveSeasonMemo();
+    await expect(recoverPendingCoreSnapshotPublication()).rejects.toThrow(
+      'Season:active is missing or malformed',
+    );
+    expect((await readPendingCoreSnapshotCachePublication(redis))?.publicationId).toBe(
+      publicationId,
+    );
+
+    await redis.set('Season:active', snapshot.season);
+    resetActiveSeasonMemo();
+    expect(await recoverPendingCoreSnapshotPublication()).toBe('finalized');
+    expect(await readPendingCoreSnapshotCachePublication(redis)).toBeNull();
+  });
+
+  test('serializes recovery behind an in-flight database publication', async () => {
+    const redis = await redisSingleton.getClient();
+    const publicationId = randomUUID();
+    let signalPublished!: () => void;
+    let releaseTransaction!: () => void;
+    const published = new Promise<void>((resolve) => {
+      signalPublished = resolve;
+    });
+    const transactionRelease = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+
+    const persistence = persistCoreSnapshotWithFinalizer(snapshot, {
+      revision: await allocateCoreSnapshotRevision(),
+      publicationId,
+      previousActiveSeason: snapshot.season,
+      finalize: async () => {
+        const publication = await publishCoreSnapshotCache(snapshot, { publicationId, redis });
+        signalPublished();
+        await transactionRelease;
+        return publication;
+      },
+      compensate: async (publication) => {
+        if (publication.receipt) {
+          await rollbackCoreSnapshotCachePublication(publication.receipt, redis);
+        }
+      },
+      // Leave the receipt for the concurrently waiting recovery attempt.
+      afterCommit: async () => undefined,
+    });
+    await published;
+
+    const recovery = recoverPendingCoreSnapshotPublication();
+    const prematureResult = await Promise.race([
+      recovery.then(() => 'resolved'),
+      new Promise<'waiting'>((resolve) => setTimeout(() => resolve('waiting'), 100)),
+    ]);
+    expect(prematureResult).toBe('waiting');
+
+    releaseTransaction();
+    await expect(persistence).resolves.toMatchObject({ status: 'committed' });
+    expect(await recovery).toBe('finalized');
+    expect(await redis.hlen(`Event:${snapshot.season}`)).toBe(38);
+    expect(await readPendingCoreSnapshotCachePublication(redis)).toBeNull();
+  });
+
+  test('recovers a committed publication left pending by a worker crash', async () => {
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', snapshot.season);
+    const publicationId = randomUUID();
+
+    await expect(
+      persistCoreSnapshotWithFinalizer(snapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId,
+        previousActiveSeason: snapshot.season,
+        finalize: () => publishCoreSnapshotCache(snapshot, { publicationId, redis }),
+        compensate: async (publication) => {
+          if (publication.receipt) {
+            await rollbackCoreSnapshotCachePublication(publication.receipt, redis);
+          }
+        },
+        afterCommit: async () => {
+          throw new Error('simulated worker crash after database commit');
+        },
+      }),
+    ).rejects.toThrow('simulated worker crash');
+
+    expect((await readPendingCoreSnapshotCachePublication(redis))?.publicationId).toBe(
+      publicationId,
+    );
+    expect(await recoverPendingCoreSnapshotPublication()).toBe('finalized');
+    expect(await readPendingCoreSnapshotCachePublication(redis)).toBeNull();
+    expect(await redis.hlen(`Event:${snapshot.season}`)).toBe(38);
+  });
+
+  test('rolls back an uncommitted pending publication during recovery', async () => {
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', snapshot.season);
+    await redis.del(`Event:${snapshot.season}`);
+    await redis.hset(`Event:${snapshot.season}`, 'sentinel', 'old-view');
+    const publication = await publishCoreSnapshotCache(snapshot, {
+      publicationId: randomUUID(),
+      redis,
+    });
+    expect(publication.published).toBe(true);
+
+    expect(await recoverPendingCoreSnapshotPublication()).toBe('rolled_back');
+    expect(await redis.hgetall(`Event:${snapshot.season}`)).toEqual({ sentinel: 'old-view' });
+    expect(await readPendingCoreSnapshotCachePublication(redis)).toBeNull();
+  });
+
+  test('rollback preserves partial writers that completed after the core cache swap', async () => {
+    const db = await getDb();
+    const redis = await redisSingleton.getClient();
+    const player = snapshot.players[0];
+    const omittedPlayer = snapshot.players.at(-1);
+    const fixture = snapshot.fixtures.find((candidate) => candidate.event === 1);
+    if (!player || !omittedPlayer || !fixture) {
+      throw new Error('Core fixture is missing recovery test rows');
+    }
+
+    await persistCoreSnapshot(snapshot);
+    await redis.set('Season:active', snapshot.season);
+    const fixtureKey = `Fixtures:${snapshot.season}:1`;
+    const playerKey = `Player:${snapshot.season}`;
+    const metaKey = `LiveSnapshotMeta:${snapshot.season}:1`;
+    const derivedKeys = [
+      `EventLive:${snapshot.season}:1`,
+      `LiveFixture:${snapshot.season}:1`,
+      `LiveFixtureV2:${snapshot.season}:1`,
+      `LiveBonus:${snapshot.season}:1`,
+      `LiveBonusV2:${snapshot.season}:1`,
+    ];
+    await redis.del(metaKey, ...derivedKeys);
+
+    const baselineSnapshot = {
+      ...snapshot,
+      players: snapshot.players.filter((candidate) => candidate.id !== omittedPlayer.id),
+    };
+    const baseline = await publishCoreSnapshotCache(baselineSnapshot, {
+      publicationId: randomUUID(),
+      redis,
+    });
+    if (!baseline.receipt) throw new Error('Baseline publication receipt is missing');
+    await finalizeCoreSnapshotCachePublication(baseline.receipt, redis);
+    expect(await redis.hexists(playerKey, String(omittedPlayer.id))).toBe(0);
+
+    const pending = await publishCoreSnapshotCache(snapshot, {
+      publicationId: randomUUID(),
+      redis,
+    });
+    if (!pending.receipt) throw new Error('Pending publication receipt is missing');
+    expect(await redis.hexists(playerKey, String(omittedPlayer.id))).toBe(1);
+
+    const durablePrice = player.price + 7;
+    const durableFixture = {
+      ...fixture,
+      finished: true,
+      finishedProvisional: true,
+      started: true,
+      teamHScore: 4,
+      teamAScore: 3,
+    };
+    const checkedAt = new Date('2026-08-04T13:00:00.000Z');
+    await db
+      .update(players)
+      .set({ price: durablePrice, priceSourceCheckedAt: checkedAt, updatedAt: checkedAt })
+      .where(eq(players.id, player.id));
+    await db
+      .update(eventFixtures)
+      .set({
+        finished: durableFixture.finished,
+        finishedProvisional: durableFixture.finishedProvisional,
+        started: durableFixture.started,
+        teamHScore: durableFixture.teamHScore,
+        teamAScore: durableFixture.teamAScore,
+      })
+      .where(eq(eventFixtures.id, fixture.id));
+    await db.update(events).set({ liveSnapshotCheckedAt: checkedAt }).where(eq(events.id, 1));
+
+    await redis.hset(
+      playerKey,
+      String(player.id),
+      JSON.stringify({ ...player, price: durablePrice }),
+    );
+    await redis.del(fixtureKey);
+    await redis.hset(fixtureKey, String(fixture.id), JSON.stringify(durableFixture));
+    for (const key of derivedKeys) await redis.hset(key, 'sentinel', 'durable-live-view');
+    await redis.set(
+      metaKey,
+      JSON.stringify({
+        schemaVersion: 1,
+        season: snapshot.season,
+        eventId: 1,
+        revision: 'd'.repeat(24),
+        state: 'settled',
+        publishedAt: checkedAt.toISOString(),
+        checkedAt: checkedAt.toISOString(),
+        eventLiveCount: 1,
+        fixtureCount: snapshot.fixtures.filter((candidate) => candidate.event === 1).length,
+        fixtureTeamCount: 2,
+        bonusTeamCount: 0,
+      }),
+    );
+
+    expect(await recoverPendingCoreSnapshotPublication()).toBe('rolled_back');
+    const recoveredPlayer = JSON.parse(
+      (await redis.hget(playerKey, String(player.id))) ?? '{}',
+    ) as {
+      price?: number;
+    };
+    const recoveredFixture = JSON.parse(
+      (await redis.hget(fixtureKey, String(fixture.id))) ?? '{}',
+    ) as { teamHScore?: number; teamAScore?: number };
+    expect(recoveredPlayer.price).toBe(durablePrice);
+    expect(await redis.hlen(playerKey)).toBe(baselineSnapshot.players.length);
+    expect(await redis.hexists(playerKey, String(omittedPlayer.id))).toBe(0);
+    expect(recoveredFixture).toMatchObject({ teamHScore: 4, teamAScore: 3 });
+    expect(await redis.exists(metaKey)).toBe(1);
+    for (const key of derivedKeys) {
+      expect(await redis.hget(key, 'sentinel')).toBe('durable-live-view');
+    }
+
+    await redis.del(metaKey, ...derivedKeys);
+  });
+
+  test('does not let an older same-season revision republish', async () => {
+    const redis = await redisSingleton.getClient();
+    await redis.set('Season:active', snapshot.season);
+    const newerRevision = await allocateCoreSnapshotRevision();
+    const committed = await persistCoreSnapshotWithFinalizer(snapshot, {
+      revision: newerRevision,
+      publicationId: randomUUID(),
+      previousActiveSeason: snapshot.season,
+      finalize: async () => ({ published: true }),
+      compensate: async () => undefined,
+      afterCommit: async () => undefined,
+    });
+    expect(committed.status).toBe('committed');
+
+    let finalized = false;
+    const stale = await persistCoreSnapshotWithFinalizer(snapshot, {
+      revision: newerRevision - 1,
+      publicationId: randomUUID(),
+      previousActiveSeason: snapshot.season,
+      finalize: async () => {
+        finalized = true;
+        return { published: true };
+      },
+      compensate: async () => undefined,
+      afterCommit: async () => undefined,
+    });
+    expect(stale.status).toBe('stale');
+    expect(finalized).toBe(false);
+  });
+
+  test('fails safely at the separately gated destructive season-rollover boundary', async () => {
+    let finalized = false;
+    await expect(
+      persistCoreSnapshotWithFinalizer(
+        { ...snapshot, season: '2728' },
+        {
+          revision: await allocateCoreSnapshotRevision(),
+          publicationId: randomUUID(),
+          previousActiveSeason: snapshot.season,
+          finalize: async () => {
+            finalized = true;
+            return { published: true };
+          },
+          compensate: async () => undefined,
+          afterCommit: async () => undefined,
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'CORE_SNAPSHOT_MANUAL_ROLLOVER_REQUIRED' });
+    expect(finalized).toBe(false);
+  });
+
+  test('rejects same-season identity reassignment before any upsert', async () => {
+    const conflicting: CoreSnapshot = {
+      ...snapshot,
+      teams: snapshot.teams.map((team) =>
+        team.id === 1 ? { ...team, code: snapshot.teams[1].code } : team,
+      ),
+    };
+    let finalized = false;
+    await expect(
+      persistCoreSnapshotWithFinalizer(conflicting, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        finalize: async () => {
+          finalized = true;
+          return { published: true };
+        },
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      }),
+    ).rejects.toMatchObject({ code: 'CORE_SNAPSHOT_IDENTITY_CONFLICT' });
+    expect(finalized).toBe(false);
+  });
+
+  test('rolls back every earlier core table write when a later fixture write fails', async () => {
+    const db = await getDb();
+    const before = await db.select({ name: events.name }).from(events).where(eq(events.id, 1));
+    expect(before).toHaveLength(1);
+
+    const invalidSnapshot: CoreSnapshot = {
+      ...snapshot,
+      events: snapshot.events.map((event) =>
+        event.id === 1 ? { ...event, name: 'Must Roll Back' } : event,
+      ),
+      fixtures: snapshot.fixtures.map((fixture, index) =>
+        index === 0 ? { ...fixture, teamH: 999 } : fixture,
+      ),
+    };
+
+    await expect(persistCoreSnapshot(invalidSnapshot)).rejects.toThrow();
+    const after = await db.select({ name: events.name }).from(events).where(eq(events.id, 1));
+    expect(after).toEqual(before);
+  });
+
+  test('retires a previously scheduled fixture while retaining it for cache publication', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const unscheduledFixtureId = snapshot.fixtures[0].id;
+    const candidate: CoreSnapshot = {
+      ...snapshot,
+      fixtures: snapshot.fixtures.map((fixture, index) =>
+        index === 0 ? { ...fixture, event: null } : fixture,
+      ),
+    };
+
+    const persistence = await persistCoreSnapshot(candidate);
+    expect(persistence.fixtures).toBe(candidate.fixtures.length - 1);
+    expect(
+      await db
+        .select({ id: eventFixtures.id, eventId: eventFixtures.eventId })
+        .from(eventFixtures)
+        .where(eq(eventFixtures.id, unscheduledFixtureId)),
+    ).toEqual([{ id: unscheduledFixtureId, eventId: null }]);
+    expect(
+      buildCoreSnapshotCachePlan(candidate).hashes.get(`Fixtures:${snapshot.season}:unscheduled`),
+    ).toHaveProperty(String(unscheduledFixtureId));
+  });
+
+  test('retires a scheduled fixture omitted from the complete snapshot', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const sourceFixture = snapshot.fixtures.find((fixture) => fixture.event !== null);
+    if (!sourceFixture) throw new Error('Core snapshot fixture requires one scheduled row');
+    const unusedAwayTeam = snapshot.teams.find(
+      (team) =>
+        team.id !== sourceFixture.teamH &&
+        !snapshot.fixtures.some(
+          (fixture) =>
+            fixture.event === sourceFixture.event &&
+            fixture.teamH === sourceFixture.teamH &&
+            fixture.teamA === team.id,
+        ),
+    );
+    if (!unusedAwayTeam) throw new Error('Core snapshot requires an unused fixture pairing');
+    const ghostFixture = {
+      ...sourceFixture,
+      id: sourceFixture.id + 1_000_000,
+      code: sourceFixture.code + 1_000_000,
+      pulseId: sourceFixture.pulseId + 1_000_000,
+      teamA: unusedAwayTeam.id,
+    };
+
+    try {
+      await createFixtureRepository(db).upsertBatch([ghostFixture]);
+
+      await persistCoreSnapshot(snapshot);
+
+      expect(
+        await db
+          .select({ id: eventFixtures.id, eventId: eventFixtures.eventId })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, ghostFixture.id)),
+      ).toEqual([{ id: ghostFixture.id, eventId: null }]);
+    } finally {
+      await db.delete(eventFixtures).where(eq(eventFixtures.id, ghostFixture.id));
+    }
+  });
+
+  test('preserves an omitted fixture owned by newer durable evidence', async () => {
+    const db = await getDb();
+    await persistCoreSnapshot(snapshot);
+    const sourceFixture = snapshot.fixtures.find((fixture) => fixture.event !== null);
+    if (!sourceFixture || sourceFixture.event === null) {
+      throw new Error('Core snapshot fixture requires one scheduled row');
+    }
+    const unusedAwayTeam = snapshot.teams.find(
+      (team) =>
+        team.id !== sourceFixture.teamH &&
+        !snapshot.fixtures.some(
+          (fixture) =>
+            fixture.event === sourceFixture.event &&
+            fixture.teamH === sourceFixture.teamH &&
+            fixture.teamA === team.id,
+        ),
+    );
+    if (!unusedAwayTeam) throw new Error('Core snapshot requires an unused fixture pairing');
+    const ghostFixture = {
+      ...sourceFixture,
+      id: sourceFixture.id + 1_000_001,
+      code: sourceFixture.code + 1_000_001,
+      pulseId: sourceFixture.pulseId + 1_000_001,
+      teamA: unusedAwayTeam.id,
+    };
+    const sourceCheckedAt = await readCoreSnapshotOrderingTimestamp();
+    const liveCheckedAt = new Date(sourceCheckedAt.getTime() + 60_000);
+
+    try {
+      await createFixtureRepository(db).upsertBatch([ghostFixture]);
+      await db
+        .update(events)
+        .set({ liveSnapshotCheckedAt: liveCheckedAt })
+        .where(eq(events.id, sourceFixture.event));
+
+      await persistCoreSnapshotWithFinalizer(snapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        sourceCheckedAt,
+        finalize: async () => ({ published: true }),
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(
+        await db
+          .select({ id: eventFixtures.id, eventId: eventFixtures.eventId })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, ghostFixture.id)),
+      ).toEqual([{ id: ghostFixture.id, eventId: sourceFixture.event }]);
+    } finally {
+      await db
+        .update(events)
+        .set({ liveSnapshotCheckedAt: null })
+        .where(eq(events.id, sourceFixture.event));
+      await db.delete(eventFixtures).where(eq(eventFixtures.id, ghostFixture.id));
+    }
+  });
+});

--- a/tests/integration/core-snapshot-atomicity.test.ts
+++ b/tests/integration/core-snapshot-atomicity.test.ts
@@ -289,6 +289,54 @@ describeAtomicity('core snapshot atomicity', () => {
     }
   });
 
+  test('retires an omitted fixture before inserting an upstream fixture-id replacement', async () => {
+    const db = await getDb();
+    const originalFixture = snapshot.fixtures.find((fixture) => fixture.event !== null)!;
+    const replacementFixtureId = 999_998;
+    const replacementFixture = {
+      ...originalFixture,
+      id: replacementFixtureId,
+      code: replacementFixtureId,
+      pulseId: replacementFixtureId,
+    };
+    const replacementSnapshot: CoreSnapshot = {
+      ...snapshot,
+      fixtures: [
+        ...snapshot.fixtures.filter((fixture) => fixture.id !== originalFixture.id),
+        replacementFixture,
+      ],
+    };
+
+    await persistCoreSnapshot(snapshot);
+
+    try {
+      await persistCoreSnapshotWithFinalizer(replacementSnapshot, {
+        revision: await allocateCoreSnapshotRevision(),
+        publicationId: randomUUID(),
+        previousActiveSeason: snapshot.season,
+        finalize: async () => ({ published: true }),
+        compensate: async () => undefined,
+        afterCommit: async () => undefined,
+      });
+
+      expect(
+        await db
+          .select({ eventId: eventFixtures.eventId })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, originalFixture.id)),
+      ).toEqual([{ eventId: null }]);
+      expect(
+        await db
+          .select({ eventId: eventFixtures.eventId })
+          .from(eventFixtures)
+          .where(eq(eventFixtures.id, replacementFixtureId)),
+      ).toEqual([{ eventId: originalFixture.event }]);
+    } finally {
+      await db.delete(eventFixtures).where(eq(eventFixtures.id, replacementFixtureId));
+      await persistCoreSnapshot(snapshot);
+    }
+  });
+
   test('preserves a newer durable player price in the published core snapshot', async () => {
     const db = await getDb();
     await persistCoreSnapshot(snapshot);

--- a/tests/integration/core-snapshot-atomicity.test.ts
+++ b/tests/integration/core-snapshot-atomicity.test.ts
@@ -296,7 +296,7 @@ describeAtomicity('core snapshot atomicity', () => {
     const replacementFixture = {
       ...originalFixture,
       id: replacementFixtureId,
-      code: replacementFixtureId,
+      code: originalFixture.code,
       pulseId: replacementFixtureId,
     };
     const replacementSnapshot: CoreSnapshot = {
@@ -321,10 +321,10 @@ describeAtomicity('core snapshot atomicity', () => {
 
       expect(
         await db
-          .select({ eventId: eventFixtures.eventId })
+          .select({ id: eventFixtures.id })
           .from(eventFixtures)
           .where(eq(eventFixtures.id, originalFixture.id)),
-      ).toEqual([{ eventId: null }]);
+      ).toEqual([]);
       expect(
         await db
           .select({ eventId: eventFixtures.eventId })

--- a/tests/integration/core-snapshot-benchmark.test.ts
+++ b/tests/integration/core-snapshot-benchmark.test.ts
@@ -1,0 +1,72 @@
+import { assertIntegrationEnv } from './helpers/env-guard';
+
+assertIntegrationEnv();
+import { describe, expect, test } from 'bun:test';
+import { performance } from 'node:perf_hooks';
+
+import {
+  syncCoreSnapshot,
+  type CoreSnapshotMilestone,
+} from '../../src/services/core-snapshot.service';
+import { buildCoreSnapshotFixture } from '../fixtures/core-snapshot.fixtures';
+
+const describeBenchmark =
+  process.env.RUN_CORE_SNAPSHOT_BENCHMARK === '1' ? describe : describe.skip;
+
+describeBenchmark('core snapshot deterministic benchmark', () => {
+  test('validates the complete snapshot with one bootstrap and one fixtures request', async () => {
+    const input = buildCoreSnapshotFixture({ playerCount: 700 });
+    const milestones: CoreSnapshotMilestone[] = [];
+    let bootstrapCalls = 0;
+    let fixtureCalls = 0;
+    const rssBefore = process.memoryUsage().rss;
+    const startedAt = performance.now();
+
+    const result = await syncCoreSnapshot({
+      getBootstrap: async () => {
+        bootstrapCalls += 1;
+        return input.bootstrap;
+      },
+      getFixtures: async () => {
+        fixtureCalls += 1;
+        return input.fixtures;
+      },
+      getActiveSeason: async () => '2627',
+      readOrderingTimestamp: async () => new Date('2026-08-04T00:00:00.000Z'),
+      reserveRevision: async () => 1,
+      createPublicationId: () => '00000000-0000-4000-8000-000000000001',
+      recoverPending: async () => undefined,
+      commit: async () => ({ status: 'committed' }),
+      cleanup: async () => undefined,
+      withPersistenceLock: async (operation) => operation(),
+      onMilestone: (milestone) => milestones.push(milestone),
+    });
+
+    const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
+    const rssDeltaBytes = process.memoryUsage().rss - rssBefore;
+    const report = {
+      event: 'core_snapshot_benchmark',
+      schemaVersion: 1,
+      events: result.events,
+      teams: result.teams,
+      players: result.players,
+      phases: result.phases,
+      fixtures: result.fixtures,
+      durationMs,
+      rssDeltaBytes,
+      milestoneOrder: milestones,
+      requests: { bootstrap: bootstrapCalls, fixtures: fixtureCalls, total: 2 },
+      requiredUnits: result.requiredUnits,
+      reusedUnits: result.reusedUnits,
+    };
+    console.error(JSON.stringify(report));
+
+    expect(result.outcome).toBe('ready');
+    expect(bootstrapCalls).toBe(1);
+    expect(fixtureCalls).toBe(1);
+    expect(milestones).toEqual(['fetched', 'validated', 'locked', 'persisted', 'published']);
+    expect(result).toMatchObject({ events: 38, teams: 20, players: 700, phases: 1, fixtures: 380 });
+    expect(Number.isFinite(durationMs)).toBe(true);
+    expect(Number.isFinite(rssDeltaBytes)).toBe(true);
+  });
+});

--- a/tests/integration/events.test.ts
+++ b/tests/integration/events.test.ts
@@ -7,10 +7,12 @@ import { getDbClient } from '../../src/db/singleton';
 import { eventRepository } from '../../src/repositories/events';
 import { getCurrentEvent, getNextEvent, syncEvents } from '../../src/services/events.service';
 import type { Event } from '../../src/types';
+import { ensureCoreSnapshot } from './helpers/reference-data';
 
 describe('Events Integration Tests', () => {
   beforeAll(async () => {
-    // Sync events once for all tests
+    await ensureCoreSnapshot();
+    // Exercise the compatibility entry point after the atomic baseline exists.
     await syncEvents();
   });
 

--- a/tests/integration/fixtures-cache-guard.test.ts
+++ b/tests/integration/fixtures-cache-guard.test.ts
@@ -61,6 +61,8 @@ let previousActiveSeason: string | null = null;
 beforeAll(async () => {
   const redis = await redisSingleton.getClient();
   previousActiveSeason = await redis.get('Season:active');
+  await redis.set('Season:active', SEASON);
+  resetActiveSeasonMemo();
 });
 
 afterAll(async () => {

--- a/tests/integration/fixtures.test.ts
+++ b/tests/integration/fixtures.test.ts
@@ -89,7 +89,7 @@ describe('Fixtures Integration Tests', () => {
     expect(assignedFixtures.length).toBeGreaterThan(0);
   });
 
-  test('event-scoped sync recovers a fixture omitted after moving to another event', async () => {
+  test('event-scoped compatibility sync uses the full feed without taking Live ownership', async () => {
     const originalGetFixtures = fplClient.getFixtures;
     const fetchFixtures = originalGetFixtures.bind(fplClient);
     const fullFixtureFeed = await fetchFixtures();
@@ -147,7 +147,7 @@ describe('Fixtures Integration Tests', () => {
 
       const result = await syncFixtures(sourceEventId);
 
-      expect(requestedEvents).toEqual([sourceEventId, undefined]);
+      expect(requestedEvents).toEqual([undefined]);
       expect(result.count).toBe(
         movedFullFixtureFeed.filter((fixture) => fixture.event !== null).length,
       );
@@ -167,17 +167,14 @@ describe('Fixtures Integration Tests', () => {
       ).toBe(1);
     } finally {
       fplClient.getFixtures = originalGetFixtures;
-      // Restore the real upstream ownership for subsequent integration tests
-      // and leave no sentinel snapshot state behind even when an assertion fails.
-      try {
-        await syncFixtures();
-      } finally {
-        await redis.del(sourceMetaKey, destinationMetaKey);
-      }
+      // Release the synthetic Live ownership before restoring the canonical
+      // upstream fixture view for subsequent tests.
+      await redis.del(sourceMetaKey, destinationMetaKey);
+      await syncFixtures();
     }
   }, 30000);
 
-  test('full sync reconciles a non-current snapshot-owned event correction', async () => {
+  test('full sync retires a stale non-current snapshot-owned fixture view', async () => {
     const originalGetFixtures = fplClient.getFixtures;
     const fetchFixtures = originalGetFixtures.bind(fplClient);
     const fullFixtureFeed = await fetchFixtures();
@@ -237,16 +234,17 @@ describe('Fixtures Integration Tests', () => {
       await syncFixtures();
 
       expect(await redis.exists(metaKey)).toBe(0);
-      for (const key of derivedKeys.slice(0, 4)) {
+      for (const key of derivedKeys) {
         expect(await redis.exists(key)).toBe(0);
       }
       const correctedRaw = await redis.hget(fixturesKey, String(targetRawFixture.id));
-      if (!correctedRaw) throw new Error('Corrected fixture source hash was not republished');
+      if (!correctedRaw) throw new Error('Corrected fixture source hash disappeared');
       const correctedFixture = JSON.parse(correctedRaw) as { teamHScore: number | null };
       expect(correctedFixture.teamHScore).toBe(expectedFixture.teamHScore);
     } finally {
       fplClient.getFixtures = originalGetFixtures;
       await redis.del(metaKey, ...derivedKeys);
+      await syncFixtures();
     }
   }, 30000);
 

--- a/tests/integration/helpers/reference-data.ts
+++ b/tests/integration/helpers/reference-data.ts
@@ -1,10 +1,6 @@
-import { syncEvents } from '../../../src/services/events.service';
-import { syncPlayers } from '../../../src/services/players.service';
-import { syncTeams } from '../../../src/services/teams.service';
+import { syncCoreSnapshot } from '../../../src/services/core-snapshot.service';
 
-let eventsReady: Promise<void> | undefined;
-let teamsReady: Promise<void> | undefined;
-let playersReady: Promise<void> | undefined;
+let coreReady: Promise<void> | undefined;
 
 function retryable(task: () => Promise<void>, reset: () => void): Promise<void> {
   return task().catch((error) => {
@@ -13,41 +9,27 @@ function retryable(task: () => Promise<void>, reset: () => void): Promise<void> 
   });
 }
 
-/** Seed FPL reference tables once, in foreign-key order, for this test process. */
-export function ensureEvents(): Promise<void> {
-  eventsReady ??= retryable(
+/** Seed the complete FPL core once so no partial writer can publish first. */
+export function ensureCoreSnapshot(): Promise<void> {
+  coreReady ??= retryable(
     async () => {
-      await syncEvents();
+      await syncCoreSnapshot();
     },
     () => {
-      eventsReady = undefined;
+      coreReady = undefined;
     },
   );
-  return eventsReady;
+  return coreReady;
+}
+
+export function ensureEvents(): Promise<void> {
+  return ensureCoreSnapshot();
 }
 
 export function ensureTeams(): Promise<void> {
-  teamsReady ??= retryable(
-    async () => {
-      await ensureEvents();
-      await syncTeams();
-    },
-    () => {
-      teamsReady = undefined;
-    },
-  );
-  return teamsReady;
+  return ensureCoreSnapshot();
 }
 
 export function ensurePlayers(): Promise<void> {
-  playersReady ??= retryable(
-    async () => {
-      await ensureTeams();
-      await syncPlayers();
-    },
-    () => {
-      playersReady = undefined;
-    },
-  );
-  return playersReady;
+  return ensureCoreSnapshot();
 }

--- a/tests/integration/live-snapshot-cache.test.ts
+++ b/tests/integration/live-snapshot-cache.test.ts
@@ -240,6 +240,15 @@ describe('coordinated live snapshot Redis integration', () => {
       ...fixture,
       teamHScore: (fixture.teamHScore ?? 0) + 1,
     }));
+    const preservedNewer = await cache.refreshFixtureDerivatives(
+      EVENT_ID,
+      correctedFixtures,
+      initial.liveBonusV2,
+      '2025-08-15T20:00:00.000Z',
+    );
+    expect(preservedNewer).toEqual({ eventId: EVENT_ID, owned: true, retired: false });
+    expect(await redis.exists(`LiveSnapshotMeta:${SEASON}:${EVENT_ID}`)).toBe(1);
+
     const corrected = await cache.refreshFixtureDerivatives(
       EVENT_ID,
       correctedFixtures,

--- a/tests/integration/live-snapshot-serialization.test.ts
+++ b/tests/integration/live-snapshot-serialization.test.ts
@@ -5,7 +5,7 @@ assertIntegrationEnv();
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 
-import { resetActiveSeasonMemo, setActiveCacheSeason } from '../../src/cache/cache-season';
+import { resetActiveSeasonMemo, withActiveSeasonWriteFence } from '../../src/cache/cache-season';
 import { redisSingleton } from '../../src/cache/singleton';
 import { events } from '../../src/db/schemas/index.schema';
 import { getDb } from '../../src/db/singleton';
@@ -100,7 +100,11 @@ describe('live snapshot PostgreSQL serialization', () => {
     });
     await snapshotEntered.promise;
 
-    const rollover = setActiveCacheSeason('2627');
+    const rollover = withActiveSeasonWriteFence(async () => {
+      await redis.set('Season:active', '2627');
+      resetActiveSeasonMemo();
+      return true;
+    });
     const rolloverState = await Promise.race([
       rollover.then(() => 'advanced' as const),
       new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 75)),
@@ -144,7 +148,11 @@ describe('live snapshot PostgreSQL serialization', () => {
     );
     await prepareEntered.promise;
 
-    const rollover = setActiveCacheSeason('2627');
+    const rollover = withActiveSeasonWriteFence(async () => {
+      await redis.set('Season:active', '2627');
+      resetActiveSeasonMemo();
+      return true;
+    });
     const rolloverState = await Promise.race([
       rollover.then(() => 'advanced' as const),
       new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 75)),

--- a/tests/integration/live-snapshot-serialization.test.ts
+++ b/tests/integration/live-snapshot-serialization.test.ts
@@ -323,6 +323,41 @@ describe('live snapshot PostgreSQL serialization', () => {
     }
   });
 
+  test('advances the durable ownership checkpoint for metadata-only live checks', async () => {
+    const eventId = 2_000_000_026;
+    const checkedAt = new Date('2026-08-04T01:00:05.000Z');
+    const db = await getDb();
+    await db.delete(events).where(eq(events.id, eventId));
+    await db.insert(events).values({ id: eventId, name: 'Metadata-only live check' });
+
+    try {
+      const result = await persistLiveSnapshotDurably({
+        eventId,
+        checkedAt,
+        prepared: { season: '2526' } as never,
+        persistFixtures: false,
+        persistEventLives: false,
+      });
+
+      expect(result).toMatchObject({
+        accepted: true,
+        winnerCheckedAt: checkedAt,
+        persistedFixtures: false,
+        persistedEventLives: false,
+      });
+      expect(
+        (
+          await db
+            .select({ checkedAt: events.liveSnapshotCheckedAt })
+            .from(events)
+            .where(eq(events.id, eventId))
+        )[0]?.checkedAt,
+      ).toEqual(checkedAt);
+    } finally {
+      await db.delete(events).where(eq(events.id, eventId));
+    }
+  });
+
   test('multi-event fixture fence rolls back every earlier claim when one event is newer', async () => {
     const firstEventId = 2_000_000_031;
     const secondEventId = 2_000_000_032;

--- a/tests/integration/phases.test.ts
+++ b/tests/integration/phases.test.ts
@@ -6,12 +6,13 @@ import { beforeAll, describe, expect, test } from 'bun:test';
 import { phases } from '../../src/db/schemas/index.schema';
 import { getDb } from '../../src/db/singleton';
 import { syncPhases } from '../../src/services/phases.service';
+import { ensureCoreSnapshot } from './helpers/reference-data';
 
 describe('Phases Integration Tests', () => {
   let syncResult: { count: number };
 
   beforeAll(async () => {
-    // Sync phases once
+    await ensureCoreSnapshot();
     syncResult = await syncPhases();
   });
 

--- a/tests/integration/player-cache-atomicity.test.ts
+++ b/tests/integration/player-cache-atomicity.test.ts
@@ -2,16 +2,19 @@ import { assertIntegrationEnv } from './helpers/env-guard';
 
 assertIntegrationEnv();
 
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
 
 import { playersCache } from '../../src/cache/operations';
-import { ACTIVE_SEASON_KEY, resetActiveSeasonMemo } from '../../src/cache/cache-season';
+import {
+  ACTIVE_SEASON_KEY,
+  resetActiveSeasonMemo,
+  withActiveSeasonWriteFence,
+} from '../../src/cache/cache-season';
 import { redisSingleton } from '../../src/cache/singleton';
 import type { Player } from '../../src/types';
 
 const SEASON = '0001';
 const KEY = `Player:${SEASON}`;
-let previousActiveSeason: string | null = null;
 
 const player = (id: number, teamId: number, price: number): Player => ({
   id,
@@ -26,51 +29,58 @@ const player = (id: number, teamId: number, price: number): Player => ({
 });
 
 describe('player cache replacement and price merge atomicity', () => {
-  beforeAll(async () => {
-    const redis = await redisSingleton.getClient();
-    previousActiveSeason = await redis.get(ACTIVE_SEASON_KEY);
-  });
-
   afterAll(async () => {
     const redis = await redisSingleton.getClient();
     await redis.del(KEY);
-    if (previousActiveSeason === null) {
-      await redis.del(ACTIVE_SEASON_KEY);
-    } else {
-      await redis.set(ACTIVE_SEASON_KEY, previousActiveSeason);
-    }
-    resetActiveSeasonMemo();
     await redisSingleton.disconnect();
   });
 
   test('a stale price job cannot restore removed players or old team identity', async () => {
-    const oldRoster = [player(1, 1, 50), player(2, 1, 60)];
-    const reassignedRoster = [player(1, 9, 52), player(2, 1, 60)];
-    const replacedRoster = [player(2, 2, 62), player(3, 2, 55)];
+    await withActiveSeasonWriteFence(async () => {
+      const redis = await redisSingleton.getClient();
+      const previousActiveSeason = await redis.get(ACTIVE_SEASON_KEY);
+      await redis.set(ACTIVE_SEASON_KEY, SEASON);
+      resetActiveSeasonMemo();
 
-    for (let iteration = 0; iteration < 20; iteration += 1) {
-      await playersCache.set(oldRoster, SEASON);
-      await Promise.allSettled([
-        playersCache.mergePrices([{ elementId: 1, value: 51 }], [1, 2], SEASON),
-        playersCache.set(reassignedRoster, SEASON),
-      ]);
+      try {
+        const oldRoster = [player(1, 1, 50), player(2, 1, 60)];
+        const reassignedRoster = [player(1, 9, 52), player(2, 1, 60)];
+        const replacedRoster = [player(2, 2, 62), player(3, 2, 55)];
 
-      const reassigned = await playersCache.get(SEASON);
-      expect(reassigned?.map(({ id }) => id).sort((left, right) => left - right)).toEqual([1, 2]);
-      expect(reassigned?.find(({ id }) => id === 1)).toMatchObject({
-        teamId: 9,
-        webName: 'Player 1',
-      });
+        for (let iteration = 0; iteration < 20; iteration += 1) {
+          await playersCache.set(oldRoster, SEASON);
+          await Promise.allSettled([
+            playersCache.mergePrices([{ elementId: 1, value: 51 }], [1, 2], SEASON),
+            playersCache.set(reassignedRoster, SEASON),
+          ]);
 
-      await Promise.allSettled([
-        playersCache.mergePrices([{ elementId: 1, value: 53 }], [1, 2], SEASON),
-        playersCache.set(replacedRoster, SEASON),
-      ]);
+          const reassigned = await playersCache.get(SEASON);
+          expect(reassigned?.map(({ id }) => id).sort((left, right) => left - right)).toEqual([
+            1, 2,
+          ]);
+          expect(reassigned?.find(({ id }) => id === 1)).toMatchObject({
+            teamId: 9,
+            webName: 'Player 1',
+          });
 
-      const replaced = await playersCache.get(SEASON);
-      expect(replaced?.map(({ id }) => id).sort((left, right) => left - right)).toEqual([2, 3]);
-      expect(replaced?.find(({ id }) => id === 1)).toBeUndefined();
-      expect(replaced?.find(({ id }) => id === 2)).toMatchObject({ teamId: 2 });
-    }
+          await Promise.allSettled([
+            playersCache.mergePrices([{ elementId: 1, value: 53 }], [1, 2], SEASON),
+            playersCache.set(replacedRoster, SEASON),
+          ]);
+
+          const replaced = await playersCache.get(SEASON);
+          expect(replaced?.map(({ id }) => id).sort((left, right) => left - right)).toEqual([2, 3]);
+          expect(replaced?.find(({ id }) => id === 1)).toBeUndefined();
+          expect(replaced?.find(({ id }) => id === 2)).toMatchObject({ teamId: 2 });
+        }
+      } finally {
+        if (previousActiveSeason === null) {
+          await redis.del(ACTIVE_SEASON_KEY);
+        } else {
+          await redis.set(ACTIVE_SEASON_KEY, previousActiveSeason);
+        }
+        resetActiveSeasonMemo();
+      }
+    });
   });
 });

--- a/tests/integration/teams.test.ts
+++ b/tests/integration/teams.test.ts
@@ -6,10 +6,11 @@ import { beforeAll, describe, expect, test } from 'bun:test';
 import { teams } from '../../src/db/schemas/index.schema';
 import { getDb } from '../../src/db/singleton';
 import { syncTeams } from '../../src/services/teams.service';
+import { ensureCoreSnapshot } from './helpers/reference-data';
 
 describe('Teams Integration Tests', () => {
   beforeAll(async () => {
-    // Sync teams once
+    await ensureCoreSnapshot();
     await syncTeams();
   });
 

--- a/tests/integration/tournament-sync-checkpoints.test.ts
+++ b/tests/integration/tournament-sync-checkpoints.test.ts
@@ -4,8 +4,8 @@ assertIntegrationEnv();
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 
-import { redisSingleton } from '../../src/cache/singleton';
 import { resetActiveSeasonMemo } from '../../src/cache/cache-season';
+import { redisSingleton } from '../../src/cache/singleton';
 import { getDbClient } from '../../src/db/singleton';
 import { entryEventCupResultsRepository } from '../../src/repositories/entry-event-cup-results';
 import {
@@ -34,6 +34,7 @@ const PICK_PLAYER_ID = 99_042_101;
 const TRANSFER_PLAYER_ID = 99_042_102;
 const SOURCE_PLAYER_ID = 99_042_103;
 const TEST_SEASON = '2526';
+let previousActiveSeason: string | null = null;
 
 async function expectBlockedByEntrySeasonLock<T>(
   operation: () => Promise<T>,
@@ -127,6 +128,7 @@ async function checkpointRow() {
 
 beforeAll(async () => {
   const redis = await redisSingleton.getClient();
+  previousActiveSeason = await redis.get('Season:active');
   await redis.set('Season:active', TEST_SEASON);
   resetActiveSeasonMemo();
   const sql = await getDbClient();
@@ -180,6 +182,12 @@ afterAll(async () => {
   await sql`DELETE FROM teams WHERE id = ${PICK_TEAM_ID}`;
   const redis = await redisSingleton.getClient();
   await redis.hdel(`EntryInfo:${TEST_SEASON}`, String(ENTRY_ID));
+  if (previousActiveSeason !== null) {
+    await redis.set('Season:active', previousActiveSeason);
+  } else {
+    await redis.del('Season:active');
+  }
+  resetActiveSeasonMemo();
 });
 
 describe('tournament initialization checkpoints', () => {

--- a/tests/integration/upsert-correctness.test.ts
+++ b/tests/integration/upsert-correctness.test.ts
@@ -254,15 +254,16 @@ describe('affected-player current price update', () => {
       { elementId: VALUE_PLAYER_A, value: 51 },
       { elementId: VALUE_PLAYER_B, value: 99 },
     ];
-    const first = await playerRepository.updatePrices(updates);
-    const second = await playerRepository.updatePrices(updates);
+    const sourceCheckedAt = new Date('2026-08-04T00:00:00.000Z');
+    const first = await playerRepository.updatePrices(updates, sourceCheckedAt);
+    const second = await playerRepository.updatePrices(updates, sourceCheckedAt);
 
     expect(first.map((row) => row.id).sort()).toEqual([VALUE_PLAYER_A, VALUE_PLAYER_B]);
     expect(first.every((row) => row.webName.length > 0 && row.teamId === TEAM_ID)).toBe(true);
     expect(second.map((row) => row.price).sort((a, b) => a - b)).toEqual([51, 99]);
 
-    const stored = await client<{ id: number; price: number }[]>`
-      SELECT id, price
+    const stored = await client<{ id: number; price: number; price_source_checked_at: Date }[]>`
+      SELECT id, price, price_source_checked_at
       FROM players
       WHERE id IN (${VALUE_PLAYER_A}, ${VALUE_PLAYER_B}, ${PLAYER_OUT})
       ORDER BY id
@@ -270,5 +271,8 @@ describe('affected-player current price update', () => {
     expect(stored.find((row) => row.id === VALUE_PLAYER_A)?.price).toBe(51);
     expect(stored.find((row) => row.id === VALUE_PLAYER_B)?.price).toBe(99);
     expect(stored.find((row) => row.id === PLAYER_OUT)?.price).toBe(77);
+    expect(
+      new Date(String(stored.find((row) => row.id === VALUE_PLAYER_A)?.price_source_checked_at)),
+    ).toEqual(sourceCheckedAt);
   });
 });

--- a/tests/integration/upsert-correctness.test.ts
+++ b/tests/integration/upsert-correctness.test.ts
@@ -275,4 +275,31 @@ describe('affected-player current price update', () => {
       new Date(String(stored.find((row) => row.id === VALUE_PLAYER_A)?.price_source_checked_at)),
     ).toEqual(sourceCheckedAt);
   });
+
+  test('does not let an older price source overwrite a newer checkpoint', async () => {
+    const client = await db();
+    const newerSourceCheckedAt = new Date('2026-08-05T00:00:00.000Z');
+    const olderSourceCheckedAt = new Date('2026-08-04T00:00:00.000Z');
+    const currentPrice = 111;
+
+    await client`
+      UPDATE players
+      SET price = ${currentPrice}, price_source_checked_at = ${newerSourceCheckedAt}
+      WHERE id = ${VALUE_PLAYER_A}
+    `;
+
+    const updated = await playerRepository.updatePrices(
+      [{ elementId: VALUE_PLAYER_A, value: currentPrice + 1 }],
+      olderSourceCheckedAt,
+    );
+
+    expect(updated).toEqual([]);
+    const stored = await client<{ price: number; price_source_checked_at: Date }[]>`
+      SELECT price, price_source_checked_at
+      FROM players
+      WHERE id = ${VALUE_PLAYER_A}
+    `;
+    expect(stored[0]?.price).toBe(currentPrice);
+    expect(stored[0]?.price_source_checked_at).toEqual(newerSourceCheckedAt);
+  });
 });

--- a/tests/integration/upsert-correctness.test.ts
+++ b/tests/integration/upsert-correctness.test.ts
@@ -282,12 +282,12 @@ describe('affected-player current price update', () => {
     const olderSourceCheckedAt = new Date('2026-08-04T00:00:00.000Z');
     const currentPrice = 111;
 
-    await client`
-      UPDATE players
-      SET price = ${currentPrice},
-          price_source_checked_at = ${newerSourceCheckedAt.toISOString()}::timestamptz
-      WHERE id = ${VALUE_PLAYER_A}
-    `;
+    const currentPlayer = (await playerRepository.findByIds([VALUE_PLAYER_A]))[0];
+    if (!currentPlayer) throw new Error('checkpoint player fixture is missing');
+    await playerRepository.upsertBatch(
+      [{ ...currentPlayer, price: currentPrice }],
+      newerSourceCheckedAt,
+    );
 
     const updated = await playerRepository.updatePrices(
       [{ elementId: VALUE_PLAYER_A, value: currentPrice + 1 }],

--- a/tests/integration/upsert-correctness.test.ts
+++ b/tests/integration/upsert-correctness.test.ts
@@ -301,6 +301,6 @@ describe('affected-player current price update', () => {
       WHERE id = ${VALUE_PLAYER_A}
     `;
     expect(stored[0]?.price).toBe(currentPrice);
-    expect(stored[0]?.price_source_checked_at).toEqual(newerSourceCheckedAt);
+    expect(new Date(String(stored[0]?.price_source_checked_at))).toEqual(newerSourceCheckedAt);
   });
 });

--- a/tests/integration/upsert-correctness.test.ts
+++ b/tests/integration/upsert-correctness.test.ts
@@ -284,7 +284,8 @@ describe('affected-player current price update', () => {
 
     await client`
       UPDATE players
-      SET price = ${currentPrice}, price_source_checked_at = ${newerSourceCheckedAt}
+      SET price = ${currentPrice},
+          price_source_checked_at = ${newerSourceCheckedAt.toISOString()}::timestamptz
       WHERE id = ${VALUE_PLAYER_A}
     `;
 

--- a/tests/unit/api-handlers.test.ts
+++ b/tests/unit/api-handlers.test.ts
@@ -41,17 +41,15 @@ mock.module('../../src/services/job-trigger.service', () => ({
 }));
 
 const enqueueEventsSyncJob = mock(async () => ({ id: 'events-job-1' }));
-const enqueueFixturesSyncJob = mock(async () => ({ id: 'fixtures-job-1' }));
-const enqueueFixturesAllGameweeksSyncJob = mock(async () => ({ id: 'fixtures-all-gw-job-1' }));
+const enqueueCoreSnapshotJob = mock(async () => ({ id: 'core-snapshot-job-1' }));
 const enqueuePlayersSyncJob = mock(async () => ({ id: 'players-job-1' }));
 const enqueuePlayerValuesSyncJob = mock(async () => ({ id: 'player-values-job-1' }));
 const enqueuePlayerStatsSyncJob = mock(async () => ({ id: 'player-stats-job-1' }));
 const enqueueTeamsSyncJob = mock(async () => ({ id: 'teams-job-1' }));
 const enqueuePhasesSyncJob = mock(async () => ({ id: 'phases-job-1' }));
 mock.module('../../src/jobs/data-sync-enqueue', () => ({
+  enqueueCoreSnapshotJob,
   enqueueEventsSyncJob,
-  enqueueFixturesSyncJob,
-  enqueueFixturesAllGameweeksSyncJob,
   enqueuePlayersSyncJob,
   enqueuePlayerValuesSyncJob,
   enqueuePlayerStatsSyncJob,
@@ -183,7 +181,7 @@ describe('eventsAPI handlers', () => {
   beforeEach(() => {
     getCurrentEvent.mockClear();
     getNextEvent.mockClear();
-    enqueueEventsSyncJob.mockClear();
+    enqueueCoreSnapshotJob.mockClear();
   });
 
   test('GET /events/current returns current event payload', async () => {
@@ -197,26 +195,26 @@ describe('eventsAPI handlers', () => {
     expect(getCurrentEvent).toHaveBeenCalledTimes(1);
   });
 
-  test('POST /events/sync enqueues the events sync job and returns 202', async () => {
+  test('POST /events/sync enqueues the complete core snapshot and returns 202', async () => {
     const response = await eventsAPI.handle(
       new Request('http://localhost/events/sync', { method: 'POST' }),
     );
     expect(response.status).toBe(202);
     const body = (await response.json()) as { success: boolean; jobId: string };
     expect(body.success).toBe(true);
-    expect(body.jobId).toBe('events-job-1');
-    expect(enqueueEventsSyncJob).toHaveBeenCalledWith('api');
+    expect(body.jobId).toBe('core-snapshot-job-1');
+    expect(enqueueCoreSnapshotJob).toHaveBeenCalledWith('api');
   });
 });
 
 describe('playersAPI handlers', () => {
-  test('POST /players/sync enqueues the shared-lock players job', async () => {
+  test('POST /players/sync enqueues the complete core snapshot', async () => {
     const response = await playersAPI.handle(
       new Request('http://localhost/players/sync', { method: 'POST' }),
     );
     expect(response.status).toBe(202);
-    expect(await response.json()).toMatchObject({ success: true, jobId: 'players-job-1' });
-    expect(enqueuePlayersSyncJob).toHaveBeenCalledWith('api');
+    expect(await response.json()).toMatchObject({ success: true, jobId: 'core-snapshot-job-1' });
+    expect(enqueueCoreSnapshotJob).toHaveBeenCalledWith('api');
   });
 });
 
@@ -353,20 +351,19 @@ describe('entrySyncAPI handlers', () => {
 
 describe('fixturesAPI handlers', () => {
   beforeEach(() => {
-    enqueueFixturesSyncJob.mockClear();
-    enqueueFixturesAllGameweeksSyncJob.mockClear();
+    enqueueCoreSnapshotJob.mockClear();
     clearFixturesCache.mockClear();
   });
 
-  test('POST /fixtures/sync enqueues the fixtures job and returns 202', async () => {
+  test('POST /fixtures/sync enqueues the complete core snapshot and returns 202', async () => {
     const response = await fixturesAPI.handle(
       new Request('http://localhost/fixtures/sync', { method: 'POST' }),
     );
     expect(response.status).toBe(202);
     const body = (await response.json()) as { success: boolean; jobId: string };
     expect(body.success).toBe(true);
-    expect(body.jobId).toBe('fixtures-job-1');
-    expect(enqueueFixturesSyncJob).toHaveBeenCalledWith('api', {});
+    expect(body.jobId).toBe('core-snapshot-job-1');
+    expect(enqueueCoreSnapshotJob).toHaveBeenCalledWith('api');
   });
 
   test('POST /fixtures/sync?event= coerces a numeric event filter', async () => {
@@ -374,7 +371,7 @@ describe('fixturesAPI handlers', () => {
       new Request('http://localhost/fixtures/sync?event=12', { method: 'POST' }),
     );
     expect(response.status).toBe(202);
-    expect(enqueueFixturesSyncJob).toHaveBeenCalledWith('api', { eventId: 12 });
+    expect(enqueueCoreSnapshotJob).toHaveBeenCalledWith('api', { eventId: 12 });
   });
 
   test('POST /fixtures/sync rejects a non-numeric event filter', async () => {
@@ -382,16 +379,15 @@ describe('fixturesAPI handlers', () => {
       new Request('http://localhost/fixtures/sync?event=abc', { method: 'POST' }),
     );
     expect(response.status).toBe(422);
-    expect(enqueueFixturesSyncJob).not.toHaveBeenCalled();
+    expect(enqueueCoreSnapshotJob).not.toHaveBeenCalled();
   });
 
-  test('POST /fixtures/sync-all-gameweeks enqueues the per-GW backfill and returns 202', async () => {
+  test('POST /fixtures/sync-all-gameweeks enqueues one complete core snapshot', async () => {
     const response = await fixturesAPI.handle(
       new Request('http://localhost/fixtures/sync-all-gameweeks', { method: 'POST' }),
     );
     expect(response.status).toBe(202);
-    expect(enqueueFixturesAllGameweeksSyncJob).toHaveBeenCalledWith('api');
-    expect(enqueueFixturesSyncJob).not.toHaveBeenCalled();
+    expect(enqueueCoreSnapshotJob).toHaveBeenCalledWith('api');
   });
 
   test('DELETE /fixtures/cache clears the cache', async () => {
@@ -640,10 +636,9 @@ describe('entryInfoAPI handlers', () => {
   });
 });
 
-describe('queued core repair APIs', () => {
+describe('queued core snapshot compatibility APIs', () => {
   beforeEach(() => {
-    enqueueTeamsSyncJob.mockClear();
-    enqueuePhasesSyncJob.mockClear();
+    enqueueCoreSnapshotJob.mockClear();
   });
 
   test('POST /teams/sync returns the queued job contract', async () => {
@@ -654,10 +649,10 @@ describe('queued core repair APIs', () => {
     expect(await response.json()).toEqual({
       success: true,
       status: 'queued',
-      jobId: 'teams-job-1',
-      message: 'Teams sync queued',
+      jobId: 'core-snapshot-job-1',
+      message: 'Core snapshot queued',
     });
-    expect(enqueueTeamsSyncJob).toHaveBeenCalledWith('api');
+    expect(enqueueCoreSnapshotJob).toHaveBeenCalledWith('api');
   });
 
   test('POST /phases/sync returns the queued job contract', async () => {
@@ -668,9 +663,9 @@ describe('queued core repair APIs', () => {
     expect(await response.json()).toEqual({
       success: true,
       status: 'queued',
-      jobId: 'phases-job-1',
-      message: 'Phases sync queued',
+      jobId: 'core-snapshot-job-1',
+      message: 'Core snapshot queued',
     });
-    expect(enqueuePhasesSyncJob).toHaveBeenCalledWith('api');
+    expect(enqueueCoreSnapshotJob).toHaveBeenCalledWith('api');
   });
 });

--- a/tests/unit/cache-hygiene.test.ts
+++ b/tests/unit/cache-hygiene.test.ts
@@ -6,9 +6,11 @@ import {
   finalizeSeasonCacheWrite,
   getActiveCacheSeason,
   getActiveCacheSeasonUncached,
+  readStoredActiveCacheSeason,
+  rememberCoreSnapshotActiveSeason,
   resetActiveSeasonMemo,
   SEASON_CACHE_PREFIXES,
-  setActiveCacheSeason,
+  withActiveSeasonWriteFence,
 } from '../../src/cache/cache-season';
 import { parseHashEntries, parseHashValues } from '../../src/cache/hash-read';
 import { redisSingleton } from '../../src/cache/singleton';
@@ -165,31 +167,26 @@ describe('getActiveCacheSeason memo', () => {
     expect(redis.get).toHaveBeenCalledTimes(2);
   });
 
-  test('setActiveCacheSeason refreshes the memo on rollover', async () => {
-    const redis = installFakeRedis({ get: async () => '2526' });
-    expect(await setActiveCacheSeason('2627')).toBe(true);
-    expect(redis.set).toHaveBeenCalledWith('Season:active', '2627');
+  test('core snapshot publication refreshes the memo after its Redis transaction', async () => {
+    const redis = installFakeRedis({ get: async () => '2627' });
+    rememberCoreSnapshotActiveSeason('2627');
     expect(await getActiveCacheSeason()).toBe('2627');
-    // Preflight and exclusive-fence recheck hit Redis; the memo served the getter.
-    expect(redis.get).toHaveBeenCalledTimes(2);
+    expect(redis.get).not.toHaveBeenCalled();
   });
 
-  test('skipped update re-arms the memo from Redis truth', async () => {
-    const redis = installFakeRedis({ get: async () => '2627' });
-    expect(await setActiveCacheSeason('2526')).toBe(false);
-    expect(await getActiveCacheSeason()).toBe('2627');
+  test('raw active-season reads return null for missing or malformed values', async () => {
+    const redis = installFakeRedis({ get: async () => 'bad' });
+    expect(await readStoredActiveCacheSeason()).toBeNull();
     expect(redis.get).toHaveBeenCalledTimes(1);
   });
 
-  test('rechecks Redis truth after waiting for the exclusive rollover fence', async () => {
-    let reads = 0;
-    const redis = installFakeRedis({
-      get: async () => (++reads === 1 ? '2526' : '2728'),
-    });
-
-    expect(await setActiveCacheSeason('2627')).toBe(false);
-    expect(redis.set).not.toHaveBeenCalled();
-    expect(await getActiveCacheSeason()).toBe('2728');
+  test('runs active-season authority changes behind the exclusive database fence', async () => {
+    const isolatedDb = {
+      transaction: async (operation: (tx: { execute: typeof seasonFenceExecute }) => unknown) =>
+        operation({ execute: seasonFenceExecute }),
+    } as never;
+    await expect(withActiveSeasonWriteFence(async () => 'done', isolatedDb)).resolves.toBe('done');
+    expect(seasonFenceExecute).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -240,20 +237,17 @@ describe('season rollover cleanup', () => {
     expect(redis.del.mock.calls[0]).not.toContain('PlayerValue:2526');
   });
 
-  test('cleans every family when the first core write advances the season', async () => {
+  test('partial writers can publish only into the already active season', async () => {
     const redis = installFakeRedis({
       get: async () => '2526',
-      scan: async (...args) => {
-        const pattern = String(args[2]);
-        return ['0', pattern === 'EventOverallResult:*' ? ['EventOverallResult:2526'] : []];
-      },
-      del: async (...deletedKeys) => deletedKeys.length,
     });
 
-    await finalizeSeasonCacheWrite('2627', ['Event']);
+    await expect(finalizeSeasonCacheWrite('2627', ['Event'])).rejects.toThrow(
+      'Core snapshot required',
+    );
+    await expect(finalizeSeasonCacheWrite('2526', ['Event'])).resolves.toBeUndefined();
 
-    expect(redis.set).toHaveBeenCalledWith('Season:active', '2627');
-    expect(redis.scan).toHaveBeenCalledTimes(SEASON_CACHE_PREFIXES.length);
-    expect(redis.del).toHaveBeenCalledWith('EventOverallResult:2526');
+    expect(redis.set).not.toHaveBeenCalled();
+    expect(redis.scan).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/cache-season.test.ts
+++ b/tests/unit/cache-season.test.ts
@@ -4,6 +4,7 @@ import {
   deriveSeasonFromEvents,
   deriveSeasonFromFixtures,
   isNewerSeason,
+  resolveFixtureRepairSeason,
   seasonFromStartYear,
 } from '../../src/cache/cache-season';
 import { mockRawFPLFixture1 } from '../fixtures/fixtures.fixtures';
@@ -66,6 +67,21 @@ describe('cache season resolver', () => {
         },
       ]),
     ).toBeNull();
+  });
+
+  test('uses an authoritative season for event repairs and rejects mixed sources', () => {
+    const laterEvent = [{ ...mockRawFPLFixture1, event: 12 }];
+    expect(resolveFixtureRepairSeason(laterEvent, '2627')).toBe('2627');
+    expect(resolveFixtureRepairSeason(laterEvent, null)).toBeNull();
+
+    const conflictingGw1 = [
+      {
+        ...mockRawFPLFixture1,
+        event: 1,
+        kickoff_time: '2025-08-14T19:00:00Z',
+      },
+    ];
+    expect(resolveFixtureRepairSeason(conflictingGw1, '2627')).toBeNull();
   });
 
   test('compares season keys numerically', () => {

--- a/tests/unit/core-fixture-derivatives.test.ts
+++ b/tests/unit/core-fixture-derivatives.test.ts
@@ -50,6 +50,7 @@ describe('core fixture derivative reconciliation', () => {
         },
         serializeEvents: async (eventIds, operation) => {
           serializedEventIds.push([...eventIds]);
+          expect(requestedFixtureIds).toHaveLength(0);
           await operation();
         },
       },

--- a/tests/unit/core-fixture-derivatives.test.ts
+++ b/tests/unit/core-fixture-derivatives.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+
+import { reconcileCoreFixtureDerivatives } from '../../src/services/core-fixture-derivatives.service';
+
+import type { Fixture } from '../../src/types';
+
+function fixture(event: number): Fixture {
+  return {
+    id: 100 + event,
+    code: 100 + event,
+    event,
+    finished: false,
+    finishedProvisional: false,
+    kickoffTime: new Date('2026-08-15T12:00:00.000Z'),
+    minutes: 0,
+    provisionalStartTime: false,
+    started: false,
+    teamA: 1,
+    teamAScore: null,
+    teamH: 2,
+    teamHScore: null,
+    stats: [],
+    teamHDifficulty: 2,
+    teamADifficulty: 3,
+    pulseId: 100 + event,
+    createdAt: null,
+    updatedAt: null,
+  };
+}
+
+describe('core fixture derivative reconciliation', () => {
+  test('checks canonical fixture rows through the coordinated ownership adapter', async () => {
+    const refreshed: Array<{ eventId: number; fixtureIds: number[] }> = [];
+    const requestedFixtureIds: number[][] = [];
+    const serializedEventIds: number[][] = [];
+    const result = await reconcileCoreFixtureDerivatives(
+      [112],
+      new Date('2026-08-04T00:00:00.000Z'),
+      {
+        findByIds: async (fixtureIds) => {
+          requestedFixtureIds.push([...fixtureIds]);
+          return [fixture(12)];
+        },
+        coordinator: {
+          retire: async (eventId) => ({ eventId, removedKeys: 0 }),
+          refreshFixtureDerivatives: async (eventId, fixtures) => {
+            refreshed.push({ eventId, fixtureIds: fixtures.map((item) => item.id) });
+            return { eventId, owned: true, retired: true };
+          },
+        },
+        serializeEvents: async (eventIds, operation) => {
+          serializedEventIds.push([...eventIds]);
+          await operation();
+        },
+      },
+    );
+
+    expect(result).toEqual({ checkedEvents: 38, retiredEmptyEvents: 0 });
+    expect(requestedFixtureIds).toEqual([[112]]);
+    expect(serializedEventIds).toEqual([Array.from({ length: 38 }, (_, index) => index + 1)]);
+    expect(refreshed).toEqual([{ eventId: 12, fixtureIds: [112] }]);
+  });
+
+  test('retires empty event views even when no ownership metadata exists', async () => {
+    const retired: number[] = [];
+    const result = await reconcileCoreFixtureDerivatives([], new Date('2026-08-04T00:00:00.000Z'), {
+      findByIds: async () => [],
+      coordinator: {
+        retire: async (eventId) => {
+          retired.push(eventId);
+          return { eventId, removedKeys: eventId === 12 ? 7 : 0 };
+        },
+        refreshFixtureDerivatives: async (eventId) => ({
+          eventId,
+          owned: false,
+          retired: false,
+        }),
+      },
+      serializeEvents: async (_eventIds, operation) => operation(),
+    });
+
+    expect(result).toEqual({ checkedEvents: 38, retiredEmptyEvents: 1 });
+    expect(retired).toEqual(Array.from({ length: 38 }, (_, index) => index + 1));
+  });
+});

--- a/tests/unit/core-snapshot.test.ts
+++ b/tests/unit/core-snapshot.test.ts
@@ -123,6 +123,7 @@ describe('core snapshot validation', () => {
 describe('core snapshot synchronization', () => {
   function dependencies(options?: {
     activeSeason?: string | null;
+    activeSeasons?: (string | null)[];
     persist?: () => Promise<unknown>;
     publish?: () => Promise<{ published: boolean }>;
     cleanup?: () => Promise<void>;
@@ -131,6 +132,7 @@ describe('core snapshot synchronization', () => {
   }): CoreSnapshotDependencies {
     const input = buildCoreSnapshotFixture();
     const calls = options?.calls ?? [];
+    let activeSeasonReads = 0;
     return {
       getBootstrap: async () => {
         calls.push('bootstrap');
@@ -140,7 +142,14 @@ describe('core snapshot synchronization', () => {
         calls.push('fixtures');
         return input.fixtures;
       },
-      getActiveSeason: async () => options?.activeSeason ?? null,
+      getActiveSeason: async () => {
+        const sequence = options?.activeSeasons;
+        if (sequence && activeSeasonReads < sequence.length) {
+          return sequence[activeSeasonReads++];
+        }
+        activeSeasonReads += 1;
+        return options?.activeSeason ?? '2627';
+      },
       readOrderingTimestamp: async () => {
         calls.push('ordering-timestamp');
         return new Date('2026-08-04T00:00:00.000Z');
@@ -217,6 +226,16 @@ describe('core snapshot synchronization', () => {
     expect(result.outcome).toBe('noop');
     expect(calls).not.toContain('persist');
     expect(calls).not.toContain('publish');
+    expect(calls).not.toContain('cleanup');
+  });
+
+  test('skips stale-season cleanup when authority changes after commit', async () => {
+    const calls: string[] = [];
+    const result = await syncCoreSnapshot(
+      dependencies({ calls, activeSeasons: ['2627', '2728'] }),
+    );
+
+    expect(result.outcome).toBe('ready');
     expect(calls).not.toContain('cleanup');
   });
 

--- a/tests/unit/core-snapshot.test.ts
+++ b/tests/unit/core-snapshot.test.ts
@@ -231,9 +231,7 @@ describe('core snapshot synchronization', () => {
 
   test('skips stale-season cleanup when authority changes after commit', async () => {
     const calls: string[] = [];
-    const result = await syncCoreSnapshot(
-      dependencies({ calls, activeSeasons: ['2627', '2728'] }),
-    );
+    const result = await syncCoreSnapshot(dependencies({ calls, activeSeasons: ['2627', '2728'] }));
 
     expect(result.outcome).toBe('ready');
     expect(calls).not.toContain('cleanup');

--- a/tests/unit/core-snapshot.test.ts
+++ b/tests/unit/core-snapshot.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildCoreSnapshotCachePlan } from '../../src/cache/core-snapshot-cache';
+import {
+  CORE_SNAPSHOT_MIN_PLAYERS_PER_TEAM,
+  prepareCoreSnapshot,
+} from '../../src/domain/core-snapshot';
+import { CacheError } from '../../src/utils/errors';
+import {
+  syncCoreSnapshot,
+  type CoreSnapshotDependencies,
+  type CoreSnapshotMilestone,
+} from '../../src/services/core-snapshot.service';
+import { buildCoreSnapshotFixture } from '../fixtures/core-snapshot.fixtures';
+
+describe('core snapshot validation', () => {
+  test('accepts one complete 38/20/players/phases/380 snapshot', () => {
+    const input = buildCoreSnapshotFixture();
+    const snapshot = prepareCoreSnapshot(input.bootstrap, input.fixtures);
+
+    expect(snapshot.season).toBe('2627');
+    expect(snapshot.events).toHaveLength(38);
+    expect(snapshot.teams).toHaveLength(20);
+    expect(snapshot.players).toHaveLength(220);
+    expect(snapshot.phases).toHaveLength(1);
+    expect(snapshot.fixtures).toHaveLength(380);
+
+    const plan = buildCoreSnapshotCachePlan(snapshot);
+    expect(plan.hashes.get('Event:2627')).toHaveProperty('38');
+    expect(plan.hashes.get('Team:2627')).toHaveProperty('20');
+    expect(plan.hashes.get('Player:2627')).toHaveProperty('220');
+    expect([...plan.hashes.keys()].filter((key) => key.startsWith('Fixtures:2627:'))).toHaveLength(
+      38,
+    );
+    expect(
+      [...plan.hashes.keys()].filter((key) => key.startsWith('FixturesByTeam:2627:')),
+    ).toHaveLength(20);
+  });
+
+  test('rejects incomplete counts, duplicate identifiers, and broken references', () => {
+    const missingEvent = buildCoreSnapshotFixture();
+    missingEvent.bootstrap.events.pop();
+    expect(() => prepareCoreSnapshot(missingEvent.bootstrap, missingEvent.fixtures)).toThrow(
+      'events count',
+    );
+
+    const duplicatePlayer = buildCoreSnapshotFixture();
+    duplicatePlayer.bootstrap.elements[1] = {
+      ...duplicatePlayer.bootstrap.elements[1],
+      id: duplicatePlayer.bootstrap.elements[0].id,
+    };
+    expect(() => prepareCoreSnapshot(duplicatePlayer.bootstrap, duplicatePlayer.fixtures)).toThrow(
+      'player identifiers',
+    );
+
+    const badFixture = buildCoreSnapshotFixture();
+    badFixture.fixtures[0] = { ...badFixture.fixtures[0], team_h: 99 };
+    expect(() => prepareCoreSnapshot(badFixture.bootstrap, badFixture.fixtures)).toThrow(
+      'unknown team',
+    );
+
+    const missingTeamPlayer = buildCoreSnapshotFixture();
+    missingTeamPlayer.bootstrap.elements = missingTeamPlayer.bootstrap.elements.filter(
+      (player, index) => player.team !== 20 || index === 19,
+    );
+    expect(() =>
+      prepareCoreSnapshot(missingTeamPlayer.bootstrap, missingTeamPlayer.fixtures),
+    ).toThrow('player team roster');
+
+    const mismatchedSeason = buildCoreSnapshotFixture();
+    mismatchedSeason.fixtures = mismatchedSeason.fixtures.map((fixture) => ({
+      ...fixture,
+      kickoff_time: fixture.event === 1 ? '2027-08-15T14:00:00.000Z' : fixture.kickoff_time,
+    }));
+    expect(() =>
+      prepareCoreSnapshot(mismatchedSeason.bootstrap, mismatchedSeason.fixtures),
+    ).toThrow('event and fixture seasons disagree');
+
+    const repeatedPairings = buildCoreSnapshotFixture();
+    repeatedPairings.fixtures.splice(
+      10,
+      10,
+      ...repeatedPairings.fixtures.slice(0, 10).map((fixture, index) => ({
+        ...fixture,
+        id: 11 + index,
+        code: 30_011 + index,
+        event: 2,
+      })),
+    );
+    expect(() =>
+      prepareCoreSnapshot(repeatedPairings.bootstrap, repeatedPairings.fixtures),
+    ).toThrow('home-and-away pairing');
+  });
+
+  test('requires a conservative starting-XI roster floor for every team', () => {
+    const truncated = buildCoreSnapshotFixture({ playerCount: 20 });
+    expect(() => prepareCoreSnapshot(truncated.bootstrap, truncated.fixtures)).toThrow(
+      'player team roster is incomplete',
+    );
+
+    const minimumComplete = buildCoreSnapshotFixture({
+      playerCount: CORE_SNAPSHOT_MIN_PLAYERS_PER_TEAM * 20,
+    });
+    expect(() =>
+      prepareCoreSnapshot(minimumComplete.bootstrap, minimumComplete.fixtures),
+    ).not.toThrow();
+  });
+
+  test('retains valid unassigned fixtures in the cache snapshot', () => {
+    const input = buildCoreSnapshotFixture();
+    input.fixtures[0] = { ...input.fixtures[0], event: null };
+
+    const snapshot = prepareCoreSnapshot(input.bootstrap, input.fixtures);
+    const plan = buildCoreSnapshotCachePlan(snapshot);
+
+    expect(snapshot.fixtures[0].event).toBeNull();
+    expect(plan.hashes.get('Fixtures:2627:unscheduled')).toHaveProperty(
+      String(snapshot.fixtures[0].id),
+    );
+  });
+});
+
+describe('core snapshot synchronization', () => {
+  function dependencies(options?: {
+    activeSeason?: string | null;
+    persist?: () => Promise<unknown>;
+    publish?: () => Promise<{ published: boolean }>;
+    cleanup?: () => Promise<void>;
+    calls?: string[];
+    milestones?: CoreSnapshotMilestone[];
+  }): CoreSnapshotDependencies {
+    const input = buildCoreSnapshotFixture();
+    const calls = options?.calls ?? [];
+    return {
+      getBootstrap: async () => {
+        calls.push('bootstrap');
+        return input.bootstrap;
+      },
+      getFixtures: async () => {
+        calls.push('fixtures');
+        return input.fixtures;
+      },
+      getActiveSeason: async () => options?.activeSeason ?? null,
+      readOrderingTimestamp: async () => {
+        calls.push('ordering-timestamp');
+        return new Date('2026-08-04T00:00:00.000Z');
+      },
+      reserveRevision: async () => 1,
+      createPublicationId: () => '00000000-0000-4000-8000-000000000001',
+      recoverPending: async () => undefined,
+      commit: async () => {
+        calls.push('persist');
+        await options?.persist?.();
+        calls.push('publish');
+        const publication = (await options?.publish?.()) ?? { published: true };
+        if (!publication.published) {
+          throw new CacheError(
+            'Core snapshot publication lost authority during persistence',
+            'CORE_SNAPSHOT_PUBLICATION_LOST_AUTHORITY',
+          );
+        }
+        return { status: 'committed' };
+      },
+      cleanup: async () => {
+        calls.push('cleanup');
+        await options?.cleanup?.();
+      },
+      withPersistenceLock: async (operation) => {
+        calls.push('lock');
+        expect(calls).toContain('bootstrap');
+        expect(calls).toContain('fixtures');
+        return operation();
+      },
+      onMilestone: (milestone) => options?.milestones?.push(milestone),
+    };
+  }
+
+  test('performs exactly two upstream reads before locking and publishes after persistence', async () => {
+    const calls: string[] = [];
+    const milestones: CoreSnapshotMilestone[] = [];
+    const result = await syncCoreSnapshot(dependencies({ calls, milestones }));
+
+    expect(calls.filter((call) => call === 'bootstrap')).toHaveLength(1);
+    expect(calls.filter((call) => call === 'fixtures')).toHaveLength(1);
+    expect(calls.indexOf('ordering-timestamp')).toBeLessThan(calls.indexOf('bootstrap'));
+    expect(calls.indexOf('lock')).toBeGreaterThan(calls.indexOf('fixtures'));
+    expect(calls.indexOf('persist')).toBeLessThan(calls.indexOf('publish'));
+    expect(calls.indexOf('publish')).toBeLessThan(calls.indexOf('cleanup'));
+    expect(milestones).toEqual(['fetched', 'validated', 'locked', 'persisted', 'published']);
+    expect(result).toMatchObject({
+      outcome: 'ready',
+      events: 38,
+      teams: 20,
+      fixtures: 380,
+      failedUnits: 0,
+    });
+  });
+
+  test('never publishes after persistence fails', async () => {
+    const calls: string[] = [];
+    await expect(
+      syncCoreSnapshot(
+        dependencies({
+          calls,
+          persist: async () => {
+            throw new Error('database unavailable');
+          },
+        }),
+      ),
+    ).rejects.toThrow('database unavailable');
+    expect(calls).not.toContain('publish');
+  });
+
+  test('does not persist a snapshot older than the active season', async () => {
+    const calls: string[] = [];
+    const result = await syncCoreSnapshot(dependencies({ calls, activeSeason: '2728' }));
+    expect(result.outcome).toBe('noop');
+    expect(calls).not.toContain('persist');
+    expect(calls).not.toContain('publish');
+    expect(calls).not.toContain('cleanup');
+  });
+
+  test('fails the attempt when publication loses authority after persistence', async () => {
+    const calls: string[] = [];
+    await expect(
+      syncCoreSnapshot(
+        dependencies({
+          calls,
+          publish: async () => ({ published: false }),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'CORE_SNAPSHOT_PUBLICATION_LOST_AUTHORITY' });
+    expect(calls.indexOf('persist')).toBeLessThan(calls.indexOf('publish'));
+  });
+});

--- a/tests/unit/core-snapshot.test.ts
+++ b/tests/unit/core-snapshot.test.ts
@@ -118,6 +118,25 @@ describe('core snapshot validation', () => {
       String(snapshot.fixtures[0].id),
     );
   });
+
+  test('omits empty per-team views when every fixture is unassigned', () => {
+    const input = buildCoreSnapshotFixture();
+    input.fixtures = input.fixtures.map((fixture, index) => ({
+      ...fixture,
+      // Keep one GW1 kickoff so fixture-season derivation remains valid while
+      // leaving most team views empty for this cache-plan regression.
+      event: index === 0 ? 1 : null,
+    }));
+
+    const snapshot = prepareCoreSnapshot(input.bootstrap, input.fixtures);
+    const plan = buildCoreSnapshotCachePlan(snapshot);
+
+    const teamHashes = [...plan.hashes.keys()].filter((key) => key.startsWith('FixturesByTeam:'));
+    expect(teamHashes).toHaveLength(2);
+    expect(teamHashes).toEqual(
+      expect.arrayContaining(['FixturesByTeam:2627:1', 'FixturesByTeam:2627:20']),
+    );
+  });
 });
 
 describe('core snapshot synchronization', () => {

--- a/tests/unit/data-sync-enqueue.test.ts
+++ b/tests/unit/data-sync-enqueue.test.ts
@@ -4,6 +4,7 @@ import {
   createDataSyncJobData,
   defaultDataSyncJobId,
 } from '../../src/jobs/data-sync-job-definition';
+import { getCoreSnapshotJobId } from '../../src/jobs/data-sync-enqueue';
 
 describe('data-sync enqueue correlation', () => {
   test('keeps a deterministic queue ID but gives settled executions distinct run IDs', () => {
@@ -13,5 +14,11 @@ describe('data-sync enqueue correlation', () => {
     expect(defaultDataSyncJobId('teams', 'api', {})).toBe('teams-api');
     expect(first.runId).toMatch(/^[0-9a-f-]{36}$/);
     expect(second.runId).not.toBe(first.runId);
+  });
+
+  test('does not dedupe an event transition behind the repair job', () => {
+    expect(getCoreSnapshotJobId('event-transition')).toBeUndefined();
+    expect(getCoreSnapshotJobId('manual')).toBe('core-snapshot-repair');
+    expect(getCoreSnapshotJobId('event-transition', { jobId: 'explicit-id' })).toBe('explicit-id');
   });
 });

--- a/tests/unit/job-trigger.service.test.ts
+++ b/tests/unit/job-trigger.service.test.ts
@@ -11,7 +11,7 @@ describe('job-trigger service', () => {
   test('lists known triggerable jobs', () => {
     const jobs = listTriggerableJobs();
     expect(jobs.length).toBeGreaterThan(0);
-    expect(jobs.some((job) => job.name === 'events-sync')).toBe(true);
+    expect(jobs.some((job) => job.name === 'core-snapshot-sync')).toBe(true);
     expect(jobs.some((job) => job.name === 'player-prices')).toBe(true);
     expect(jobs.every((job) => job.name && job.description && job.schedule)).toBe(true);
   });

--- a/tests/unit/migration-history.test.ts
+++ b/tests/unit/migration-history.test.ts
@@ -89,3 +89,17 @@ describe('tournament lifecycle progress migration', () => {
     expect(migration).toMatch(/FROM public\.tournament_knockouts/);
   });
 });
+
+describe('core snapshot authority migration', () => {
+  test('installs a singleton revision authority outside the client Data API', () => {
+    const migration = readFileSync('migrations/0045_core_snapshot_authority.sql', 'utf8');
+
+    expect(migration).toContain('core_snapshot_revision_seq');
+    expect(migration).toContain('core_snapshot_authority');
+    expect(migration).toContain('CHECK (singleton_id = 1)');
+    expect(migration).toContain('ENABLE ROW LEVEL SECURITY');
+    expect(migration).toContain('REVOKE ALL ON TABLE');
+    expect(migration).toContain('REVOKE ALL ON SEQUENCE');
+    expect(migration).toContain('price_source_checked_at');
+  });
+});

--- a/tests/unit/migration-history.test.ts
+++ b/tests/unit/migration-history.test.ts
@@ -92,7 +92,7 @@ describe('tournament lifecycle progress migration', () => {
 
 describe('core snapshot authority migration', () => {
   test('installs a singleton revision authority outside the client Data API', () => {
-    const migration = readFileSync('migrations/0045_core_snapshot_authority.sql', 'utf8');
+    const migration = readFileSync('migrations/0049_core_snapshot_authority.sql', 'utf8');
 
     expect(migration).toContain('core_snapshot_revision_seq');
     expect(migration).toContain('core_snapshot_authority');

--- a/tests/unit/mutation-scope.test.ts
+++ b/tests/unit/mutation-scope.test.ts
@@ -30,7 +30,7 @@ describe('resolveMutationScopes', () => {
     ]);
   });
 
-  it('serializes the snapshot fixture write with ordinary fixture syncs', () => {
+  it('maps legacy fixture jobs to the complete core snapshot scopes', () => {
     const snapshotScopes = resolveMutationScopes({
       queueName: 'live-data-p0',
       jobName: 'live-snapshot',
@@ -44,18 +44,24 @@ describe('resolveMutationScopes', () => {
 
     expect(snapshotScopes).toContain('data-core:fixtures');
     expect(snapshotScopes).toContain('live-snapshot:event:33');
-    expect(fixtureScopes).toEqual(['data-core:fixtures']);
+    expect(fixtureScopes).toEqual([
+      'data-core:events',
+      'data-core:teams',
+      'data-core:players',
+      'data-core:phases',
+      'data-core:fixtures',
+    ]);
   });
 
-  it('serializes partial price updates with the full players sync', () => {
+  it('keeps partial price updates inside the complete legacy player alias scope', () => {
     const fullSync = resolveMutationScopes({ queueName: 'data-sync-p1', jobName: 'players' });
     const priceSync = resolveMutationScopes({
       queueName: 'data-sync-p1',
       jobName: 'player-prices',
     });
 
-    expect(fullSync).toEqual(['data-core:players']);
-    expect(priceSync).toEqual(fullSync);
+    expect(fullSync).toContain('data-core:players');
+    expect(priceSync).toEqual(['data-core:players']);
   });
 
   it('adds event-scoped conflict groups for league event results', () => {

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -4,6 +4,9 @@ import { createPlayerPricesSync } from '../../src/services/player-prices.service
 import type { Player } from '../../src/types';
 import { singleRawFPLElementFixture } from '../fixtures/player-values.fixtures';
 
+const sourceCheckedAt = new Date('2026-08-04T00:00:00.000Z');
+const readOrderingTimestamp = async () => sourceCheckedAt;
+
 const stored = (
   elementId: number,
   value: number,
@@ -65,13 +68,17 @@ describe('player-prices sync', () => {
       getBootstrap,
       updatePrices,
       mergePlayerPricesCache,
+      readOrderingTimestamp,
     });
 
     expect(await sync('20260803')).toEqual({ count: 2, changeDate: '20260803' });
-    expect(updatePrices).toHaveBeenCalledWith([
-      { elementId: 2, value: 61 },
-      { elementId: 3, value: 49 },
-    ]);
+    expect(updatePrices).toHaveBeenCalledWith(
+      [
+        { elementId: 2, value: 61 },
+        { elementId: 3, value: 49 },
+      ],
+      sourceCheckedAt,
+    );
     expect(getBootstrap).toHaveBeenCalledTimes(1);
     expect(findLatestForPlayerIds).toHaveBeenCalledWith([2, 3], '20260601', '20270601');
     expect(mergePlayerPricesCache).toHaveBeenCalledWith(
@@ -93,10 +100,11 @@ describe('player-prices sync', () => {
       getBootstrap: async () => bootstrap([1, 2]),
       updatePrices,
       mergePlayerPricesCache: async () => undefined,
+      readOrderingTimestamp,
     });
 
     await sync('20260803');
-    expect(updatePrices).toHaveBeenCalledWith([{ elementId: 2, value: 63 }]);
+    expect(updatePrices).toHaveBeenCalledWith([{ elementId: 2, value: 63 }], sourceCheckedAt);
   });
 
   test('skips cleanly when a date contains only Start rows', async () => {
@@ -109,6 +117,7 @@ describe('player-prices sync', () => {
       getBootstrap,
       updatePrices,
       mergePlayerPricesCache,
+      readOrderingTimestamp,
     });
 
     expect(await sync('20260802')).toEqual({ count: 0, changeDate: '20260802' });
@@ -127,6 +136,7 @@ describe('player-prices sync', () => {
       getBootstrap: async () => bootstrap([1, 3]),
       updatePrices,
       mergePlayerPricesCache,
+      readOrderingTimestamp,
     });
 
     expect(await sync('20260803')).toEqual({ count: 0, changeDate: '20260803' });
@@ -152,6 +162,7 @@ describe('player-prices sync', () => {
       getBootstrap: async () => validBootstrap as never,
       updatePrices: async () => [player(2, 61)],
       mergePlayerPricesCache,
+      readOrderingTimestamp,
     });
 
     expect(await sync('20260803')).toEqual({ count: 1, changeDate: '20260803' });

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -80,7 +80,12 @@ describe('player-prices sync', () => {
       sourceCheckedAt,
     );
     expect(getBootstrap).toHaveBeenCalledTimes(1);
-    expect(findLatestForPlayerIds).toHaveBeenCalledWith([2, 3], '20260601', '20270601');
+    expect(findLatestForPlayerIds).toHaveBeenCalledWith(
+      [2, 3],
+      '20260601',
+      '20270601',
+      sourceCheckedAt,
+    );
     expect(mergePlayerPricesCache).toHaveBeenCalledWith(
       [
         { elementId: 2, value: 61 },

--- a/tests/unit/player-prices.test.ts
+++ b/tests/unit/player-prices.test.ts
@@ -168,4 +168,26 @@ describe('player-prices sync', () => {
     expect(await sync('20260803')).toEqual({ count: 1, changeDate: '20260803' });
     expect(mergePlayerPricesCache).toHaveBeenCalledWith([{ elementId: 2, value: 61 }], [1, 2]);
   });
+
+  test('merges only price rows that won the durable freshness predicate', async () => {
+    const updatePrices = mock(async () => [player(2, 63)]);
+    const mergePlayerPricesCache = mock(async () => undefined);
+    const sync = createPlayerPricesSync({
+      findByChangeDate: async () => [
+        stored(2, 61, '20260803', 'Rise'),
+        stored(3, 49, '20260803', 'Faller'),
+      ],
+      findLatestForPlayerIds: async () => [
+        stored(2, 63, '20260805', 'Rise'),
+        stored(3, 47, '20260805', 'Faller'),
+      ],
+      getBootstrap: async () => bootstrap([1, 2, 3]),
+      updatePrices,
+      mergePlayerPricesCache,
+      readOrderingTimestamp,
+    });
+
+    await expect(sync('20260803')).resolves.toEqual({ count: 1, changeDate: '20260803' });
+    expect(mergePlayerPricesCache).toHaveBeenCalledWith([{ elementId: 2, value: 63 }], [1, 2, 3]);
+  });
 });

--- a/tests/unit/players.service.test.ts
+++ b/tests/unit/players.service.test.ts
@@ -1,79 +1,46 @@
 import { describe, expect, mock, test } from 'bun:test';
 
-import {
-  createPlayersSync,
-  type PlayersSyncDependencies,
-} from '../../src/services/players.service';
-import type { Player, RawFPLElement } from '../../src/types';
-import { rawFPLElementsFixture } from '../fixtures/player-stats.fixtures';
+import { createPlayersSync } from '../../src/services/players.service';
+import type { CoreSnapshotSyncResult } from '../../src/services/core-snapshot.service';
 
-function bootstrap(elements: RawFPLElement[]) {
-  return { elements, events: [] } as never;
-}
-
-function createDependencies(
-  elements: RawFPLElement[],
-  overrides: Partial<PlayersSyncDependencies> = {},
-) {
-  const upsertPlayers = mock(async (players: Player[]) => players.map((player) => ({ ...player })));
-  const setPlayersCache = mock(async (_players: Player[], _season?: string) => undefined);
-  const dependencies: PlayersSyncDependencies = {
-    getBootstrap: mock(async () => bootstrap(elements)),
-    upsertPlayers,
-    setPlayersCache,
-    resolvePublishedSeason: mock(async () => '2526'),
+function coreResult(overrides: Partial<CoreSnapshotSyncResult> = {}): CoreSnapshotSyncResult {
+  return {
+    outcome: 'ready',
+    season: '2627',
+    events: 38,
+    teams: 20,
+    players: 220,
+    phases: 1,
+    fixtures: 380,
+    requiredUnits: 659,
+    reusedUnits: 0,
+    succeededUnits: 659,
+    failedUnits: 0,
     ...overrides,
   };
-  return { dependencies, upsertPlayers, setPlayersCache };
 }
 
-describe('players sync publication', () => {
-  test('preserves the published roster when any bootstrap element is invalid', async () => {
-    const partialRoster = [rawFPLElementsFixture[0], { ...rawFPLElementsFixture[1], id: -1 }];
-    const { dependencies, upsertPlayers, setPlayersCache } = createDependencies(partialRoster);
+describe('players sync compatibility', () => {
+  test('routes player refreshes through one complete core snapshot', async () => {
+    const syncCore = mock(async () => coreResult());
 
-    await expect(createPlayersSync(dependencies)()).rejects.toThrow(
-      'Failed to transform player at index 1',
-    );
-
-    expect(upsertPlayers).not.toHaveBeenCalled();
-    expect(setPlayersCache).not.toHaveBeenCalled();
+    await expect(createPlayersSync({ syncCore })()).resolves.toEqual({ count: 220, errors: 0 });
+    expect(syncCore).toHaveBeenCalledTimes(1);
   });
 
-  test('rejects duplicate player identity before database or cache writes', async () => {
-    const duplicateRoster = [rawFPLElementsFixture[0], { ...rawFPLElementsFixture[0] }];
-    const { dependencies, upsertPlayers, setPlayersCache } = createDependencies(duplicateRoster);
-
-    await expect(createPlayersSync(dependencies)()).rejects.toThrow(
-      'FPL player roster contains duplicate player ID 1',
+  test('maps a stale complete snapshot without starting a partial write', async () => {
+    const syncCore = mock(async () =>
+      coreResult({ outcome: 'noop', reusedUnits: 659, succeededUnits: 0 }),
     );
 
-    expect(upsertPlayers).not.toHaveBeenCalled();
-    expect(setPlayersCache).not.toHaveBeenCalled();
+    await expect(createPlayersSync({ syncCore })()).resolves.toEqual({ count: 220, errors: 0 });
   });
 
-  test('refuses cache publication when database persistence is incomplete', async () => {
-    const roster = rawFPLElementsFixture.slice(0, 2);
-    const setPlayersCache = mock(async (_players: Player[], _season?: string) => undefined);
-    const { dependencies } = createDependencies(roster, {
-      upsertPlayers: async (players) => players.slice(0, 1),
-      setPlayersCache,
+  test('propagates canonical publication failures', async () => {
+    const syncCore = mock(async (): Promise<CoreSnapshotSyncResult> => {
+      throw new Error('core publication failed');
     });
 
-    await expect(createPlayersSync(dependencies)()).rejects.toThrow(
-      'Player persistence returned an incomplete roster: 1/2',
-    );
-    expect(setPlayersCache).not.toHaveBeenCalled();
-  });
-
-  test('publishes one complete verified roster with no tolerated errors', async () => {
-    const roster = rawFPLElementsFixture.slice(0, 2);
-    const { dependencies, upsertPlayers, setPlayersCache } = createDependencies(roster);
-
-    await expect(createPlayersSync(dependencies)()).resolves.toEqual({ count: 2, errors: 0 });
-    expect(upsertPlayers).toHaveBeenCalledTimes(1);
-    expect(setPlayersCache).toHaveBeenCalledTimes(1);
-    expect(setPlayersCache.mock.calls[0]?.[0]).toHaveLength(2);
-    expect(setPlayersCache.mock.calls[0]?.[1]).toBe('2526');
+    await expect(createPlayersSync({ syncCore })()).rejects.toThrow('core publication failed');
   });
 });


### PR DESCRIPTION
## Summary
- replace independent core entity refreshes with one validated events/teams/players/phases/fixtures snapshot
- persist the snapshot transactionally, stage and atomically publish Redis cache families, and make it the sole season authority
- queue partial repair endpoints through the core snapshot when season authority is missing/newer
- add rollback/cache fault injection tests and a deterministic two-request benchmark

## Scope
Non-live sync only. Live workers, services, schedules, and public Live contracts are intentionally excluded.

## Test plan
- `bun run typecheck`
- `bun run lint` (0 errors; 7 pre-existing warnings)
- `bun test tests/unit` (569 pass)
- `bun run test:integration` (111 pass, 10 intentional skips)
- `bun run test:core-snapshot` (3 pass)
- `bun run test:core-snapshot-benchmark` (1 pass; 1 bootstrap + 1 fixtures request)
- `bun run build`
- `bun run db:check`
- SQL migrations applied twice and status verified

## Dependency
Stacked on #47 (`codex/nonlive-sync-foundation`).