### PR TITLE
fix(db): restore immutable GraphQL RPC migration

### DIFF
--- a/migrations/0043_create_graphql_read_rpcs.sql
+++ b/migrations/0043_create_graphql_read_rpcs.sql
@@ -5,6 +5,13 @@
 -- service_role credential. Keep the executable surface explicit: browser JWT
 -- roles cannot invoke these functions and the functions run as the caller.
 
+-- These picker RPCs existed before the SQL migration ledger and returned the
+-- legacy smallint player type. PostgreSQL cannot change a TABLE OUT column
+-- type through CREATE OR REPLACE, so rebuild only these exact signatures.
+-- Neither function owns dependent objects; do not use CASCADE here.
+DROP FUNCTION IF EXISTS public.get_players_for_picker(integer, integer);
+DROP FUNCTION IF EXISTS public.search_players_for_picker(text, integer, integer);
+
 CREATE OR REPLACE FUNCTION public.get_players_for_picker(
   p_limit integer DEFAULT 20,
   p_cursor integer DEFAULT NULL

--- a/tests/unit/migration-history.test.ts
+++ b/tests/unit/migration-history.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { describe, expect, test } from 'bun:test';
 import { readdirSync, readFileSync } from 'node:fs';
 
@@ -169,8 +171,11 @@ describe('GraphQL read RPC migration', () => {
     );
     const create = replacement.indexOf('CREATE FUNCTION public.get_players_for_picker(');
 
-    expect(applied).not.toContain(
+    expect(applied).toContain(
       'DROP FUNCTION IF EXISTS public.get_players_for_picker(integer, integer);',
+    );
+    expect(createHash('sha256').update(applied, 'utf8').digest('hex')).toBe(
+      '2b9044286ce634077c01be9168ca907b3ecba05c25fe092a619d2065d4f80701',
     );
     expect(drop).toBeGreaterThanOrEqual(0);
     expect(create).toBeGreaterThan(drop);


### PR DESCRIPTION
## Purpose
Restore `migrations/0043_create_graphql_read_rpcs.sql` to the exact production-ledgered source so deploy checksum validation can pass. The prior source removed legacy overload drops after production had already applied the file.

## Verification
- `bun test tests/unit/migration-history.test.ts` (17 pass)
- `bun run lint` (0 errors; 7 pre-existing warnings)
- `bun run typecheck`
- `bun run build`
- Production read-only audit: 68 ledger rows, this was the only checksum mismatch

No production ledger mutation or checksum bypass is included.